### PR TITLE
feat(charts): Improve run and sweep management, chart ordering and rendering

### DIFF
--- a/app/contextual/page.tsx
+++ b/app/contextual/page.tsx
@@ -38,59 +38,12 @@ import { listSweeps, type Sweep as ApiSweep } from '@/lib/api-client'
 import { buildHomeHref, type HomeTab, type JourneySubTab } from '@/lib/navigation'
 import { extractContextReferences } from '@/lib/contextual-chat'
 import type { ChatMode } from '@/components/chat-input'
-import type { Sweep as UiSweep, SweepStatus } from '@/lib/types'
+import type { Sweep as UiSweep } from '@/lib/types'
+import { mapApiSweepToUiSweep } from '@/lib/sweep-mappers'
 
 const DESKTOP_SIDEBAR_MIN_WIDTH = 72
 const DESKTOP_SIDEBAR_MAX_WIDTH = 520
 const DESKTOP_SIDEBAR_DEFAULT_WIDTH = 300
-
-function mapApiSweepStatusToUi(status: ApiSweep['status']): SweepStatus {
-  if (status === 'ready') return 'pending'
-  return status
-}
-
-function toChoiceValues(values: unknown[]): Array<string | number> {
-  return values.filter((value): value is string | number => {
-    return typeof value === 'string' || typeof value === 'number'
-  })
-}
-
-function mapApiSweepToUiSweep(sweep: ApiSweep): UiSweep {
-  const createdAt = new Date(sweep.created_at * 1000)
-  return {
-    id: sweep.id,
-    config: {
-      id: sweep.id,
-      name: sweep.name,
-      description: sweep.goal || '',
-      goal: sweep.goal || '',
-      command: sweep.base_command,
-      hyperparameters: Object.entries(sweep.parameters || {}).map(([name, values]) => ({
-        name,
-        type: 'choice' as const,
-        values: Array.isArray(values) ? toChoiceValues(values) : [],
-      })),
-      metrics: [],
-      insights: [],
-      maxRuns: sweep.progress.total,
-      parallelRuns: Math.max(1, sweep.progress.running),
-      earlyStoppingEnabled: false,
-      earlyStoppingPatience: 3,
-      createdAt,
-      updatedAt: createdAt,
-    },
-    status: mapApiSweepStatusToUi(sweep.status),
-    runIds: sweep.run_ids,
-    createdAt,
-    startedAt: sweep.status === 'running' ? createdAt : undefined,
-    progress: {
-      completed: sweep.progress.completed,
-      total: sweep.progress.total,
-      failed: sweep.progress.failed,
-      running: sweep.progress.running,
-    },
-  }
-}
 
 export default function ContextualChatPage() {
   const router = useRouter()

--- a/components/charts-view.tsx
+++ b/components/charts-view.tsx
@@ -1,18 +1,43 @@
 'use client'
 
-import React from 'react'
-import { useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
-  TrendingUp,
-  Star,
-  Pin,
-  Layers,
   BarChart3,
-  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  Layers,
+  Pin,
   Settings,
+  Star,
+  TrendingUp,
 } from 'lucide-react'
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { RunVisibilitySelector } from './run-visibility-selector'
+import { VisibilityManageView } from './visibility-manage-view'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   Select,
@@ -21,32 +46,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
 import { Switch } from '@/components/ui/switch'
-import { Label } from '@/components/ui/label'
-import { Input } from '@/components/ui/input'
-import {
-  LineChart,
-  Line,
-  BarChart,
-  Bar,
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  ScatterChart,
-  Scatter,
-} from 'recharts'
-import { RunVisibilitySelector } from './run-visibility-selector'
-import { VisibilityManageView } from './visibility-manage-view'
-import type { InsightChart, MetricVisualization, ExperimentRun, VisibilityGroup } from '@/lib/types'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { defaultMetricVisualizations } from '@/lib/mock-data'
+import type {
+  ExperimentRun,
+  InsightChart,
+  MetricVisualization,
+  VisibilityGroup,
+} from '@/lib/types'
 
 interface ChartsViewProps {
   runs: ExperimentRun[]
@@ -57,77 +65,532 @@ interface ChartsViewProps {
   onShowVisibilityManageChange?: (show: boolean) => void
 }
 
-// Generate mock metric data
-const generateMetricData = (metricId: string, runs: ExperimentRun[], visibleRunIds: Set<string>) => {
-  const data: { step: number;[key: string]: number }[] = []
-  const visibleRuns = runs.filter(r => visibleRunIds.has(r.id))
+type LayoutMode = 'fixed-grid' | 'flex'
 
-  for (let i = 0; i <= 100; i += 5) {
-    const point: { step: number;[key: string]: number } = { step: i * 100 }
-    visibleRuns.forEach((run) => {
-      if (!run.isArchived && run.lossHistory) {
-        const baseValue = metricId.includes('loss')
-          ? 2.5 * Math.exp(-i / 30) + 0.1
-          : metricId.includes('grad')
-            ? 1.5 * Math.exp(-i / 50) + 0.5 + Math.random() * 0.2
-            : Math.random() * 0.5 + 0.3
-        point[run.name] = Number(baseValue.toFixed(4))
-      }
-    })
-    data.push(point)
-  }
-  return data
+interface ChartsViewSettings {
+  showVisibilitySection: boolean
+  layoutMode: LayoutMode
+  chartsPerRow: number
+  multiColumnThresholdPx: number
+  minChartWidth: number
+  maxChartWidth: number
+  chartHeight: number
+  xAxisFontSize: number
+  yAxisFontSize: number
+  xAxisTickCount: number
+  yAxisTickCount: number
+  yAxisWidth: number
 }
 
-export function ChartsView({ runs, customCharts, onTogglePin, onToggleOverview, onUpdateRun, onShowVisibilityManageChange }: ChartsViewProps) {
-  const [activeSection, setActiveSection] = useState<'standard' | 'custom'>('standard')
-  const [metrics, setMetrics] = useState<MetricVisualization[]>(defaultMetricVisualizations)
-  const [selectedLayer, setSelectedLayer] = useState<Record<string, number>>({})
-  const [showVisibilityManage, setShowVisibilityManageInternal] = useState(false)
-  const [showVisibilitySection, setShowVisibilitySection] = useState(false)
+const CHART_SETTINGS_STORAGE_KEY = 'research-agent-charts-view-settings-v1'
 
-  // Chart axis settings (applied settings)
-  const [chartSettings, setChartSettings] = useState({
-    xAxisFontSize: 10,
-    yAxisFontSize: 10,
-    xAxisTickCount: 5,
-    yAxisTickCount: 5,
-    yAxisWidth: 25,
-  })
-  // Draft settings (edited in popover, applied on save)
-  const [draftSettings, setDraftSettings] = useState({ ...chartSettings })
-  const [settingsOpen, setSettingsOpen] = useState(false)
+const DEFAULT_CHART_SETTINGS: ChartsViewSettings = {
+  showVisibilitySection: false,
+  layoutMode: 'fixed-grid',
+  chartsPerRow: 2,
+  multiColumnThresholdPx: 980,
+  minChartWidth: 280,
+  maxChartWidth: 560,
+  chartHeight: 180,
+  xAxisFontSize: 10,
+  yAxisFontSize: 10,
+  xAxisTickCount: 5,
+  yAxisTickCount: 5,
+  yAxisWidth: 40,
+}
 
-  const handleSaveSettings = () => {
-    setChartSettings({ ...draftSettings })
-    setSettingsOpen(false)
+interface StandardMetricDataset {
+  rows: Array<Record<string, number>>
+  runIdsWithData: Set<string>
+}
+
+function clampInt(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min
+  return Math.min(max, Math.max(min, Math.round(value)))
+}
+
+function sanitizeSettings(partial?: Partial<ChartsViewSettings>): ChartsViewSettings {
+  const source = { ...DEFAULT_CHART_SETTINGS, ...(partial || {}) }
+  return {
+    showVisibilitySection: Boolean(source.showVisibilitySection),
+    layoutMode: source.layoutMode === 'flex' ? 'flex' : 'fixed-grid',
+    chartsPerRow: clampInt(source.chartsPerRow, 1, 6),
+    multiColumnThresholdPx: clampInt(source.multiColumnThresholdPx, 640, 2400),
+    minChartWidth: clampInt(source.minChartWidth, 180, 1200),
+    maxChartWidth: clampInt(source.maxChartWidth, 200, 1400),
+    chartHeight: clampInt(source.chartHeight, 120, 520),
+    xAxisFontSize: clampInt(source.xAxisFontSize, 8, 20),
+    yAxisFontSize: clampInt(source.yAxisFontSize, 8, 20),
+    xAxisTickCount: clampInt(source.xAxisTickCount, 2, 16),
+    yAxisTickCount: clampInt(source.yAxisTickCount, 2, 16),
+    yAxisWidth: clampInt(source.yAxisWidth, 24, 120),
   }
+}
 
-  const handleOpenSettings = (open: boolean) => {
-    if (open) {
-      // Reset draft to current settings when opening
-      setDraftSettings({ ...chartSettings })
+function loadStoredSettings(): ChartsViewSettings {
+  if (typeof window === 'undefined') return DEFAULT_CHART_SETTINGS
+  try {
+    const raw = window.localStorage.getItem(CHART_SETTINGS_STORAGE_KEY)
+    if (!raw) return DEFAULT_CHART_SETTINGS
+    const parsed = JSON.parse(raw) as Partial<ChartsViewSettings>
+    return sanitizeSettings(parsed)
+  } catch {
+    return DEFAULT_CHART_SETTINGS
+  }
+}
+
+function hasRunSeries(data: StandardMetricDataset, runId: string): boolean {
+  return data.runIdsWithData.has(runId)
+}
+
+function getValueForMetric(
+  metricPath: string,
+  currentPoint: { step: number; trainLoss: number; valLoss?: number },
+  previousPoint: { step: number; trainLoss: number; valLoss?: number } | undefined,
+  previousEma: number | null,
+): { value: number | null; ema: number | null } {
+  switch (metricPath) {
+    case 'train/loss':
+      return { value: currentPoint.trainLoss, ema: previousEma }
+    case 'val/loss':
+      return {
+        value: typeof currentPoint.valLoss === 'number' ? currentPoint.valLoss : null,
+        ema: previousEma,
+      }
+    case 'train/loss_ema': {
+      const nextEma = previousEma == null
+        ? currentPoint.trainLoss
+        : (0.2 * currentPoint.trainLoss + 0.8 * previousEma)
+      return { value: nextEma, ema: nextEma }
     }
-    setSettingsOpen(open)
+    case 'train/loss_slope':
+      return {
+        value: previousPoint ? (currentPoint.trainLoss - previousPoint.trainLoss) : null,
+        ema: previousEma,
+      }
+    case 'val/generalization_gap':
+      return {
+        value: typeof currentPoint.valLoss === 'number'
+          ? (currentPoint.valLoss - currentPoint.trainLoss)
+          : null,
+        ema: previousEma,
+      }
+    default:
+      // No true source data for these metrics yet.
+      return { value: null, ema: previousEma }
   }
+}
+
+function buildMetricDataset(metricPath: string, runs: ExperimentRun[]): StandardMetricDataset {
+  const stepMap = new Map<number, Record<string, number>>()
+  const runIdsWithData = new Set<string>()
+
+  runs.forEach((run) => {
+    if (!run.lossHistory || run.lossHistory.length === 0) return
+
+    let previousEma: number | null = null
+    let previousPoint: { step: number; trainLoss: number; valLoss?: number } | undefined
+
+    run.lossHistory.forEach((point) => {
+      const { value, ema } = getValueForMetric(metricPath, point, previousPoint, previousEma)
+      previousEma = ema
+      previousPoint = point
+
+      if (typeof value !== 'number' || Number.isNaN(value)) return
+
+      const rounded = Number(value.toFixed(6))
+      const row = stepMap.get(point.step) || { step: point.step }
+      row[run.id] = rounded
+      stepMap.set(point.step, row)
+      runIdsWithData.add(run.id)
+    })
+  })
+
+  const rows = Array.from(stepMap.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([, row]) => row)
+
+  return { rows, runIdsWithData }
+}
+
+function CustomChartCard({
+  chart,
+  chartHeight,
+  chartSettings,
+  onTogglePin,
+  onToggleOverview,
+}: {
+  chart: InsightChart
+  chartHeight: number
+  chartSettings: ChartsViewSettings
+  onTogglePin?: (id: string) => void
+  onToggleOverview?: (id: string) => void
+}) {
+  const data = chart.data.map((item) => ({ label: item.label, value: item.value, secondary: item.secondary }))
+
+  return (
+    <div className="rounded-lg border border-border bg-card overflow-hidden">
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-foreground">{chart.title}</p>
+          {chart.description && (
+            <p className="truncate text-[11px] text-muted-foreground">{chart.description}</p>
+          )}
+        </div>
+        <div className="ml-2 flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => onToggleOverview?.(chart.id)}
+          >
+            <Star className={`h-4 w-4 ${chart.isInOverview ? 'fill-yellow-500 text-yellow-500' : 'text-muted-foreground'}`} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => onTogglePin?.(chart.id)}
+          >
+            <Pin className={`h-4 w-4 ${chart.isPinned ? 'fill-accent text-accent' : 'text-muted-foreground'}`} />
+          </Button>
+        </div>
+      </div>
+      <div className="px-2 pb-2 pt-2" style={{ height: chartHeight }}>
+        {data.length > 0 ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(148, 163, 184, 0.22)" />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: chartSettings.xAxisFontSize, fill: '#94a3b8' }}
+                axisLine={{ stroke: 'rgba(148, 163, 184, 0.4)' }}
+                tickLine={false}
+                tickCount={chartSettings.xAxisTickCount}
+              />
+              <YAxis
+                tick={{ fontSize: chartSettings.yAxisFontSize, fill: '#94a3b8' }}
+                axisLine={{ stroke: 'rgba(148, 163, 184, 0.4)' }}
+                tickLine={false}
+                width={chartSettings.yAxisWidth}
+                tickCount={chartSettings.yAxisTickCount}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: '#0f172a',
+                  border: '1px solid rgba(148, 163, 184, 0.4)',
+                  borderRadius: '8px',
+                  fontSize: '11px',
+                }}
+              />
+              <Line type="monotone" dataKey="value" stroke="#4ade80" strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex h-full items-center justify-center rounded-md border border-dashed border-border text-xs text-muted-foreground">
+            No chart data available.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function StandardMetricCard({
+  metric,
+  visibleRuns,
+  dataset,
+  chartSettings,
+  chartHeight,
+  onToggleMetricPin,
+  onToggleMetricOverview,
+}: {
+  metric: MetricVisualization
+  visibleRuns: ExperimentRun[]
+  dataset: StandardMetricDataset
+  chartSettings: ChartsViewSettings
+  chartHeight: number
+  onToggleMetricPin: (metricId: string) => void
+  onToggleMetricOverview: (metricId: string) => void
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card overflow-hidden">
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-foreground">{metric.name}</p>
+          <p className="truncate text-[10px] text-muted-foreground">{metric.path}</p>
+        </div>
+        <div className="ml-2 flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => onToggleMetricOverview(metric.id)}
+          >
+            <Star className={`h-4 w-4 ${metric.isInOverview ? 'fill-yellow-500 text-yellow-500' : 'text-muted-foreground'}`} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => onToggleMetricPin(metric.id)}
+          >
+            <Pin className={`h-4 w-4 ${metric.isPinned ? 'fill-accent text-accent' : 'text-muted-foreground'}`} />
+          </Button>
+        </div>
+      </div>
+
+      <div className="px-2 pb-2 pt-2" style={{ height: chartHeight }}>
+        {dataset.rows.length > 0 && visibleRuns.some((run) => hasRunSeries(dataset, run.id)) ? (
+          <ResponsiveContainer width="100%" height="100%">
+            {metric.type === 'area' ? (
+              <AreaChart data={dataset.rows}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(148, 163, 184, 0.22)" />
+                <XAxis
+                  dataKey="step"
+                  tick={{ fontSize: chartSettings.xAxisFontSize, fill: '#94a3b8' }}
+                  axisLine={{ stroke: 'rgba(148, 163, 184, 0.4)' }}
+                  tickLine={false}
+                  tickCount={chartSettings.xAxisTickCount}
+                />
+                <YAxis
+                  tick={{ fontSize: chartSettings.yAxisFontSize, fill: '#94a3b8' }}
+                  axisLine={{ stroke: 'rgba(148, 163, 184, 0.4)' }}
+                  tickLine={false}
+                  width={chartSettings.yAxisWidth}
+                  tickCount={chartSettings.yAxisTickCount}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: '#0f172a',
+                    border: '1px solid rgba(148, 163, 184, 0.4)',
+                    borderRadius: '8px',
+                    fontSize: '11px',
+                  }}
+                />
+                {visibleRuns.map((run) => (
+                  <Area
+                    key={run.id}
+                    type="monotone"
+                    dataKey={run.id}
+                    name={run.alias || run.name}
+                    stroke={run.color || '#4ade80'}
+                    fill={`${run.color || '#4ade80'}33`}
+                    strokeWidth={1.8}
+                    connectNulls
+                  />
+                ))}
+              </AreaChart>
+            ) : (
+              <LineChart data={dataset.rows}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(148, 163, 184, 0.22)" />
+                <XAxis
+                  dataKey="step"
+                  tick={{ fontSize: chartSettings.xAxisFontSize, fill: '#94a3b8' }}
+                  axisLine={{ stroke: 'rgba(148, 163, 184, 0.4)' }}
+                  tickLine={false}
+                  tickCount={chartSettings.xAxisTickCount}
+                />
+                <YAxis
+                  tick={{ fontSize: chartSettings.yAxisFontSize, fill: '#94a3b8' }}
+                  axisLine={{ stroke: 'rgba(148, 163, 184, 0.4)' }}
+                  tickLine={false}
+                  width={chartSettings.yAxisWidth}
+                  tickCount={chartSettings.yAxisTickCount}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: '#0f172a',
+                    border: '1px solid rgba(148, 163, 184, 0.4)',
+                    borderRadius: '8px',
+                    fontSize: '11px',
+                  }}
+                />
+                {visibleRuns.map((run) => (
+                  <Line
+                    key={run.id}
+                    type="monotone"
+                    dataKey={run.id}
+                    name={run.alias || run.name}
+                    stroke={run.color || '#4ade80'}
+                    strokeWidth={1.8}
+                    dot={false}
+                    connectNulls
+                  />
+                ))}
+              </LineChart>
+            )}
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex h-full items-center justify-center rounded-md border border-dashed border-border text-xs text-muted-foreground">
+            No source data for this metric in visible runs.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function ChartsView({
+  runs,
+  customCharts,
+  onTogglePin,
+  onToggleOverview,
+  onUpdateRun,
+  onShowVisibilityManageChange,
+}: ChartsViewProps) {
+  const isMobile = useIsMobile()
+
+  const [metrics, setMetrics] = useState<MetricVisualization[]>(defaultMetricVisualizations)
+  const [showVisibilityManage, setShowVisibilityManageInternal] = useState(false)
+  const [chartSettings, setChartSettings] = useState<ChartsViewSettings>(DEFAULT_CHART_SETTINGS)
+  const [draftSettings, setDraftSettings] = useState<ChartsViewSettings>(DEFAULT_CHART_SETTINGS)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [settingsHydrated, setSettingsHydrated] = useState(false)
+
+  const [viewportWidth, setViewportWidth] = useState(1440)
+
+  const [overviewOpen, setOverviewOpen] = useState(true)
+  const [pinnedOpen, setPinnedOpen] = useState(true)
+  const [primaryOpen, setPrimaryOpen] = useState(true)
+  const [secondaryOpen, setSecondaryOpen] = useState(true)
+  const [customOpen, setCustomOpen] = useState(true)
+
+  const activeRuns = useMemo(
+    () => runs.filter((run) => !run.isArchived && run.lossHistory && run.lossHistory.length > 0),
+    [runs]
+  )
+
+  const [visibleRunIds, setVisibleRunIds] = useState<Set<string>>(
+    new Set(activeRuns.map((run) => run.id))
+  )
+  const [visibilityGroups, setVisibilityGroups] = useState<VisibilityGroup[]>([])
+  const [activeGroupId, setActiveGroupId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const loaded = loadStoredSettings()
+    setChartSettings(loaded)
+    setDraftSettings(loaded)
+    setSettingsHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    if (!settingsHydrated) return
+    window.localStorage.setItem(CHART_SETTINGS_STORAGE_KEY, JSON.stringify(chartSettings))
+  }, [chartSettings, settingsHydrated])
+
+  useEffect(() => {
+    const updateWidth = () => setViewportWidth(window.innerWidth)
+    updateWidth()
+    window.addEventListener('resize', updateWidth)
+    return () => window.removeEventListener('resize', updateWidth)
+  }, [])
+
+  useEffect(() => {
+    setVisibleRunIds((prev) => {
+      const activeIds = new Set(activeRuns.map((run) => run.id))
+      const next = new Set<string>()
+      prev.forEach((runId) => {
+        if (activeIds.has(runId)) next.add(runId)
+      })
+      if (next.size === 0) {
+        activeRuns.forEach((run) => next.add(run.id))
+      }
+      return next
+    })
+  }, [activeRuns])
 
   const setShowVisibilityManage = (show: boolean) => {
     setShowVisibilityManageInternal(show)
     onShowVisibilityManageChange?.(show)
   }
 
-  // Visibility state
-  const activeRuns = runs.filter(r => !r.isArchived && r.lossHistory && r.lossHistory.length > 0)
-  const [visibleRunIds, setVisibleRunIds] = useState<Set<string>>(
-    new Set(activeRuns.map((r) => r.id))
+  const visibleRuns = useMemo(
+    () => activeRuns.filter((run) => visibleRunIds.has(run.id)),
+    [activeRuns, visibleRunIds]
   )
-  const [visibilityGroups, setVisibilityGroups] = useState<VisibilityGroup[]>([])
-  const [activeGroupId, setActiveGroupId] = useState<string | null>(null)
 
-  const visibleRuns = runs.filter(r => !r.isArchived && visibleRunIds.has(r.id))
-  const primaryMetrics = metrics.filter(m => m.category === 'primary')
-  const secondaryMetrics = metrics.filter(m => m.category === 'secondary')
-  const pinnedMetrics = metrics.filter(m => m.isPinned)
+  const metricDatasets = useMemo(() => {
+    const map = new Map<string, StandardMetricDataset>()
+    metrics.forEach((metric) => {
+      map.set(metric.id, buildMetricDataset(metric.path, visibleRuns))
+    })
+    return map
+  }, [metrics, visibleRuns])
+
+  const overviewMetrics = metrics.filter((metric) => metric.isInOverview)
+  const pinnedMetrics = metrics.filter((metric) => metric.isPinned)
+  const primaryMetrics = metrics.filter((metric) => metric.category === 'primary')
+  const secondaryMetrics = metrics.filter((metric) => metric.category === 'secondary')
+
+  const overviewCustomCharts = customCharts.filter((chart) => chart.isInOverview)
+
+  const canUseMultiColumn = !isMobile && viewportWidth >= chartSettings.multiColumnThresholdPx
+  const safeMinWidth = Math.max(180, Math.min(chartSettings.minChartWidth, chartSettings.maxChartWidth))
+  const safeMaxWidth = Math.max(safeMinWidth, chartSettings.maxChartWidth)
+  const effectiveColumns = canUseMultiColumn ? clampInt(chartSettings.chartsPerRow, 1, 6) : 1
+
+  const wrapForLayout = (items: React.ReactNode[]) => {
+    if (items.length === 0) {
+      return (
+        <div className="rounded-md border border-dashed border-border px-3 py-6 text-center text-xs text-muted-foreground">
+          No charts in this section.
+        </div>
+      )
+    }
+
+    if (chartSettings.layoutMode === 'fixed-grid') {
+      return (
+        <div
+          className="grid gap-3"
+          style={{
+            gridTemplateColumns: `repeat(${effectiveColumns}, minmax(${safeMinWidth}px, 1fr))`,
+          }}
+        >
+          {items.map((item, index) => (
+            <div key={`grid-${index}`} style={{ width: '100%', maxWidth: canUseMultiColumn ? `${safeMaxWidth}px` : '100%' }}>
+              {item}
+            </div>
+          ))}
+        </div>
+      )
+    }
+
+    return (
+      <div className="flex flex-wrap gap-3">
+        {items.map((item, index) => (
+          <div
+            key={`flex-${index}`}
+            style={canUseMultiColumn
+              ? {
+                  flex: `1 1 ${safeMinWidth}px`,
+                  minWidth: `${safeMinWidth}px`,
+                  maxWidth: `${safeMaxWidth}px`,
+                }
+              : {
+                  flexBasis: '100%',
+                  minWidth: '100%',
+                  maxWidth: '100%',
+                }}
+          >
+            {item}
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  const handleOpenSettings = (open: boolean) => {
+    if (open) {
+      setDraftSettings({ ...chartSettings })
+    }
+    setSettingsOpen(open)
+  }
+
+  const handleSaveSettings = () => {
+    setChartSettings(sanitizeSettings(draftSettings))
+    setSettingsOpen(false)
+  }
 
   const toggleRunVisibility = (runId: string) => {
     setVisibleRunIds((prev) => {
@@ -145,240 +608,39 @@ export function ChartsView({ runs, customCharts, onTogglePin, onToggleOverview, 
   const handleSelectGroup = (groupId: string | null) => {
     setActiveGroupId(groupId)
     if (groupId) {
-      const group = visibilityGroups.find(g => g.id === groupId)
+      const group = visibilityGroups.find((item) => item.id === groupId)
       if (group) {
         setVisibleRunIds(new Set(group.runIds))
       }
-    } else {
-      // Show all runs
-      setVisibleRunIds(new Set(activeRuns.map(r => r.id)))
+      return
     }
+    setVisibleRunIds(new Set(activeRuns.map((run) => run.id)))
   }
 
   const handleCreateGroup = (group: VisibilityGroup) => {
-    setVisibilityGroups(prev => [...prev, group])
+    setVisibilityGroups((prev) => [...prev, group])
   }
 
   const handleDeleteGroup = (groupId: string) => {
-    setVisibilityGroups(prev => prev.filter(g => g.id !== groupId))
+    setVisibilityGroups((prev) => prev.filter((group) => group.id !== groupId))
     if (activeGroupId === groupId) {
       setActiveGroupId(null)
-      setVisibleRunIds(new Set(activeRuns.map(r => r.id)))
+      setVisibleRunIds(new Set(activeRuns.map((run) => run.id)))
     }
   }
 
   const handleToggleMetricPin = (metricId: string) => {
-    setMetrics(prev => prev.map(m =>
-      m.id === metricId ? { ...m, isPinned: !m.isPinned } : m
-    ))
+    setMetrics((prev) => prev.map((metric) => (
+      metric.id === metricId ? { ...metric, isPinned: !metric.isPinned } : metric
+    )))
   }
 
   const handleToggleMetricOverview = (metricId: string) => {
-    setMetrics(prev => prev.map(m =>
-      m.id === metricId ? { ...m, isInOverview: !m.isInOverview } : m
-    ))
+    setMetrics((prev) => prev.map((metric) => (
+      metric.id === metricId ? { ...metric, isInOverview: !metric.isInOverview } : metric
+    )))
   }
 
-  const renderMetricChart = (metric: MetricVisualization) => {
-    const data = generateMetricData(metric.id, runs, visibleRunIds)
-
-    const ChartComponent = metric.type === 'area' ? AreaChart : LineChart
-
-    return (
-      // Hack: max-w-[calc(100vw-20px)]
-      <div key={metric.id} className="rounded-m border border-border bg-card p-2 max-w-[calc(100vw-20px)] overflow-hidden">
-        <div className="flex items-center justify-between mb-3">
-          <div className="flex items-center gap-0 min-w-0">
-            <h4 className="font-medium text-sm text-foreground truncate">{metric.name}</h4>
-            <Badge variant="outline" className="text-[10px] shrink-0">
-              {metric.path}
-            </Badge>
-          </div>
-          <div className="flex items-center gap-1 shrink-0">
-            {metric.layerSelector && (
-              <Select
-                value={String(selectedLayer[metric.id] || 0)}
-                onValueChange={(v) => setSelectedLayer(prev => ({ ...prev, [metric.id]: Number(v) }))}
-              >
-                <SelectTrigger className="h-7 w-20 text-xs">
-                  <SelectValue placeholder="Layer" />
-                </SelectTrigger>
-                <SelectContent>
-                  {Array.from({ length: 12 }, (_, i) => (
-                    <SelectItem key={i} value={String(i)}>
-                      Layer {i}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7"
-              onClick={() => handleToggleMetricOverview(metric.id)}
-            >
-              <Star className={`h-4 w-4 ${metric.isInOverview ? 'fill-yellow-500 text-yellow-500' : 'text-muted-foreground'}`} />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7"
-              onClick={() => handleToggleMetricPin(metric.id)}
-            >
-              <Pin className={`h-4 w-4 ${metric.isPinned ? 'fill-accent text-accent' : 'text-muted-foreground'}`} />
-            </Button>
-          </div>
-        </div>
-        <div className="h-36 overflow-x-auto max-w-full">
-          <ResponsiveContainer width="100%" height="100%" minWidth={150}>
-            <ChartComponent data={data}>
-              <XAxis
-                dataKey="step"
-                tick={{ fontSize: chartSettings.xAxisFontSize, fill: '#888' }}
-                axisLine={{ stroke: '#333' }}
-                tickLine={false}
-                tickCount={chartSettings.xAxisTickCount}
-              />
-              <YAxis
-                tick={{ fontSize: chartSettings.yAxisFontSize, fill: '#888' }}
-                axisLine={{ stroke: '#333' }}
-                tickLine={false}
-                width={chartSettings.yAxisWidth}
-                tickCount={chartSettings.yAxisTickCount}
-              />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: '#1a1a1a',
-                  border: '1px solid #333',
-                  borderRadius: '8px',
-                  fontSize: '11px'
-                }}
-              />
-              {visibleRuns.map((run) =>
-                metric.type === 'area' ? (
-                  <Area
-                    key={run.id}
-                    type="monotone"
-                    dataKey={run.name}
-                    stroke={run.color || '#4ade80'}
-                    fill={`${run.color || '#4ade80'}33`}
-                    strokeWidth={2}
-                  />
-                ) : (
-                  <Line
-                    key={run.id}
-                    type="monotone"
-                    dataKey={run.name}
-                    stroke={run.color || '#4ade80'}
-                    strokeWidth={2}
-                    dot={false}
-                  />
-                )
-              )}
-            </ChartComponent>
-          </ResponsiveContainer>
-        </div>
-      </div>
-    )
-  }
-
-  const renderCustomChart = (chart: InsightChart) => {
-    const data = chart.data.map((d) => ({
-      name: d.label,
-      value: d.value,
-      secondary: d.secondary,
-    }))
-
-    let chartElement: React.ReactNode = null
-
-    switch (chart.type) {
-      case 'line':
-        chartElement = (
-          <ResponsiveContainer width="100%" height={120}>
-            <LineChart data={data}>
-              <XAxis dataKey="name" tick={{ fontSize: chartSettings.xAxisFontSize, fill: '#888' }} axisLine={{ stroke: '#333' }} tickLine={false} tickCount={chartSettings.xAxisTickCount} />
-              <YAxis tick={{ fontSize: chartSettings.yAxisFontSize, fill: '#888' }} axisLine={{ stroke: '#333' }} tickLine={false} width={chartSettings.yAxisWidth} tickCount={chartSettings.yAxisTickCount} />
-              <Tooltip contentStyle={{ backgroundColor: '#1a1a1a', border: '1px solid #333', borderRadius: '8px', fontSize: '12px' }} />
-              <Line type="monotone" dataKey="value" stroke="#4ade80" strokeWidth={2} dot={{ fill: '#4ade80', r: 3 }} />
-            </LineChart>
-          </ResponsiveContainer>
-        )
-        break
-      case 'bar':
-        chartElement = (
-          <ResponsiveContainer width="100%" height={120}>
-            <BarChart data={data}>
-              <XAxis dataKey="name" tick={{ fontSize: chartSettings.xAxisFontSize, fill: '#888' }} axisLine={{ stroke: '#333' }} tickLine={false} tickCount={chartSettings.xAxisTickCount} />
-              <YAxis tick={{ fontSize: chartSettings.yAxisFontSize, fill: '#888' }} axisLine={{ stroke: '#333' }} tickLine={false} width={chartSettings.yAxisWidth} tickCount={chartSettings.yAxisTickCount} />
-              <Tooltip contentStyle={{ backgroundColor: '#1a1a1a', border: '1px solid #333', borderRadius: '8px', fontSize: '12px' }} />
-              <Bar dataKey="value" fill="#4ade80" radius={[4, 4, 0, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
-        )
-        break
-      case 'area':
-        chartElement = (
-          <ResponsiveContainer width="100%" height={120}>
-            <AreaChart data={data}>
-              <XAxis dataKey="name" tick={{ fontSize: chartSettings.xAxisFontSize, fill: '#888' }} axisLine={{ stroke: '#333' }} tickLine={false} tickCount={chartSettings.xAxisTickCount} />
-              <YAxis tick={{ fontSize: chartSettings.yAxisFontSize, fill: '#888' }} axisLine={{ stroke: '#333' }} tickLine={false} width={chartSettings.yAxisWidth} tickCount={chartSettings.yAxisTickCount} />
-              <Tooltip contentStyle={{ backgroundColor: '#1a1a1a', border: '1px solid #333', borderRadius: '8px', fontSize: '12px' }} />
-              <Area type="monotone" dataKey="value" stroke="#4ade80" fill="#4ade8033" strokeWidth={2} />
-            </AreaChart>
-          </ResponsiveContainer>
-        )
-        break
-      case 'scatter':
-        chartElement = (
-          <ResponsiveContainer width="100%" height={120}>
-            <ScatterChart>
-              <XAxis dataKey="name" tick={{ fontSize: chartSettings.xAxisFontSize, fill: '#888' }} axisLine={{ stroke: '#333' }} tickLine={false} type="category" allowDuplicatedCategory={false} tickCount={chartSettings.xAxisTickCount} />
-              <YAxis dataKey="value" tick={{ fontSize: chartSettings.yAxisFontSize, fill: '#888' }} axisLine={{ stroke: '#333' }} tickLine={false} width={chartSettings.yAxisWidth} tickCount={chartSettings.yAxisTickCount} />
-              <Tooltip contentStyle={{ backgroundColor: '#1a1a1a', border: '1px solid #333', borderRadius: '8px', fontSize: '12px' }} />
-              <Scatter data={data} fill="#4ade80" />
-            </ScatterChart>
-          </ResponsiveContainer>
-        )
-        break
-    }
-
-    return (
-      <div key={chart.id} className="rounded-xl border border-border bg-card p-4 max-w-[100vw] overflow-hidden">
-        <div className="flex items-center justify-between mb-3">
-          <div className="flex-1 min-w-0">
-            <h4 className="font-medium text-sm text-foreground truncate">{chart.title}</h4>
-            {chart.description && (
-              <p className="text-xs text-muted-foreground truncate">{chart.description}</p>
-            )}
-          </div>
-          <div className="flex items-center gap-1 shrink-0">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7"
-              onClick={() => onToggleOverview?.(chart.id)}
-            >
-              <Star className={`h-4 w-4 ${chart.isInOverview ? 'fill-yellow-500 text-yellow-500' : 'text-muted-foreground'}`} />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7"
-              onClick={() => onTogglePin?.(chart.id)}
-            >
-              <Pin className={`h-4 w-4 ${chart.isPinned ? 'fill-accent text-accent' : 'text-muted-foreground'}`} />
-            </Button>
-          </div>
-        </div>
-        <div className="rounded-lg bg-secondary/50 p-2 overflow-x-auto max-w-full">
-          {chartElement}
-        </div>
-      </div>
-    )
-  }
-
-  // Show visibility manage view
   if (showVisibilityManage) {
     return (
       <VisibilityManageView
@@ -396,35 +658,14 @@ export function ChartsView({ runs, customCharts, onTogglePin, onToggleOverview, 
   }
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
-      {/* Section Tabs */}
+    <div className="flex h-full flex-col overflow-hidden">
       <div className="shrink-0 border-b border-border px-4 py-3">
-        <div className="flex items-center gap-2">
-          <div className="flex-1 min-w-0 rounded-lg bg-secondary p-1 overflow-x-auto">
-            <div className="flex min-w-max items-center gap-1">
-              <button
-                type="button"
-                onClick={() => setActiveSection('standard')}
-                className={`shrink-0 inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeSection === 'standard'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-                  }`}
-              >
-                <Layers className="h-4 w-4" />
-                <span className="truncate">Standard</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => setActiveSection('custom')}
-                className={`shrink-0 inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeSection === 'custom'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-                  }`}
-              >
-                <BarChart3 className="h-4 w-4" />
-                <span className="truncate">Custom</span>
-              </button>
-            </div>
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium text-foreground">Charts</h3>
+            <p className="truncate text-xs text-muted-foreground">
+              Run-detail charting style, aggregated across all visible runs.
+            </p>
           </div>
           <Popover open={settingsOpen} onOpenChange={handleOpenSettings}>
             <PopoverTrigger asChild>
@@ -432,94 +673,153 @@ export function ChartsView({ runs, customCharts, onTogglePin, onToggleOverview, 
                 <Settings className="h-4 w-4" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent align="end" className="w-64">
+            <PopoverContent align="end" className="w-[320px]">
               <div className="space-y-4">
-                <h4 className="font-medium text-sm">Chart Settings</h4>
+                <h4 className="text-sm font-medium">Charts Settings</h4>
 
-                {/* Visibility Toggle */}
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="show-visibility" className="text-xs">
-                    Show visibility toggle
-                  </Label>
-                  <Switch
-                    id="show-visibility"
-                    checked={showVisibilitySection}
-                    onCheckedChange={setShowVisibilitySection}
-                  />
-                </div>
-
-                <div className="border-t border-border pt-3 space-y-3">
-                  <p className="text-xs font-medium text-muted-foreground">Axis Settings</p>
-
-                  {/* X-Axis Font Size */}
-                  <div className="flex items-center justify-between gap-2">
-                    <Label className="text-xs">X-Axis Font</Label>
-                    <Input
-                      type="number"
-                      value={draftSettings.xAxisFontSize}
-                      onChange={(e) => setDraftSettings(prev => ({ ...prev, xAxisFontSize: Number(e.target.value) }))}
-                      className="h-7 w-16 text-xs"
-                      min={0}
-
-                    />
-                  </div>
-
-                  {/* Y-Axis Font Size */}
-                  <div className="flex items-center justify-between gap-2">
-                    <Label className="text-xs">Y-Axis Font</Label>
-                    <Input
-                      type="number"
-                      value={draftSettings.yAxisFontSize}
-                      onChange={(e) => setDraftSettings(prev => ({ ...prev, yAxisFontSize: Number(e.target.value) }))}
-                      className="h-7 w-16 text-xs"
-                      min={0}
-                    />
-                  </div>
-
-                  {/* X-Axis Tick Count */}
-                  <div className="flex items-center justify-between gap-2">
-                    <Label className="text-xs">X-Axis Ticks</Label>
-                    <Input
-                      type="number"
-                      value={draftSettings.xAxisTickCount}
-                      onChange={(e) => setDraftSettings(prev => ({ ...prev, xAxisTickCount: Number(e.target.value) }))}
-                      className="h-7 w-16 text-xs"
-                      min={0}
-                    />
-                  </div>
-
-                  {/* Y-Axis Tick Count */}
-                  <div className="flex items-center justify-between gap-2">
-                    <Label className="text-xs">Y-Axis Ticks</Label>
-                    <Input
-                      type="number"
-                      value={draftSettings.yAxisTickCount}
-                      onChange={(e) => setDraftSettings(prev => ({ ...prev, yAxisTickCount: Number(e.target.value) }))}
-                      className="h-7 w-16 text-xs"
-                      min={0}
-                    />
-                  </div>
-
-                  {/* Y-Axis Width */}
-                  <div className="flex items-center justify-between gap-2">
-                    <Label className="text-xs">Y-Axis Width</Label>
-                    <Input
-                      type="number"
-                      value={draftSettings.yAxisWidth}
-                      onChange={(e) => setDraftSettings(prev => ({ ...prev, yAxisWidth: Number(e.target.value) }))}
-                      className="h-7 w-16 text-xs"
-                      min={0}
+                <div className="space-y-2 border-b border-border pb-3">
+                  <p className="text-xs font-medium text-muted-foreground">Visibility</p>
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="show-visibility" className="text-xs">Show run visibility selector</Label>
+                    <Switch
+                      id="show-visibility"
+                      checked={draftSettings.showVisibilitySection}
+                      onCheckedChange={(checked) => setDraftSettings((prev) => ({ ...prev, showVisibilitySection: checked }))}
                     />
                   </div>
                 </div>
 
-                {/* Save Button */}
-                <Button
-                  size="sm"
-                  className="w-full h-8 text-xs"
-                  onClick={handleSaveSettings}
-                >
-                  Save Settings
+                <div className="space-y-3 border-b border-border pb-3">
+                  <p className="text-xs font-medium text-muted-foreground">Layout</p>
+
+                  <div className="grid gap-1.5">
+                    <Label className="text-xs">Layout Mode</Label>
+                    <Select
+                      value={draftSettings.layoutMode}
+                      onValueChange={(value) => setDraftSettings((prev) => ({ ...prev, layoutMode: value as LayoutMode }))}
+                    >
+                      <SelectTrigger className="h-8 text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="fixed-grid">Fixed grid</SelectItem>
+                        <SelectItem value="flex">Flex wrap</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Charts / row</Label>
+                      <Input
+                        type="number"
+                        className="h-8 text-xs"
+                        value={draftSettings.chartsPerRow}
+                        onChange={(e) => setDraftSettings((prev) => ({ ...prev, chartsPerRow: Number(e.target.value) }))}
+                        min={1}
+                        max={6}
+                      />
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Multi-col threshold</Label>
+                      <Input
+                        type="number"
+                        className="h-8 text-xs"
+                        value={draftSettings.multiColumnThresholdPx}
+                        onChange={(e) => setDraftSettings((prev) => ({ ...prev, multiColumnThresholdPx: Number(e.target.value) }))}
+                        min={640}
+                        max={2400}
+                      />
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Min chart width</Label>
+                      <Input
+                        type="number"
+                        className="h-8 text-xs"
+                        value={draftSettings.minChartWidth}
+                        onChange={(e) => setDraftSettings((prev) => ({ ...prev, minChartWidth: Number(e.target.value) }))}
+                        min={180}
+                        max={1200}
+                      />
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Max chart width</Label>
+                      <Input
+                        type="number"
+                        className="h-8 text-xs"
+                        value={draftSettings.maxChartWidth}
+                        onChange={(e) => setDraftSettings((prev) => ({ ...prev, maxChartWidth: Number(e.target.value) }))}
+                        min={200}
+                        max={1400}
+                      />
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Chart height</Label>
+                      <Input
+                        type="number"
+                        className="h-8 text-xs"
+                        value={draftSettings.chartHeight}
+                        onChange={(e) => setDraftSettings((prev) => ({ ...prev, chartHeight: Number(e.target.value) }))}
+                        min={120}
+                        max={520}
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <p className="text-xs font-medium text-muted-foreground">Axis</p>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">X font</Label>
+                      <Input
+                        type="number"
+                        className="h-8 text-xs"
+                        value={draftSettings.xAxisFontSize}
+                        onChange={(e) => setDraftSettings((prev) => ({ ...prev, xAxisFontSize: Number(e.target.value) }))}
+                      />
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Y font</Label>
+                      <Input
+                        type="number"
+                        className="h-8 text-xs"
+                        value={draftSettings.yAxisFontSize}
+                        onChange={(e) => setDraftSettings((prev) => ({ ...prev, yAxisFontSize: Number(e.target.value) }))}
+                      />
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">X ticks</Label>
+                      <Input
+                        type="number"
+                        className="h-8 text-xs"
+                        value={draftSettings.xAxisTickCount}
+                        onChange={(e) => setDraftSettings((prev) => ({ ...prev, xAxisTickCount: Number(e.target.value) }))}
+                      />
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Y ticks</Label>
+                      <Input
+                        type="number"
+                        className="h-8 text-xs"
+                        value={draftSettings.yAxisTickCount}
+                        onChange={(e) => setDraftSettings((prev) => ({ ...prev, yAxisTickCount: Number(e.target.value) }))}
+                      />
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Y axis width</Label>
+                      <Input
+                        type="number"
+                        className="h-8 text-xs"
+                        value={draftSettings.yAxisWidth}
+                        onChange={(e) => setDraftSettings((prev) => ({ ...prev, yAxisWidth: Number(e.target.value) }))}
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <Button size="sm" className="h-8 w-full text-xs" onClick={handleSaveSettings}>
+                  Save settings
                 </Button>
               </div>
             </PopoverContent>
@@ -527,8 +827,7 @@ export function ChartsView({ runs, customCharts, onTogglePin, onToggleOverview, 
         </div>
       </div>
 
-      {/* Run Visibility Selector - Sticky (conditionally shown) */}
-      {showVisibilitySection && (
+      {chartSettings.showVisibilitySection && (
         <div className="shrink-0 border-b border-border bg-background px-4 py-3">
           <RunVisibilitySelector
             runs={activeRuns}
@@ -544,62 +843,181 @@ export function ChartsView({ runs, customCharts, onTogglePin, onToggleOverview, 
 
       <div className="flex-1 min-h-0 overflow-hidden">
         <ScrollArea className="h-full">
-          <div className="p-4 space-y-6">
-            {activeSection === 'standard' ? (
-              <>
-                {/* Pinned Metrics */}
-                {pinnedMetrics.length > 0 && (
-                  <div>
-                    <div className="flex items-center gap-2 mb-3">
-                      <Pin className="h-4 w-4 text-accent" />
-                      <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                        Pinned
-                      </h3>
+          <div className="space-y-4 p-4">
+            <Collapsible open={overviewOpen} onOpenChange={setOverviewOpen}>
+              <div className="rounded-lg border border-border bg-card overflow-hidden">
+                <CollapsibleTrigger asChild>
+                  <button type="button" className="flex w-full items-center justify-between p-3">
+                    <div className="flex items-center gap-2">
+                      <Star className="h-4 w-4 text-yellow-500" />
+                      <span className="text-xs font-medium text-foreground">Overview (Favorites)</span>
+                      <Badge variant="outline" className="h-4 text-[10px]">
+                        {overviewMetrics.length + overviewCustomCharts.length}
+                      </Badge>
                     </div>
-                    <div className="space-y-4">
-                      {pinnedMetrics.map(renderMetricChart)}
-                    </div>
+                    {overviewOpen ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
+                  </button>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="border-t border-border p-3">
+                    {wrapForLayout([
+                      ...overviewMetrics.map((metric) => (
+                        <StandardMetricCard
+                          key={`overview-${metric.id}`}
+                          metric={metric}
+                          visibleRuns={visibleRuns}
+                          dataset={metricDatasets.get(metric.id) || { rows: [], runIdsWithData: new Set() }}
+                          chartSettings={chartSettings}
+                          chartHeight={chartSettings.chartHeight}
+                          onToggleMetricPin={handleToggleMetricPin}
+                          onToggleMetricOverview={handleToggleMetricOverview}
+                        />
+                      )),
+                      ...overviewCustomCharts.map((chart) => (
+                        <CustomChartCard
+                          key={`overview-custom-${chart.id}`}
+                          chart={chart}
+                          chartHeight={chartSettings.chartHeight}
+                          chartSettings={chartSettings}
+                          onTogglePin={onTogglePin}
+                          onToggleOverview={onToggleOverview}
+                        />
+                      )),
+                    ])}
                   </div>
-                )}
-
-                {/* Primary Metrics */}
-                <div>
-                  <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">
-                    Primary Metrics
-                  </h3>
-                  <div className="space-y-4">
-                    {primaryMetrics.filter(m => !m.isPinned).map(renderMetricChart)}
-                  </div>
-                </div>
-
-                {/* Secondary Metrics */}
-                <div>
-                  <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">
-                    Secondary Metrics
-                  </h3>
-                  <div className="space-y-4">
-                    {secondaryMetrics.filter(m => !m.isPinned).map(renderMetricChart)}
-                  </div>
-                </div>
-              </>
-            ) : (
-              <div>
-                <div className="flex items-center gap-3 mb-4">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent/10 border border-accent/30">
-                    <TrendingUp className="h-5 w-5 text-accent" />
-                  </div>
-                  <div>
-                    <h3 className="text-sm font-medium text-foreground">Custom Visualizations</h3>
-                    <p className="text-xs text-muted-foreground">
-                      {customCharts.length} saved charts
-                    </p>
-                  </div>
-                </div>
-                <div className="space-y-4">
-                  {customCharts.map(renderCustomChart)}
-                </div>
+                </CollapsibleContent>
               </div>
-            )}
+            </Collapsible>
+
+            <Collapsible open={pinnedOpen} onOpenChange={setPinnedOpen}>
+              <div className="rounded-lg border border-border bg-card overflow-hidden">
+                <CollapsibleTrigger asChild>
+                  <button type="button" className="flex w-full items-center justify-between p-3">
+                    <div className="flex items-center gap-2">
+                      <Pin className="h-4 w-4 text-accent" />
+                      <span className="text-xs font-medium text-foreground">Pinned</span>
+                      <Badge variant="outline" className="h-4 text-[10px]">{pinnedMetrics.length}</Badge>
+                    </div>
+                    {pinnedOpen ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
+                  </button>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="border-t border-border p-3">
+                    {wrapForLayout(
+                      pinnedMetrics.map((metric) => (
+                        <StandardMetricCard
+                          key={`pinned-${metric.id}`}
+                          metric={metric}
+                          visibleRuns={visibleRuns}
+                          dataset={metricDatasets.get(metric.id) || { rows: [], runIdsWithData: new Set() }}
+                          chartSettings={chartSettings}
+                          chartHeight={chartSettings.chartHeight}
+                          onToggleMetricPin={handleToggleMetricPin}
+                          onToggleMetricOverview={handleToggleMetricOverview}
+                        />
+                      ))
+                    )}
+                  </div>
+                </CollapsibleContent>
+              </div>
+            </Collapsible>
+
+            <Collapsible open={primaryOpen} onOpenChange={setPrimaryOpen}>
+              <div className="rounded-lg border border-border bg-card overflow-hidden">
+                <CollapsibleTrigger asChild>
+                  <button type="button" className="flex w-full items-center justify-between p-3">
+                    <div className="flex items-center gap-2">
+                      <Layers className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-xs font-medium text-foreground">Primary Metrics</span>
+                      <Badge variant="outline" className="h-4 text-[10px]">{primaryMetrics.length}</Badge>
+                    </div>
+                    {primaryOpen ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
+                  </button>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="border-t border-border p-3">
+                    {wrapForLayout(
+                      primaryMetrics.map((metric) => (
+                        <StandardMetricCard
+                          key={`primary-${metric.id}`}
+                          metric={metric}
+                          visibleRuns={visibleRuns}
+                          dataset={metricDatasets.get(metric.id) || { rows: [], runIdsWithData: new Set() }}
+                          chartSettings={chartSettings}
+                          chartHeight={chartSettings.chartHeight}
+                          onToggleMetricPin={handleToggleMetricPin}
+                          onToggleMetricOverview={handleToggleMetricOverview}
+                        />
+                      ))
+                    )}
+                  </div>
+                </CollapsibleContent>
+              </div>
+            </Collapsible>
+
+            <Collapsible open={secondaryOpen} onOpenChange={setSecondaryOpen}>
+              <div className="rounded-lg border border-border bg-card overflow-hidden">
+                <CollapsibleTrigger asChild>
+                  <button type="button" className="flex w-full items-center justify-between p-3">
+                    <div className="flex items-center gap-2">
+                      <BarChart3 className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-xs font-medium text-foreground">Secondary Metrics</span>
+                      <Badge variant="outline" className="h-4 text-[10px]">{secondaryMetrics.length}</Badge>
+                    </div>
+                    {secondaryOpen ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
+                  </button>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="border-t border-border p-3">
+                    {wrapForLayout(
+                      secondaryMetrics.map((metric) => (
+                        <StandardMetricCard
+                          key={`secondary-${metric.id}`}
+                          metric={metric}
+                          visibleRuns={visibleRuns}
+                          dataset={metricDatasets.get(metric.id) || { rows: [], runIdsWithData: new Set() }}
+                          chartSettings={chartSettings}
+                          chartHeight={chartSettings.chartHeight}
+                          onToggleMetricPin={handleToggleMetricPin}
+                          onToggleMetricOverview={handleToggleMetricOverview}
+                        />
+                      ))
+                    )}
+                  </div>
+                </CollapsibleContent>
+              </div>
+            </Collapsible>
+
+            <Collapsible open={customOpen} onOpenChange={setCustomOpen}>
+              <div className="rounded-lg border border-border bg-card overflow-hidden">
+                <CollapsibleTrigger asChild>
+                  <button type="button" className="flex w-full items-center justify-between p-3">
+                    <div className="flex items-center gap-2">
+                      <TrendingUp className="h-4 w-4 text-accent" />
+                      <span className="text-xs font-medium text-foreground">Custom Visualizations</span>
+                      <Badge variant="outline" className="h-4 text-[10px]">{customCharts.length}</Badge>
+                    </div>
+                    {customOpen ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
+                  </button>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="border-t border-border p-3">
+                    {wrapForLayout(
+                      customCharts.map((chart) => (
+                        <CustomChartCard
+                          key={chart.id}
+                          chart={chart}
+                          chartHeight={chartSettings.chartHeight}
+                          chartSettings={chartSettings}
+                          onTogglePin={onTogglePin}
+                          onToggleOverview={onToggleOverview}
+                        />
+                      ))
+                    )}
+                  </div>
+                </CollapsibleContent>
+              </div>
+            </Collapsible>
           </div>
         </ScrollArea>
       </div>

--- a/components/settings-page-content.tsx
+++ b/components/settings-page-content.tsx
@@ -12,6 +12,7 @@ import {
   LayoutGrid,
   Monitor,
   Moon,
+  Rows3,
   RotateCcw,
   Server,
   Slack,
@@ -162,6 +163,15 @@ export function SettingsPageContent({
           value: settings.appearance.buttonSize,
         },
         {
+          id: 'runItemInteractionMode',
+          label: 'Runs/Sweeps Click Mode',
+          description: 'Open detail page or expand inline details',
+          icon: Rows3,
+          type: 'select' as const,
+          options: ['detail-page', 'inline-expand'],
+          value: settings.appearance.runItemInteractionMode || 'detail-page',
+        },
+        {
           id: 'showStarterCards',
           label: 'Starter Cards',
           description: 'Show contextual prompt cards on new chats',
@@ -242,6 +252,13 @@ export function SettingsPageContent({
     onSettingsChange({
       ...settings,
       appearance: { ...settings.appearance, buttonSize },
+    })
+  }
+
+  const handleRunItemInteractionModeChange = (mode: 'detail-page' | 'inline-expand') => {
+    onSettingsChange({
+      ...settings,
+      appearance: { ...settings.appearance, runItemInteractionMode: mode },
     })
   }
 
@@ -401,12 +418,13 @@ export function SettingsPageContent({
                     if (item.id === 'theme') handleThemeChange(option as 'dark' | 'light' | 'system')
                     if (item.id === 'fontSize') handleFontSizeChange(option as 'small' | 'medium' | 'large')
                     if (item.id === 'buttonSize') handleButtonSizeChange(option as 'compact' | 'default' | 'large')
+                    if (item.id === 'runItemInteractionMode') handleRunItemInteractionModeChange(option as 'detail-page' | 'inline-expand')
                   }}
                   className={`flex-1 rounded-lg px-3 py-2 text-xs font-medium capitalize transition-colors ${item.value === option
                     ? 'bg-accent text-accent-foreground'
                     : 'bg-background text-muted-foreground hover:text-foreground'}`}
                 >
-                  {option}
+                  {option.replace('-', ' ')}
                 </button>
               ))}
             </div>

--- a/hooks/use-cluster.ts
+++ b/hooks/use-cluster.ts
@@ -1,0 +1,82 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  detectCluster,
+  getClusterStatus,
+  updateCluster,
+  type ClusterState,
+  type ClusterStatusResponse,
+  type ClusterType,
+  type ClusterUpdateRequest,
+} from '@/lib/api-client'
+
+interface UseClusterResult {
+  cluster: ClusterState | null
+  runSummary: ClusterStatusResponse['run_summary'] | null
+  isLoading: boolean
+  error: string | null
+  refetch: () => Promise<void>
+  autoDetect: (preferredType?: ClusterType) => Promise<void>
+  saveCluster: (request: ClusterUpdateRequest) => Promise<void>
+}
+
+export function useCluster(): UseClusterResult {
+  const [cluster, setCluster] = useState<ClusterState | null>(null)
+  const [runSummary, setRunSummary] = useState<ClusterStatusResponse['run_summary'] | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const pollingRef = useRef<NodeJS.Timeout | null>(null)
+
+  const fetchCluster = useCallback(async () => {
+    try {
+      const response = await getClusterStatus()
+      setCluster(response.cluster)
+      setRunSummary(response.run_summary)
+      setError(null)
+    } catch (e) {
+      console.error('Failed to fetch cluster status:', e)
+      setError(e instanceof Error ? e.message : 'Failed to fetch cluster status')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchCluster()
+
+    pollingRef.current = setInterval(() => {
+      void fetchCluster()
+    }, 15000)
+
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current)
+      }
+    }
+  }, [fetchCluster])
+
+  const autoDetect = useCallback(async (preferredType?: ClusterType) => {
+    const response = await detectCluster(preferredType ? { preferred_type: preferredType } : undefined)
+    setCluster(response.cluster)
+    setRunSummary(response.run_summary)
+    setError(null)
+  }, [])
+
+  const saveCluster = useCallback(async (request: ClusterUpdateRequest) => {
+    const response = await updateCluster(request)
+    setCluster(response.cluster)
+    setRunSummary(response.run_summary)
+    setError(null)
+  }, [])
+
+  return {
+    cluster,
+    runSummary,
+    isLoading,
+    error,
+    refetch: fetchCluster,
+    autoDetect,
+    saveCluster,
+  }
+}

--- a/hooks/use-runs.ts
+++ b/hooks/use-runs.ts
@@ -67,6 +67,15 @@ function apiRunToExperimentRun(run: Run, metadata?: RunMetadata): ExperimentRun 
         'stopped': 'canceled',
     }
 
+    const createdAt = new Date(run.created_at * 1000)
+    const queuedAt = run.queued_at ? new Date(run.queued_at * 1000) : undefined
+    const launchedAt = run.launched_at ? new Date(run.launched_at * 1000) : undefined
+    const startedAt = run.started_at ? new Date(run.started_at * 1000) : undefined
+    const stoppedAt = run.stopped_at ? new Date(run.stopped_at * 1000) : undefined
+    const endTime = run.ended_at
+        ? new Date(run.ended_at * 1000)
+        : (run.stopped_at ? new Date(run.stopped_at * 1000) : undefined)
+
     return {
         id: run.id,
         name: run.name,
@@ -76,8 +85,13 @@ function apiRunToExperimentRun(run: Run, metadata?: RunMetadata): ExperimentRun 
         command: run.command,
         status: statusMap[run.status],
         progress: run.progress ?? (run.status === 'running' ? 50 : run.status === 'finished' ? 100 : 0),
-        startTime: new Date(run.created_at * 1000),
-        endTime: run.ended_at ? new Date(run.ended_at * 1000) : undefined,
+        createdAt,
+        queuedAt,
+        launchedAt,
+        startedAt,
+        stoppedAt,
+        startTime: startedAt || launchedAt || createdAt,
+        endTime,
         isArchived: run.is_archived,
         parentRunId: run.parent_run_id || undefined,
         originAlertId: run.origin_alert_id || undefined,

--- a/hooks/use-sweeps.ts
+++ b/hooks/use-sweeps.ts
@@ -1,0 +1,130 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  createSweep,
+  listSweeps,
+  startSweep,
+  updateSweep,
+} from '@/lib/api-client'
+import type { Sweep as ApiSweep } from '@/lib/api-client'
+import type { Sweep, SweepConfig } from '@/lib/types'
+import {
+  mapApiSweepToUiSweep,
+  sweepConfigToCreateRequest,
+  sweepConfigToUpdateRequest,
+} from '@/lib/sweep-mappers'
+
+interface UseSweepsResult {
+  sweeps: Sweep[]
+  isLoading: boolean
+  error: string | null
+  refetch: () => Promise<void>
+  saveDraftSweep: (config: SweepConfig) => Promise<Sweep>
+  launchSweepFromConfig: (config: SweepConfig) => Promise<Sweep>
+}
+
+function isSweepActive(status: Sweep['status']) {
+  return status === 'running' || status === 'pending'
+}
+
+function findSweepForConfig(sweeps: Sweep[], config: SweepConfig): Sweep | null {
+  return (
+    sweeps.find((sweep) => sweep.id === config.id) ||
+    sweeps.find((sweep) => sweep.config.id === config.id) ||
+    null
+  )
+}
+
+export function useSweeps(): UseSweepsResult {
+  const [sweeps, setSweeps] = useState<Sweep[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const pollingRef = useRef<NodeJS.Timeout | null>(null)
+  const sweepsRef = useRef<Sweep[]>([])
+  sweepsRef.current = sweeps
+
+  const fetchSweeps = useCallback(async () => {
+    try {
+      const apiSweeps = await listSweeps()
+      const mapped = apiSweeps.map(mapApiSweepToUiSweep)
+      setSweeps(mapped)
+      setError(null)
+    } catch (e) {
+      console.error('Failed to fetch sweeps:', e)
+      setError(e instanceof Error ? e.message : 'Failed to fetch sweeps')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchSweeps()
+
+    pollingRef.current = setInterval(() => {
+      const hasActiveSweeps = sweepsRef.current.some((sweep) => isSweepActive(sweep.status))
+      if (hasActiveSweeps) {
+        fetchSweeps()
+      }
+    }, 5000)
+
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current)
+      }
+    }
+  }, [fetchSweeps])
+
+  const saveDraftSweep = useCallback(async (config: SweepConfig): Promise<Sweep> => {
+    const existing = findSweepForConfig(sweepsRef.current, config)
+
+    let apiSweep: ApiSweep
+    if (existing && (existing.status === 'draft' || existing.status === 'pending')) {
+      try {
+        apiSweep = await updateSweep(existing.id, sweepConfigToUpdateRequest(config, 'draft'))
+      } catch {
+        // If the server rejects in-place mutation (e.g. sweep already has runs), create a new draft revision.
+        apiSweep = await createSweep(sweepConfigToCreateRequest(config, 'draft'))
+      }
+    } else {
+      apiSweep = await createSweep(sweepConfigToCreateRequest(config, 'draft'))
+    }
+
+    await fetchSweeps()
+    return mapApiSweepToUiSweep(apiSweep)
+  }, [fetchSweeps])
+
+  const launchSweepFromConfig = useCallback(async (config: SweepConfig): Promise<Sweep> => {
+    const existing = findSweepForConfig(sweepsRef.current, config)
+    const parallel = Math.max(1, config.parallelRuns || 1)
+
+    let targetSweepId: string
+    if (existing && existing.runIds.length > 0 && (existing.status === 'pending' || existing.status === 'running')) {
+      targetSweepId = existing.id
+    } else {
+      const createdSweep = await createSweep(sweepConfigToCreateRequest(config, 'pending'))
+      targetSweepId = createdSweep.id
+    }
+
+    await startSweep(targetSweepId, parallel)
+    await fetchSweeps()
+
+    const latest = sweepsRef.current.find((sweep) => sweep.id === targetSweepId)
+    if (latest) return latest
+
+    const latestFromApi = (await listSweeps()).find((sweep) => sweep.id === targetSweepId)
+    if (!latestFromApi) {
+      throw new Error(`Sweep not found after launch: ${targetSweepId}`)
+    }
+    return mapApiSweepToUiSweep(latestFromApi)
+  }, [fetchSweeps])
+
+  return {
+    sweeps,
+    isLoading,
+    error,
+    refetch: fetchSweeps,
+    saveDraftSweep,
+    launchSweepFromConfig,
+  }
+}

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -28,7 +28,15 @@ export type {
     Alert,
     Sweep,
     CreateSweepRequest,
+    UpdateSweepRequest,
     WildModeState,
+    ClusterType,
+    ClusterState,
+    ClusterHealthStatus,
+    ClusterSource,
+    ClusterStatusResponse,
+    ClusterUpdateRequest,
+    ClusterDetectRequest,
 } from './api'
 
 // Dynamic API selection based on runtime config
@@ -124,8 +132,20 @@ export const listSweeps = (...args: Parameters<typeof realApi.listSweeps>) =>
 export const createSweep = (...args: Parameters<typeof realApi.createSweep>) =>
     getApi().createSweep(...args)
 
+export const updateSweep = (...args: Parameters<typeof realApi.updateSweep>) =>
+    getApi().updateSweep(...args)
+
 export const getSweep = (...args: Parameters<typeof realApi.getSweep>) =>
     getApi().getSweep(...args)
 
 export const startSweep = (...args: Parameters<typeof realApi.startSweep>) =>
     getApi().startSweep(...args)
+
+export const getClusterStatus = (...args: Parameters<typeof realApi.getClusterStatus>) =>
+    getApi().getClusterStatus(...args)
+
+export const detectCluster = (...args: Parameters<typeof realApi.detectCluster>) =>
+    getApi().detectCluster(...args)
+
+export const updateCluster = (...args: Parameters<typeof realApi.updateCluster>) =>
+    getApi().updateCluster(...args)

--- a/lib/api-mock.ts
+++ b/lib/api-mock.ts
@@ -16,11 +16,17 @@ import type {
     Alert,
     Sweep,
     CreateSweepRequest,
+    UpdateSweepRequest,
     WildModeState,
+    ClusterType,
+    ClusterState,
+    ClusterStatusResponse,
+    ClusterUpdateRequest,
+    ClusterDetectRequest,
 } from './api'
 
 // Re-export types
-export type { ChatSession, SessionWithMessages, StreamEvent, Run, RunStatus, CreateRunRequest, RunRerunRequest, LogResponse, Artifact, Alert, Sweep, CreateSweepRequest, WildModeState }
+export type { ChatSession, SessionWithMessages, StreamEvent, Run, RunStatus, CreateRunRequest, RunRerunRequest, LogResponse, Artifact, Alert, Sweep, CreateSweepRequest, UpdateSweepRequest, WildModeState, ClusterType, ClusterState, ClusterStatusResponse, ClusterUpdateRequest, ClusterDetectRequest }
 export type { ChatMessageData, StreamEventType } from './api'
 
 // =============================================================================
@@ -268,6 +274,32 @@ const mockAlerts: Map<string, Alert> = new Map([
 
 let wildModeEnabled = false
 
+const CLUSTER_TYPE_LABELS: Record<ClusterType, string> = {
+    unknown: 'Unknown',
+    slurm: 'Slurm',
+    local_gpu: 'Local GPU',
+    kubernetes: 'Kubernetes',
+    ray: 'Ray',
+    shared_head_node: 'Shared GPU Head Node',
+}
+
+let mockCluster: ClusterState = {
+    type: 'local_gpu',
+    status: 'healthy',
+    source: 'detected',
+    label: CLUSTER_TYPE_LABELS.local_gpu,
+    description: 'Single-host GPU workstation/cluster detected.',
+    head_node: 'local-host',
+    node_count: 1,
+    gpu_count: 4,
+    confidence: 0.84,
+    details: {
+        signals: ['nvidia-smi'],
+    },
+    last_detected_at: Date.now() / 1000 - 120,
+    updated_at: Date.now() / 1000 - 120,
+}
+
 // =============================================================================
 // Helper Functions
 // =============================================================================
@@ -278,6 +310,66 @@ function delay(ms: number): Promise<void> {
 
 function generateId(): string {
     return Math.random().toString(36).substring(2, 14)
+}
+
+function nowSeconds() {
+    return Date.now() / 1000
+}
+
+function normalizeClusterType(input?: string | null): ClusterType {
+    if (!input) return 'unknown'
+    const normalized = input.trim().toLowerCase().replace('-', '_')
+    if (normalized === 'k8s') return 'kubernetes'
+    if (normalized === 'shared_gpu') return 'shared_head_node'
+    if (normalized === 'head_node') return 'shared_head_node'
+    if (
+        normalized === 'unknown' ||
+        normalized === 'slurm' ||
+        normalized === 'local_gpu' ||
+        normalized === 'kubernetes' ||
+        normalized === 'ray' ||
+        normalized === 'shared_head_node'
+    ) {
+        return normalized
+    }
+    return 'unknown'
+}
+
+function getRunSummary() {
+    const activeRuns = Array.from(mockRuns.values()).filter((run) => !run.is_archived)
+    return {
+        total: activeRuns.length,
+        running: activeRuns.filter((run) => run.status === 'running').length,
+        launching: activeRuns.filter((run) => run.status === 'launching').length,
+        queued: activeRuns.filter((run) => run.status === 'queued').length,
+        ready: activeRuns.filter((run) => run.status === 'ready').length,
+        failed: activeRuns.filter((run) => run.status === 'failed').length,
+        finished: activeRuns.filter((run) => run.status === 'finished').length,
+    }
+}
+
+function getClusterDescription(type: ClusterType): string {
+    switch (type) {
+        case 'slurm':
+            return 'Slurm-managed cluster scheduler detected.'
+        case 'local_gpu':
+            return 'Single-host GPU workstation/cluster detected.'
+        case 'kubernetes':
+            return 'Kubernetes cluster control plane detected.'
+        case 'ray':
+            return 'Ray cluster runtime detected.'
+        case 'shared_head_node':
+            return 'Head node with SSH fan-out to worker nodes.'
+        default:
+            return 'Cluster has not been configured yet.'
+    }
+}
+
+function buildClusterResponse(): ClusterStatusResponse {
+    return {
+        cluster: mockCluster,
+        run_summary: getRunSummary(),
+    }
 }
 
 // =============================================================================
@@ -642,6 +734,35 @@ export async function listSweeps(): Promise<Sweep[]> {
 export async function createSweep(request: CreateSweepRequest): Promise<Sweep> {
     await delay(300)
     const sweepId = `sweep-${generateId()}`
+    const requestedStatus = request.status || (request.auto_start ? 'running' : 'pending')
+    const shouldCreateDraft = requestedStatus === 'draft'
+
+    if (shouldCreateDraft) {
+        const sweep: Sweep = {
+            id: sweepId,
+            name: request.name,
+            base_command: request.base_command,
+            workdir: request.workdir,
+            parameters: request.parameters,
+            run_ids: [],
+            status: 'draft',
+            created_at: Date.now() / 1000,
+            goal: request.goal,
+            ui_config: request.ui_config,
+            progress: {
+                total: 0,
+                completed: 0,
+                failed: 0,
+                running: 0,
+                launching: 0,
+                ready: 0,
+                queued: 0,
+                canceled: 0,
+            },
+        }
+        mockSweeps.set(sweepId, sweep)
+        return sweep
+    }
 
     // Create runs for each parameter combination
     const runIds: string[] = []
@@ -675,7 +796,7 @@ export async function createSweep(request: CreateSweepRequest): Promise<Sweep> {
             name: `${request.name} #${i + 1}`,
             command: `${request.base_command} ${paramStr}`,
             workdir: request.workdir || '/workspace',
-            status: request.auto_start ? 'queued' : 'ready',
+            status: requestedStatus === 'running' ? 'queued' : 'ready',
             is_archived: false,
             created_at: Date.now() / 1000,
             sweep_id: sweepId,
@@ -692,15 +813,19 @@ export async function createSweep(request: CreateSweepRequest): Promise<Sweep> {
         workdir: request.workdir,
         parameters: request.parameters,
         run_ids: runIds,
-        status: request.auto_start ? 'running' : 'ready',
+        status: requestedStatus === 'running' ? 'running' : 'pending',
         created_at: Date.now() / 1000,
+        goal: request.goal,
+        ui_config: request.ui_config,
         progress: {
             total: runIds.length,
             completed: 0,
             failed: 0,
             running: 0,
-            ready: request.auto_start ? 0 : runIds.length,
-            queued: request.auto_start ? runIds.length : 0,
+            launching: 0,
+            ready: requestedStatus === 'running' ? 0 : runIds.length,
+            queued: requestedStatus === 'running' ? runIds.length : 0,
+            canceled: 0,
         },
     }
     mockSweeps.set(sweepId, sweep)
@@ -716,6 +841,26 @@ export async function getSweep(sweepId: string): Promise<Sweep> {
     return sweep
 }
 
+export async function updateSweep(sweepId: string, request: UpdateSweepRequest): Promise<Sweep> {
+    await delay(150)
+    const sweep = mockSweeps.get(sweepId)
+    if (!sweep) {
+        throw new Error('Sweep not found')
+    }
+
+    if (request.base_command !== undefined) sweep.base_command = request.base_command
+    if (request.workdir !== undefined) sweep.workdir = request.workdir
+    if (request.parameters !== undefined) sweep.parameters = request.parameters
+    if (request.max_runs !== undefined) sweep.max_runs = request.max_runs
+    if (request.goal !== undefined) sweep.goal = request.goal
+    if (request.status !== undefined) sweep.status = request.status
+    if (request.name !== undefined) sweep.name = request.name
+    if (request.ui_config !== undefined) sweep.ui_config = request.ui_config
+
+    mockSweeps.set(sweepId, sweep)
+    return sweep
+}
+
 export async function startSweep(sweepId: string, parallel: number = 1): Promise<{ message: string }> {
     await delay(200)
     const sweep = mockSweeps.get(sweepId)
@@ -723,5 +868,67 @@ export async function startSweep(sweepId: string, parallel: number = 1): Promise
         throw new Error('Sweep not found')
     }
     sweep.status = 'running'
+    sweep.started_at = sweep.started_at || Date.now() / 1000
+    if (sweep.progress) {
+        sweep.progress.queued = Math.max(0, (sweep.progress.queued || 0) - Math.min(parallel, sweep.run_ids.length))
+        sweep.progress.running = Math.min(parallel, sweep.run_ids.length)
+    }
     return { message: `Started ${Math.min(parallel, sweep.run_ids.length)} runs (mock)` }
+}
+
+// =============================================================================
+// Cluster Management Functions
+// =============================================================================
+
+export async function getClusterStatus(): Promise<ClusterStatusResponse> {
+    await delay(120)
+    return buildClusterResponse()
+}
+
+export async function detectCluster(request?: ClusterDetectRequest): Promise<ClusterStatusResponse> {
+    await delay(180)
+    const preferredType = normalizeClusterType(request?.preferred_type)
+    const detectedType: ClusterType = preferredType !== 'unknown'
+        ? preferredType
+        : (mockCluster.type === 'unknown' ? 'local_gpu' : mockCluster.type)
+
+    const now = nowSeconds()
+    mockCluster = {
+        ...mockCluster,
+        type: detectedType,
+        status: 'healthy',
+        source: preferredType !== 'unknown' ? 'manual' : 'detected',
+        label: CLUSTER_TYPE_LABELS[detectedType],
+        description: getClusterDescription(detectedType),
+        confidence: preferredType !== 'unknown' ? 1 : 0.85,
+        head_node: detectedType === 'shared_head_node' ? 'gpu-head-01' : (detectedType === 'local_gpu' ? 'local-host' : mockCluster.head_node),
+        node_count: detectedType === 'local_gpu' ? 1 : (detectedType === 'slurm' ? 6 : detectedType === 'kubernetes' ? 4 : detectedType === 'shared_head_node' ? 5 : mockCluster.node_count),
+        gpu_count: detectedType === 'kubernetes' ? 16 : detectedType === 'shared_head_node' ? 12 : detectedType === 'slurm' ? 32 : 4,
+        details: {
+            detected_by: preferredType !== 'unknown' ? 'user-selection' : 'mock-auto-detect',
+            ...(mockCluster.details || {}),
+        },
+        last_detected_at: now,
+        updated_at: now,
+    }
+
+    return buildClusterResponse()
+}
+
+export async function updateCluster(request: ClusterUpdateRequest): Promise<ClusterStatusResponse> {
+    await delay(150)
+    const now = nowSeconds()
+    const nextType = request.type ? normalizeClusterType(request.type) : mockCluster.type
+
+    mockCluster = {
+        ...mockCluster,
+        ...request,
+        type: nextType,
+        label: CLUSTER_TYPE_LABELS[nextType],
+        description: getClusterDescription(nextType),
+        source: request.source || 'manual',
+        updated_at: now,
+    }
+
+    return buildClusterResponse()
 }

--- a/lib/app-settings.tsx
+++ b/lib/app-settings.tsx
@@ -7,6 +7,7 @@ const STORAGE_KEY_APP_SETTINGS = 'research-agent-app-settings'
 const STORAGE_KEY_APPEARANCE_THEME = 'research-agent-appearance-theme'
 const STORAGE_KEY_APPEARANCE_FONT_SIZE = 'research-agent-appearance-font-size'
 const STORAGE_KEY_APPEARANCE_BUTTON_SIZE = 'research-agent-appearance-button-size'
+const STORAGE_KEY_APPEARANCE_RUN_ITEM_INTERACTION = 'research-agent-appearance-run-item-interaction-mode'
 const STORAGE_KEY_APPEARANCE_CUSTOM_FONT_SIZE_PX = 'research-agent-appearance-custom-font-size-px'
 const STORAGE_KEY_APPEARANCE_CUSTOM_BUTTON_SCALE_PERCENT = 'research-agent-appearance-custom-button-scale-percent'
 const STORAGE_KEY_APPEARANCE_CHAT_TOOLBAR_BUTTON_SIZE_PX = 'research-agent-appearance-chat-toolbar-button-size-px'
@@ -16,6 +17,7 @@ export const defaultAppSettings: AppSettings = {
     theme: 'light',
     fontSize: 'medium',
     buttonSize: 'default',
+    runItemInteractionMode: 'detail-page',
     customFontSizePx: null,
     customButtonScalePercent: null,
     chatToolbarButtonSizePx: null,
@@ -56,6 +58,12 @@ function isValidButtonSize(value: unknown): value is AppSettings['appearance']['
   return value === 'compact' || value === 'default' || value === 'large'
 }
 
+function isValidRunItemInteractionMode(
+  value: unknown,
+): value is NonNullable<AppSettings['appearance']['runItemInteractionMode']> {
+  return value === 'detail-page' || value === 'inline-expand'
+}
+
 function parseStoredNumber(value: string | null): number | null {
   if (value === null || value.trim() === '') return null
   const parsed = Number(value)
@@ -73,6 +81,10 @@ function writeSettingsToStorage(nextSettings: AppSettings) {
   localStorage.setItem(STORAGE_KEY_APPEARANCE_THEME, nextSettings.appearance.theme)
   localStorage.setItem(STORAGE_KEY_APPEARANCE_FONT_SIZE, nextSettings.appearance.fontSize)
   localStorage.setItem(STORAGE_KEY_APPEARANCE_BUTTON_SIZE, nextSettings.appearance.buttonSize)
+  localStorage.setItem(
+    STORAGE_KEY_APPEARANCE_RUN_ITEM_INTERACTION,
+    nextSettings.appearance.runItemInteractionMode || defaultAppSettings.appearance.runItemInteractionMode || 'detail-page'
+  )
 
   const customFontSizePx = sanitizePositiveNumber(nextSettings.appearance.customFontSizePx)
   if (customFontSizePx === null) {
@@ -115,6 +127,7 @@ function readStoredSettings(): AppSettings {
     const themeFromBlob = parsed?.appearance?.theme
     const fontSizeFromBlob = parsed?.appearance?.fontSize
     const buttonSizeFromBlob = parsed?.appearance?.buttonSize
+    const runItemInteractionModeFromBlob = parsed?.appearance?.runItemInteractionMode
     const customFontSizePxFromBlob = sanitizePositiveNumber(parsed?.appearance?.customFontSizePx)
     const customButtonScalePercentFromBlob = sanitizePositiveNumber(parsed?.appearance?.customButtonScalePercent)
     const chatToolbarButtonSizePxFromBlob = sanitizePositiveNumber(parsed?.appearance?.chatToolbarButtonSizePx)
@@ -122,6 +135,7 @@ function readStoredSettings(): AppSettings {
     const storedTheme = localStorage.getItem(STORAGE_KEY_APPEARANCE_THEME)
     const storedFontSize = localStorage.getItem(STORAGE_KEY_APPEARANCE_FONT_SIZE)
     const storedButtonSize = localStorage.getItem(STORAGE_KEY_APPEARANCE_BUTTON_SIZE)
+    const storedRunItemInteractionMode = localStorage.getItem(STORAGE_KEY_APPEARANCE_RUN_ITEM_INTERACTION)
     const storedCustomFontSizePx = parseStoredNumber(localStorage.getItem(STORAGE_KEY_APPEARANCE_CUSTOM_FONT_SIZE_PX))
     const storedCustomButtonScalePercent = parseStoredNumber(localStorage.getItem(STORAGE_KEY_APPEARANCE_CUSTOM_BUTTON_SCALE_PERCENT))
     const storedChatToolbarButtonSizePx = parseStoredNumber(localStorage.getItem(STORAGE_KEY_APPEARANCE_CHAT_TOOLBAR_BUTTON_SIZE_PX))
@@ -138,11 +152,18 @@ function readStoredSettings(): AppSettings {
       ? storedButtonSize
       : (isValidButtonSize(buttonSizeFromBlob) ? buttonSizeFromBlob : defaultAppSettings.appearance.buttonSize)
 
+    const resolvedRunItemInteractionMode = isValidRunItemInteractionMode(storedRunItemInteractionMode)
+      ? storedRunItemInteractionMode
+      : (isValidRunItemInteractionMode(runItemInteractionModeFromBlob)
+        ? runItemInteractionModeFromBlob
+        : defaultAppSettings.appearance.runItemInteractionMode)
+
     return {
       appearance: {
         theme: resolvedTheme,
         fontSize: resolvedFontSize,
         buttonSize: resolvedButtonSize,
+        runItemInteractionMode: resolvedRunItemInteractionMode,
         customFontSizePx: sanitizePositiveNumber(storedCustomFontSizePx) ?? customFontSizePxFromBlob ?? defaultAppSettings.appearance.customFontSizePx,
         customButtonScalePercent: sanitizePositiveNumber(storedCustomButtonScalePercent) ?? customButtonScalePercentFromBlob ?? defaultAppSettings.appearance.customButtonScalePercent,
         chatToolbarButtonSizePx: sanitizePositiveNumber(storedChatToolbarButtonSizePx) ?? chatToolbarButtonSizePxFromBlob ?? defaultAppSettings.appearance.chatToolbarButtonSizePx,

--- a/lib/sweep-mappers.ts
+++ b/lib/sweep-mappers.ts
@@ -1,0 +1,190 @@
+import type {
+  CreateSweepRequest,
+  Sweep as ApiSweep,
+  UpdateSweepRequest,
+} from '@/lib/api-client'
+import type {
+  Sweep as UiSweep,
+  SweepConfig,
+  SweepHyperparameter,
+  SweepStatus,
+} from '@/lib/types'
+
+const MAX_RANGE_VALUES_PER_PARAM = 128
+
+function toChoiceValues(values: unknown[]): Array<string | number> {
+  return values.filter((value): value is string | number => (
+    typeof value === 'string' || typeof value === 'number'
+  ))
+}
+
+function toDate(value: unknown, fallback: Date): Date {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value)
+    if (!Number.isNaN(parsed.getTime())) return parsed
+  }
+  return fallback
+}
+
+function buildFallbackConfig(sweep: ApiSweep, createdAt: Date): SweepConfig {
+  return {
+    id: sweep.id,
+    name: sweep.name || sweep.id,
+    description: sweep.goal || '',
+    goal: sweep.goal || '',
+    command: sweep.base_command || '',
+    hyperparameters: Object.entries(sweep.parameters || {}).map(([name, values]) => ({
+      name,
+      type: 'choice',
+      values: Array.isArray(values) ? toChoiceValues(values) : [],
+    })),
+    metrics: [],
+    insights: [],
+    maxRuns: sweep.max_runs ?? sweep.progress.total,
+    parallelRuns: Math.max(1, (sweep.progress.running || 0) + (sweep.progress.launching || 0) || 1),
+    earlyStoppingEnabled: false,
+    earlyStoppingPatience: 3,
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+function hydrateConfigFromApi(sweep: ApiSweep, createdAt: Date): SweepConfig {
+  const fallback = buildFallbackConfig(sweep, createdAt)
+  const rawConfig = sweep.ui_config
+  if (!rawConfig || typeof rawConfig !== 'object') {
+    return fallback
+  }
+
+  const uiConfig = rawConfig as Partial<SweepConfig>
+  return {
+    ...fallback,
+    ...uiConfig,
+    id: typeof uiConfig.id === 'string' ? uiConfig.id : fallback.id,
+    name: typeof uiConfig.name === 'string' ? uiConfig.name : fallback.name,
+    description: typeof uiConfig.description === 'string' ? uiConfig.description : fallback.description,
+    goal: typeof uiConfig.goal === 'string' ? uiConfig.goal : fallback.goal,
+    command: typeof uiConfig.command === 'string' ? uiConfig.command : fallback.command,
+    hyperparameters: Array.isArray(uiConfig.hyperparameters)
+      ? (uiConfig.hyperparameters as SweepHyperparameter[])
+      : fallback.hyperparameters,
+    metrics: Array.isArray(uiConfig.metrics) ? uiConfig.metrics : fallback.metrics,
+    insights: Array.isArray(uiConfig.insights) ? uiConfig.insights : fallback.insights,
+    createdAt: toDate(uiConfig.createdAt, fallback.createdAt),
+    updatedAt: toDate(uiConfig.updatedAt, fallback.updatedAt),
+  }
+}
+
+function expandRangeValues(param: SweepHyperparameter): Array<string | number> {
+  if (param.min === undefined || param.max === undefined) return []
+  if (param.max < param.min) return []
+
+  const step = typeof param.step === 'number' && param.step > 0 ? param.step : 1
+  const values: Array<string | number> = []
+  let current = param.min
+  let guard = 0
+
+  while (current <= param.max + Number.EPSILON && guard < MAX_RANGE_VALUES_PER_PARAM) {
+    const rounded = Number.isInteger(current) ? current : Number(current.toFixed(12))
+    values.push(rounded)
+    current += step
+    guard += 1
+  }
+
+  return values
+}
+
+function hyperparametersToParameterGrid(hyperparameters: SweepHyperparameter[]): Record<string, unknown[]> {
+  const parameters: Record<string, unknown[]> = {}
+
+  hyperparameters.forEach((param) => {
+    const name = param.name?.trim()
+    if (!name) return
+
+    if (param.type === 'choice') {
+      const values = toChoiceValues(param.values || [])
+      if (values.length > 0) parameters[name] = values
+      return
+    }
+
+    if (param.type === 'fixed') {
+      if (param.fixedValue !== undefined) parameters[name] = [param.fixedValue]
+      return
+    }
+
+    if (param.type === 'range') {
+      const values = expandRangeValues(param)
+      if (values.length > 0) parameters[name] = values
+    }
+  })
+
+  return parameters
+}
+
+function serializeConfig(config: SweepConfig): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(config)) as Record<string, unknown>
+}
+
+export function mapApiSweepStatusToUi(status: ApiSweep['status']): SweepStatus {
+  if (status === 'ready' || status === 'pending') return 'pending'
+  if (status === 'draft') return 'draft'
+  if (status === 'running') return 'running'
+  if (status === 'completed') return 'completed'
+  if (status === 'failed') return 'failed'
+  if (status === 'canceled') return 'canceled'
+  return 'pending'
+}
+
+export function mapApiSweepToUiSweep(sweep: ApiSweep): UiSweep {
+  const createdAt = new Date(sweep.created_at * 1000)
+  return {
+    id: sweep.id,
+    config: hydrateConfigFromApi(sweep, createdAt),
+    status: mapApiSweepStatusToUi(sweep.status),
+    runIds: sweep.run_ids,
+    createdAt,
+    startedAt: sweep.started_at
+      ? new Date(sweep.started_at * 1000)
+      : (sweep.status === 'running' ? createdAt : undefined),
+    completedAt: sweep.completed_at ? new Date(sweep.completed_at * 1000) : undefined,
+    progress: {
+      completed: sweep.progress.completed,
+      total: sweep.progress.total,
+      failed: sweep.progress.failed,
+      running: (sweep.progress.running || 0) + (sweep.progress.launching || 0),
+    },
+  }
+}
+
+export function sweepConfigToCreateRequest(
+  config: SweepConfig,
+  status: CreateSweepRequest['status'],
+): CreateSweepRequest {
+  return {
+    name: config.name || `sweep-${Date.now()}`,
+    base_command: config.command || '',
+    parameters: hyperparametersToParameterGrid(config.hyperparameters),
+    max_runs: config.maxRuns || 10,
+    auto_start: false,
+    goal: config.goal,
+    status,
+    ui_config: serializeConfig(config),
+  }
+}
+
+export function sweepConfigToUpdateRequest(
+  config: SweepConfig,
+  status?: UpdateSweepRequest['status'],
+): UpdateSweepRequest {
+  const request: UpdateSweepRequest = {
+    name: config.name || `sweep-${Date.now()}`,
+    base_command: config.command || '',
+    parameters: hyperparametersToParameterGrid(config.hyperparameters),
+    max_runs: config.maxRuns || 10,
+    goal: config.goal,
+    ui_config: serializeConfig(config),
+  }
+  if (status) request.status = status
+  return request
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,6 +32,11 @@ export interface ExperimentRun {
   alias?: string;
   status: RunStatus;
   progress: number;
+  createdAt?: Date;
+  queuedAt?: Date;
+  launchedAt?: Date;
+  startedAt?: Date;
+  stoppedAt?: Date;
   startTime: Date;
   endTime?: Date;
   command: string;
@@ -74,6 +79,7 @@ export interface AppSettings {
     theme: "dark" | "light" | "system";
     fontSize: "small" | "medium" | "large";
     buttonSize: "compact" | "default" | "large";
+    runItemInteractionMode?: "detail-page" | "inline-expand";
     customFontSizePx?: number | null;
     customButtonScalePercent?: number | null;
     chatToolbarButtonSizePx?: number | null;


### PR DESCRIPTION
### summary
- Made runs and sweeps first-class with detail-page and inline-expand interaction modes.
- Added backend-persisted sweep/run lifecycle improvements (draft sweeps, status/state sync, archive fixes).
- Added cluster management (detect/manual set) with backend state + Runs page cluster status UI + onboarding card.
- Rebuilt Charts page to use run-detail style sections, real run-history data across visible runs, and responsive/tunable layout settings.

### description
#### runs + sweeps UX/state
- Sweeps are now clickable like runs and can open sweep detail.
- Added appearance setting to switch run/sweep click behavior:
  - detail page mode
  - inline expand/collapse mode
- Draft sweeps now persist and are visible in sweeps list.
- Improved sweep status representation and server-side recomputation logic.
- Added run card/detail action improvements:
  - start/stop/check-alert actions
  - start time, created time, running duration
- Fixed run archive/unarchive behavior and ensured backend state reflects UI changes.
- Added safer sweep/run association logic for active/running states.

#### cluster management
- Added server cluster state model and persistence.
- Added endpoints:
  - `GET /cluster`
  - `POST /cluster/detect`
  - `POST /cluster`
- Supports cluster types:
  - slurm
  - local_gpu
  - kubernetes
  - ray
  - shared_head_node
- Added Runs page “Cluster Status” section with:
  - current type/status/source
  - node/GPU/head-node summary
  - auto-detect + manual type selection
- Added starter onboarding card to help users identify cluster setup.

#### runs page structure/navigation
- Made runs subsections collapsible.
- Added `>` action in Charts header to navigate to Charts detail page.

#### charts page overhaul
- Reworked charts page to follow run-detail chart style/sectioning.
- Replaced fake/random chart generation for standard metrics with data derived from real `run.lossHistory` across visible runs.
- Added responsive chart layout:
  - mobile: single chart per row
  - desktop: multi-column after threshold
- Added tunable chart layout settings:
  - fixed-grid vs flex
  - charts per row
  - multi-column threshold
  - min/max chart width
  - chart height
  - axis settings
- Added favorites/overview behavior so overview-starred charts appear in overview panel.
- Kept run visibility controls integrated.

### limitation
- Some standard metrics still depend on available `lossHistory` fields; metrics without source signals show empty-state messaging.
- Lint command cannot run in this environment because `eslint` is missing.

### validation
- `npx tsc --noEmit` passed
- `npm run build` passed
- `python -m py_compile server/server.py` passed