### PR TITLE
(feat): Make chat UI stable and make chat persistent

### DIFF
--- a/.dev/chat_feature_improvements.md
+++ b/.dev/chat_feature_improvements.md
@@ -1,0 +1,397 @@
+# Chat Feature Improvements Plan
+
+## Problem Statement
+
+The current chat implementation has two key issues:
+
+1. **Fake chat history**: Messages are stored with a flat structure (`role`, `content`, `thinking`), but the `thinking` field is a single string that loses the sequential order of thinking → tool call → thinking patterns.
+
+2. **Incorrect streaming render**: When backend streams `thinking → tool → thinking`, all thinking deltas get accumulated into a single thinking bubble. The UI should show separate bubbles for each thinking/tool segment in order.
+
+## Root Cause Analysis
+
+### Current Data Flow
+
+```mermaid
+graph LR
+    A[OpenCode SSE] -->|"part_delta (reasoning/text)"| B[server.py]
+    A -->|"part_update (tool)"| B
+    B -->|NDJSON Stream| C[api.ts streamChat]
+    C -->|Events| D[use-chat-session.ts]
+    D -->|"Accumulate to strings"| E[StreamingState]
+    E -->|Single blocks| F[StreamingMessage.tsx]
+```
+
+### Problems by Layer
+
+| Layer        | File                               | Issue                                                         |
+| ------------ | ---------------------------------- | ------------------------------------------------------------- |
+| **Types**    | `lib/types.ts`                     | `ChatMessage.thinking` is `string`, not `MessagePart[]`       |
+| **Hook**     | `hooks/use-chat-session.ts`        | `StreamingState` accumulates all thinking into one string     |
+| **Backend**  | `server/server.py`                 | Stores messages as `{content, thinking}` losing part ordering |
+| **Frontend** | `components/streaming-message.tsx` | Renders one thinking block, not interleaved parts             |
+
+---
+
+## Proposed Changes
+
+### Phase 1: Data Model Enhancement
+
+Introduce a **message parts** model that preserves the order of thinking, tool calls, and text.
+
+---
+
+#### [MODIFY] [types.ts](file:///Users/mike/Project/GitHub/v0-research-agent-mobile/lib/types.ts)
+
+Add new types for message parts:
+
+```typescript
+export type MessagePartType = "thinking" | "tool" | "text";
+
+export interface MessagePart {
+  id: string;
+  type: MessagePartType;
+  content: string;
+  // For tool parts
+  toolName?: string;
+  toolState?: "pending" | "running" | "completed" | "error";
+}
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string; // Legacy: plain text content (for backward compat)
+  thinking?: string; // Legacy: combined thinking (for backward compat)
+  parts?: MessagePart[]; // NEW: ordered array of parts
+  timestamp: Date;
+  // ... existing fields
+}
+```
+
+---
+
+#### [MODIFY] [api.ts](file:///Users/mike/Project/GitHub/v0-research-agent-mobile/lib/api.ts)
+
+Update `ChatMessageData` to include optional parts:
+
+```typescript
+export interface ChatMessageData {
+  role: "user" | "assistant";
+  content: string;
+  thinking?: string | null;
+  parts?: MessagePart[] | null; // NEW
+  timestamp: number;
+}
+```
+
+---
+
+### Phase 2: Streaming State Refactor
+
+Change `StreamingState` to track an **ordered array of parts** instead of accumulating strings.
+
+---
+
+#### [MODIFY] [use-chat-session.ts](file:///Users/mike/Project/GitHub/v0-research-agent-mobile/hooks/use-chat-session.ts)
+
+```typescript
+export interface StreamingPart {
+  id: string;
+  type: "thinking" | "tool" | "text";
+  content: string;
+  toolName?: string;
+  toolState?: "pending" | "running" | "completed" | "error";
+}
+
+export interface StreamingState {
+  isStreaming: boolean;
+  parts: StreamingPart[]; // Ordered array of parts
+  // Legacy for backward compat
+  thinkingContent: string;
+  textContent: string;
+  toolCalls: ToolCallState[];
+}
+```
+
+Update `sendMessage` to track parts by their `id`:
+
+> [!IMPORTANT]
+> OpenCode assigns a **unique ID to each distinct part**. When the model switches from thinking → tool → thinking again, each segment gets a **different ID**. The algorithm is purely ID-based, NOT type-change-based.
+
+**Part Tracking Algorithm:**
+
+```typescript
+// In sendMessage, process each stream event:
+function processStreamEvent(
+  event: StreamEvent,
+  parts: StreamingPart[],
+): StreamingPart[] {
+  const partId = event.id;
+  const ptype = event.ptype; // 'text' | 'reasoning' | 'tool'
+
+  // Handle missing ID (shouldn't happen, but be defensive)
+  if (!partId) {
+    console.warn("Event missing part ID, skipping:", event);
+    return parts;
+  }
+
+  // Find existing part with this ID
+  const existingIndex = parts.findIndex((p) => p.id === partId);
+
+  if (event.type === "part_delta") {
+    // Text or reasoning delta
+    const partType = ptype === "reasoning" ? "thinking" : "text";
+
+    if (existingIndex >= 0) {
+      // APPEND to existing part (same ID = same part)
+      const updated = [...parts];
+      updated[existingIndex] = {
+        ...updated[existingIndex],
+        content: updated[existingIndex].content + (event.delta || ""),
+      };
+      return updated;
+    } else {
+      // NEW part (new ID = new segment)
+      return [
+        ...parts,
+        {
+          id: partId,
+          type: partType,
+          content: event.delta || "",
+        },
+      ];
+    }
+  }
+
+  if (event.type === "part_update" && ptype === "tool") {
+    // Tool status update
+    if (existingIndex >= 0) {
+      // Update existing tool's state
+      const updated = [...parts];
+      updated[existingIndex] = {
+        ...updated[existingIndex],
+        toolState: event.state as ToolCallState["state"],
+        toolName: event.name || updated[existingIndex].toolName,
+      };
+      return updated;
+    } else {
+      // New tool part
+      return [
+        ...parts,
+        {
+          id: partId,
+          type: "tool",
+          content: "",
+          toolName: event.name,
+          toolState: (event.state as ToolCallState["state"]) || "pending",
+        },
+      ];
+    }
+  }
+
+  return parts;
+}
+```
+
+**Key Invariants:**
+
+1. **Same ID → same part**: If we see the same ID again, we append content or update state.
+2. **New ID → new part**: A new ID means a new segment (could be same type or different type).
+3. **Order preservation**: Parts are appended in the order they first appear.
+4. **Type is immutable per ID**: Once a part is created with a type, it keeps that type (OpenCode guarantees this).
+
+**Example Event Sequence:**
+
+```
+Event: {id: "abc", ptype: "reasoning", delta: "Let me think..."} → Create parts[0] = {id:"abc", type:"thinking"}
+Event: {id: "abc", ptype: "reasoning", delta: " about this"}   → Append to parts[0]
+Event: {id: "def", ptype: "tool", name: "grep", state: "running"} → Create parts[1] = {id:"def", type:"tool"}
+Event: {id: "def", ptype: "tool", name: "grep", state: "completed"} → Update parts[1].toolState
+Event: {id: "ghi", ptype: "reasoning", delta: "Based on..."}    → Create parts[2] = {id:"ghi", type:"thinking"} ← NEW thinking part!
+Event: {id: "jkl", ptype: "text", delta: "Here's my answer:"}  → Create parts[3] = {id:"jkl", type:"text"}
+```
+
+---
+
+### Phase 3: Backend Persistence
+
+Update the backend to store and retrieve message parts.
+
+---
+
+#### [MODIFY] [server.py](file:///Users/mike/Project/GitHub/v0-research-agent-mobile/server/server.py)
+
+1. **Stream parsing**: Track parts by `id` in `response_generator()`:
+
+```python
+parts = []  # List of {"id", "type", "content", "tool_name", "tool_state"}
+current_part_id = None
+
+async for event, text_delta, thinking_delta in stream_opencode_events(...):
+    part_id = event.get("id")
+    ptype = event.get("ptype")
+
+    if ptype in ("text", "reasoning"):
+        # Find or create part
+        part = next((p for p in parts if p["id"] == part_id), None)
+        if not part:
+            part = {"id": part_id, "type": "thinking" if ptype == "reasoning" else "text", "content": ""}
+            parts.append(part)
+        part["content"] += event.get("delta", "")
+    elif ptype == "tool":
+        # Tool part
+        part = next((p for p in parts if p["id"] == part_id), None)
+        if not part:
+            part = {"id": part_id, "type": "tool", "content": "", "tool_name": event.get("name"), "tool_state": event.get("state")}
+            parts.append(part)
+        else:
+            part["tool_state"] = event.get("state")
+```
+
+2. **Persistence**: Store `parts` array in the assistant message:
+
+```python
+assistant_msg = {
+    "role": "assistant",
+    "content": full_text.strip(),
+    "thinking": full_thinking.strip() if full_thinking else None,
+    "parts": parts,  # NEW
+    "timestamp": time.time()
+}
+```
+
+---
+
+### Phase 4: Frontend Rendering
+
+Update `StreamingMessage` and `ChatMessage` to render parts in order.
+
+---
+
+#### [MODIFY] [streaming-message.tsx](file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/streaming-message.tsx)
+
+Render parts in order instead of separate thinking/tool/text blocks:
+
+```tsx
+export function StreamingMessage({ streamingState }: StreamingMessageProps) {
+  const { isStreaming, parts } = streamingState;
+
+  return (
+    <div className="px-0.5 py-2">
+      <div className="space-y-2">
+        {parts.map((part) => {
+          if (part.type === "thinking") {
+            return (
+              <ThinkingPart key={part.id} content={part.content} isStreaming />
+            );
+          }
+          if (part.type === "tool") {
+            return <ToolCallIndicator key={part.id} tool={part} />;
+          }
+          if (part.type === "text") {
+            return (
+              <TextPart key={part.id} content={part.content} isStreaming />
+            );
+          }
+        })}
+        {/* Loading indicator when no parts yet */}
+        {parts.length === 0 && isStreaming && <LoadingIndicator />}
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+#### [MODIFY] [chat-message.tsx](file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/chat-message.tsx)
+
+For saved messages, render from `parts` array if available, fall back to legacy `thinking`/`content`:
+
+```tsx
+// For assistant messages with parts
+if (message.parts?.length) {
+  return (
+    <div className="space-y-2">
+      {message.parts.map((part) => {
+        if (part.type === "thinking")
+          return <ThinkingBlock key={part.id} content={part.content} />;
+        if (part.type === "tool") return <ToolBlock key={part.id} {...part} />;
+        if (part.type === "text")
+          return <TextBlock key={part.id} content={part.content} />;
+      })}
+    </div>
+  );
+}
+
+// Legacy fallback
+return (
+  <>
+    {message.thinking && <ThinkingBlock content={message.thinking} />}
+    <TextBlock content={message.content} />
+  </>
+);
+```
+
+---
+
+## Implementation Phases
+
+| Phase | Description              | Files Changed                               | Estimated Effort |
+| ----- | ------------------------ | ------------------------------------------- | ---------------- |
+| **1** | Data model types         | `types.ts`, `api.ts`                        | Small            |
+| **2** | Streaming state refactor | `use-chat-session.ts`                       | Medium           |
+| **3** | Backend persistence      | `server.py`                                 | Medium           |
+| **4** | Frontend rendering       | `streaming-message.tsx`, `chat-message.tsx` | Medium           |
+
+> [!TIP]
+> Start with Phase 1 + 2, which enables correct streaming render. Phase 3 can be done in parallel or after. Phase 4 ties it all together.
+
+---
+
+## Verification Plan
+
+### Manual Testing
+
+Since there is no existing automated test suite for chat, verification will be manual:
+
+1. **Start the servers**:
+
+   ```bash
+   # Terminal 1: Start backend
+   cd /Users/mike/Project/GitHub/v0-research-agent-mobile/server
+   python server.py --workdir /Users/mike/Project/GitHub/v0-research-agent-mobile
+
+   # Terminal 2: Start frontend
+   cd /Users/mike/Project/GitHub/v0-research-agent-mobile
+   npm run dev
+   ```
+
+2. **Open browser at `http://localhost:3000`**
+
+3. **Test streaming render**:
+   - Send a message that triggers thinking → tool → thinking (e.g., "search the codebase for X")
+   - **Expected**: See interleaved bubbles: [Thinking...] → [Tool: search ✓] → [Thinking...] → [Response text]
+   - **Current bug**: All thinking merged into single [Thinking...] bubble
+
+4. **Test history persistence**:
+   - Refresh the page after a chat
+   - **Expected**: Previous messages render with correct interleaved parts
+   - **Current bug**: Only shows combined thinking block
+
+### Browser Automation (Future)
+
+Could add Playwright tests to automate:
+
+- Stream event mocking
+- Part rendering verification
+
+---
+
+## Open Questions for User
+
+1. **Backward compatibility**: Should we migrate existing chat history data, or just support new format going forward?
+
+2. **Tool call details**: Should we store/display tool call arguments and results, or just name and status?
+
+3. **Collapsed vs expanded**: For saved messages, should thinking blocks default to collapsed (current) or show first few lines?

--- a/.dev/chat_session_display_fix.md
+++ b/.dev/chat_session_display_fix.md
@@ -1,0 +1,82 @@
+# Chat Session Persistence Fix
+
+## Problem Statement
+
+The "Recent Chats" section in the navigation panel shows hardcoded mock data instead of real chat sessions from the backend. Backend persistence works correctly (verified in `chat_data.json`), but the frontend navigation page doesn't fetch or display real sessions.
+
+## Root Cause
+
+| Component             | Current Behavior                        | Expected                              |
+| --------------------- | --------------------------------------- | ------------------------------------- |
+| `server.py`           | ✅ Stores sessions correctly            | -                                     |
+| `useChatSession` hook | ✅ Fetches sessions via API             | -                                     |
+| `app/page.tsx`        | ❌ Doesn't pass sessions to NavPage     | Pass `sessions` and `onSelectSession` |
+| `nav-page.tsx`        | ❌ Uses `mockChatHistory` (lines 29-66) | Accept and display real sessions      |
+
+## Proposed Changes
+
+### [MODIFY] [nav-page.tsx](file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/nav-page.tsx)
+
+1. **Remove mock data** (lines 29-66)
+2. **Add new props** to `NavPageProps`:
+   - `sessions: ChatSession[]` - real sessions from backend
+   - `onSelectSession: (sessionId: string) => void` - callback when user clicks a session
+3. **Update Recent Chats section** (lines 300-332) to use `sessions` prop instead of `filteredChats`
+
+---
+
+### [MODIFY] [app/page.tsx](file:///Users/mike/Project/GitHub/v0-research-agent-mobile/app/page.tsx)
+
+1. **Get sessions from hook**: Use `useChatSession` to get `sessions` and `selectSession`
+2. **Pass to NavPage**:
+   - `sessions={sessions}`
+   - `onSelectSession={(id) => { selectSession(id); setActiveTab('chat'); }}`
+
+---
+
+### [MODIFY] [connected-chat-view.tsx](file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/connected-chat-view.tsx)
+
+1. **Export `useChatSession` hook** from this file (already done, used in page.tsx line 86)
+2. Verify `selectSession` is exposed from the hook
+
+---
+
+## Verification Plan
+
+### Manual Testing
+
+1. **Start servers**:
+
+   ```bash
+   # Terminal 1
+   cd /Users/mike/Project/GitHub/v0-research-agent-mobile/server
+   python server.py --workdir ../tests/story/train-mlp
+
+   # Terminal 2
+   cd /Users/mike/Project/GitHub/v0-research-agent-mobile
+   npm run dev
+   ```
+
+2. **Test session display**:
+   - Open `http://localhost:3000`
+   - Click hamburger menu
+   - **Expected**: Recent Chats shows real sessions from `chat_data.json` (e.g., "Hi", "Analyze my latest run", etc.)
+   - **Currently**: Shows mock data ("GPT-4 Fine-tuning Analysis", etc.)
+
+3. **Test session selection**:
+   - Click on a session in Recent Chats
+   - **Expected**: Chat view loads with that session's messages
+   - Navigate back, click different session
+   - **Expected**: Messages change to selected session
+
+4. **Test new chat**:
+   - Click "New Chat" button
+   - Send a message
+   - Open nav menu
+   - **Expected**: New session appears in Recent Chats
+
+---
+
+## Open Questions
+
+None - this is a straightforward wiring fix.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,8 +82,9 @@ export default function ResearchChat() {
   const [collapseChats, setCollapseChats] = useState(false)
   const [collapseArtifactsInChat, setCollapseArtifactsInChat] = useState(false)
 
-  // Chat session hook for New Chat functionality
-  const { createNewSession } = useChatSession()
+  // Chat session hook - single instance shared with ConnectedChatView
+  const chatSession = useChatSession()
+  const { createNewSession, sessions, selectSession } = chatSession
 
   // Build breadcrumbs based on current state
   const breadcrumbs = useMemo(() => {
@@ -333,6 +334,7 @@ export default function ResearchChat() {
               mode={chatMode}
               onModeChange={setChatMode}
               collapseArtifactsInChat={collapseArtifactsInChat}
+              chatSession={chatSession}
             />
           )}
           {activeTab === 'chat' && showSweepForm && (
@@ -409,6 +411,11 @@ export default function ResearchChat() {
           onJourneySubTabChange={setJourneySubTab}
           onNewChat={async () => {
             await createNewSession()
+            setActiveTab('chat')
+          }}
+          sessions={sessions}
+          onSelectSession={async (sessionId) => {
+            await selectSession(sessionId)
             setActiveTab('chat')
           }}
         />

--- a/components/connected-chat-view.tsx
+++ b/components/connected-chat-view.tsx
@@ -27,6 +27,8 @@ interface ConnectedChatViewProps {
     collapseArtifactsInChat?: boolean
     // Expose session state for sidebar integration
     onSessionChange?: (sessionId: string | null) => void
+    // Optional: pass chat session state from parent (for shared state)
+    chatSession?: ReturnType<typeof useChatSession>
 }
 
 /**
@@ -44,9 +46,12 @@ export function ConnectedChatView({
     onModeChange,
     collapseArtifactsInChat = false,
     onSessionChange,
+    chatSession: externalChatSession,
 }: ConnectedChatViewProps) {
     const scrollRef = useRef<HTMLDivElement>(null)
 
+    // Use external chat session if provided (for shared state), otherwise use own hook
+    const internalChatSession = useChatSession()
     const {
         isConnected,
         isLoading,
@@ -56,7 +61,7 @@ export function ConnectedChatView({
         streamingState,
         sendMessage,
         createNewSession,
-    } = useChatSession()
+    } = externalChatSession || internalChatSession
 
     // Notify parent of session changes
     useEffect(() => {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -17,7 +17,18 @@ export interface ChatMessageData {
     role: 'user' | 'assistant'
     content: string
     thinking?: string | null
+    parts?: MessagePartData[] | null  // NEW: ordered parts array
     timestamp: number
+}
+
+export interface MessagePartData {
+    id: string
+    type: 'thinking' | 'tool' | 'text'
+    content: string
+    tool_name?: string
+    tool_state?: 'pending' | 'running' | 'completed' | 'error'
+    tool_input?: string
+    tool_output?: string
 }
 
 export interface SessionWithMessages extends ChatSession {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -97,11 +97,28 @@ export interface RunEvent {
   relatedMetrics?: { name: string; value: string }[]
 }
 
+// Message parts for ordered rendering of thinking, tools, and text
+export type MessagePartType = 'thinking' | 'tool' | 'text'
+
+export type ToolState = 'pending' | 'running' | 'completed' | 'error'
+
+export interface MessagePart {
+  id: string
+  type: MessagePartType
+  content: string
+  // For tool parts
+  toolName?: string
+  toolState?: ToolState
+  toolInput?: string   // Tool arguments/input
+  toolOutput?: string  // Tool result/output
+}
+
 export interface ChatMessage {
   id: string
   role: 'user' | 'assistant'
   content: string
-  thinking?: string
+  thinking?: string  // Legacy: combined thinking (backward compat)
+  parts?: MessagePart[]  // NEW: ordered array of parts
   timestamp: Date
   attachments?: {
     name: string


### PR DESCRIPTION
## Improve Chat Feature with Interleaved Message Parts & Session Persistence

### Summary

This PR improves the chat feature with two major enhancements:

1. **Interleaved Message Parts Rendering** - Thinking → tool → thinking sequences now render correctly as separate bubbles instead of merging into a single block
2. **Real Session Display & Selection** - "Recent Chats" now shows actual sessions from the backend and clicking a session loads its conversation

### Changes

#### Data Model
- Added `MessagePart`, `MessagePartType`, [ToolState](cci:1://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/hooks/use-chat-session.ts:223:12-232:13) types to [lib/types.ts](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/lib/types.ts:0:0-0:0)
- Added `MessagePartData` interface to [lib/api.ts](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/lib/api.ts:0:0-0:0)

#### Streaming & Persistence
- [hooks/use-chat-session.ts](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/hooks/use-chat-session.ts:0:0-0:0): Added [StreamingPart](cci:2://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/hooks/use-chat-session.ts:23:0-29:1) interface, track parts by ID during streaming
- [server/server.py](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/server/server.py:0:0-0:0): Track and store ordered `parts[]` array in assistant messages

#### Frontend Rendering
- [components/streaming-message.tsx](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/streaming-message.tsx:0:0-0:0): Render parts in order via [StreamingPartRenderer](cci:1://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/streaming-message.tsx:81:0-128:1)
- [components/chat-message.tsx](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/chat-message.tsx:0:0-0:0): Render saved messages with [SavedPartRenderer](cci:1://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/chat-message.tsx:253:0-361:1), collapsible tool details

#### Session Management
- [components/nav-page.tsx](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/nav-page.tsx:0:0-0:0): Removed mock data, accept real [sessions](cci:1://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/server/server.py:390:0-403:19) and `onSelectSession` props
- [components/connected-chat-view.tsx](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/connected-chat-view.tsx:0:0-0:0): Accept optional `chatSession` prop for shared state
- [app/page.tsx](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/app/page.tsx:0:0-0:0): Pass shared `chatSession` to both NavPage and ConnectedChatView

### Files Changed

| File | Description |
|------|-------------|
| [lib/types.ts](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/lib/types.ts:0:0-0:0) | Added `MessagePart` types for ordered message components |
| [lib/api.ts](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/lib/api.ts:0:0-0:0) | Added `MessagePartData` for API layer |
| [hooks/use-chat-session.ts](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/hooks/use-chat-session.ts:0:0-0:0) | Streaming parts tracking, [StreamingPart](cci:2://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/hooks/use-chat-session.ts:23:0-29:1) interface |
| [server/server.py](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/server/server.py:0:0-0:0) | Store parts array in assistant messages |
| [components/streaming-message.tsx](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/streaming-message.tsx:0:0-0:0) | Parts-based streaming render |
| [components/chat-message.tsx](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/chat-message.tsx:0:0-0:0) | Parts-based saved message render with collapsible tool details |
| [components/nav-page.tsx](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/nav-page.tsx:0:0-0:0) | Real sessions display instead of mock data |
| [components/connected-chat-view.tsx](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/components/connected-chat-view.tsx:0:0-0:0) | Accept shared `chatSession` prop |
| [app/page.tsx](cci:7://file:///Users/mike/Project/GitHub/v0-research-agent-mobile/app/page.tsx:0:0-0:0) | Wire shared session state |

### Testing

- [x] Build passes
- [x] Manual test: Send message triggering thinking → tool → thinking, verify interleaved bubbles
- [x] Manual test: Click session in Recent Chats, verify messages load