### PR TITLE
Add explorer tab to research chat

### DIFF
--- a/app/api/file-explorer/_utils.ts
+++ b/app/api/file-explorer/_utils.ts
@@ -1,0 +1,51 @@
+import path from 'node:path'
+
+const WORKSPACE_ROOT = path.resolve(process.cwd())
+
+export interface ExplorerTreeEntry {
+  name: string
+  path: string
+  type: 'file' | 'directory'
+  hidden: boolean
+}
+
+export function normalizeExplorerPath(rawPath: string | null): string {
+  const value = (rawPath ?? '').trim().replace(/\\/g, '/')
+
+  if (!value || value === '.' || value === '/') {
+    return ''
+  }
+
+  const withoutLeadingSlash = value.replace(/^\/+/, '')
+  const normalized = path.posix.normalize(withoutLeadingSlash)
+
+  if (
+    !normalized ||
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    normalized.includes('/../')
+  ) {
+    throw new Error('Invalid path')
+  }
+
+  return normalized
+}
+
+export function resolveExplorerPath(relativePath: string): string {
+  const absolutePath = path.resolve(WORKSPACE_ROOT, relativePath)
+
+  if (
+    absolutePath !== WORKSPACE_ROOT &&
+    !absolutePath.startsWith(`${WORKSPACE_ROOT}${path.sep}`)
+  ) {
+    throw new Error('Path is outside workspace')
+  }
+
+  return absolutePath
+}
+
+export function joinExplorerPath(parentPath: string, childName: string): string {
+  return parentPath ? `${parentPath}/${childName}` : childName
+}
+

--- a/app/api/file-explorer/file/route.ts
+++ b/app/api/file-explorer/file/route.ts
@@ -1,0 +1,91 @@
+import { open, stat } from 'node:fs/promises'
+import { NextRequest, NextResponse } from 'next/server'
+import { normalizeExplorerPath, resolveExplorerPath } from '../_utils'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const MAX_PREVIEW_BYTES = 200_000
+const BINARY_DETECTION_BYTES = 12_000
+
+function looksBinary(buffer: Buffer): boolean {
+  if (buffer.length === 0) {
+    return false
+  }
+
+  if (buffer.includes(0)) {
+    return true
+  }
+
+  const text = buffer.toString('utf8')
+  if (!text) {
+    return false
+  }
+
+  let replacementCharacters = 0
+  for (const char of text) {
+    if (char === '\uFFFD') {
+      replacementCharacters += 1
+    }
+  }
+
+  return replacementCharacters > Math.max(2, Math.floor(text.length * 0.02))
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error == null || !('code' in error)) {
+    return undefined
+  }
+
+  const value = (error as { code?: unknown }).code
+  return typeof value === 'string' ? value : undefined
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const relativePath = normalizeExplorerPath(request.nextUrl.searchParams.get('path'))
+    if (!relativePath) {
+      return NextResponse.json({ error: 'A file path is required' }, { status: 400 })
+    }
+
+    const absolutePath = resolveExplorerPath(relativePath)
+    const fileStat = await stat(absolutePath)
+
+    if (!fileStat.isFile()) {
+      return NextResponse.json({ error: 'Path is not a file' }, { status: 400 })
+    }
+
+    const bytesToRead = Math.min(fileStat.size, MAX_PREVIEW_BYTES)
+    const handle = await open(absolutePath, 'r')
+
+    try {
+      const previewBuffer = Buffer.alloc(bytesToRead)
+      if (bytesToRead > 0) {
+        await handle.read(previewBuffer, 0, bytesToRead, 0)
+      }
+
+      const binarySample = previewBuffer.subarray(0, Math.min(previewBuffer.length, BINARY_DETECTION_BYTES))
+      const binary = looksBinary(binarySample)
+
+      return NextResponse.json({
+        path: relativePath,
+        content: binary ? null : previewBuffer.toString('utf8'),
+        binary,
+        truncated: fileStat.size > MAX_PREVIEW_BYTES,
+        size: fileStat.size,
+      })
+    } finally {
+      await handle.close()
+    }
+  } catch (error) {
+    const code = getErrorCode(error)
+    if (code === 'ENOENT') {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 })
+    }
+
+    const message = error instanceof Error ? error.message : 'Failed to load file'
+    const status = message === 'Invalid path' || message === 'Path is outside workspace' ? 400 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+

--- a/app/api/file-explorer/tree/route.ts
+++ b/app/api/file-explorer/tree/route.ts
@@ -1,0 +1,51 @@
+import { readdir } from 'node:fs/promises'
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  joinExplorerPath,
+  normalizeExplorerPath,
+  resolveExplorerPath,
+  type ExplorerTreeEntry,
+} from '../_utils'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const nameCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: 'base',
+})
+
+function sortTreeEntries(a: ExplorerTreeEntry, b: ExplorerTreeEntry): number {
+  if (a.type !== b.type) {
+    return a.type === 'directory' ? -1 : 1
+  }
+
+  return nameCollator.compare(a.name, b.name)
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const relativePath = normalizeExplorerPath(request.nextUrl.searchParams.get('path'))
+    const absolutePath = resolveExplorerPath(relativePath)
+    const dirEntries = await readdir(absolutePath, { withFileTypes: true })
+
+    const entries: ExplorerTreeEntry[] = dirEntries
+      .filter((entry) => entry.name !== '.' && entry.name !== '..')
+      .map((entry): ExplorerTreeEntry => ({
+        name: entry.name,
+        path: joinExplorerPath(relativePath, entry.name),
+        type: entry.isDirectory() ? 'directory' : 'file',
+        hidden: entry.name.startsWith('.'),
+      }))
+      .sort(sortTreeEntries)
+
+    return NextResponse.json({
+      path: relativePath,
+      entries,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load directory'
+    const status = message === 'Invalid path' || message === 'Path is outside workspace' ? 400 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { InsightsView } from '@/components/insights-view'
 import { EventsView } from '@/components/events-view'
 import { JourneyView } from '@/components/journey-view'
 import { ReportView, type ReportToolbarState } from '@/components/report-view'
+import { FileExplorerView } from '@/components/file-explorer-view'
 import { SettingsPageContent } from '@/components/settings-page-content'
 import { DesktopSidebar } from '@/components/desktop-sidebar'
 import { useRuns } from '@/hooks/use-runs'
@@ -698,6 +699,9 @@ export default function ResearchChat() {
             )}
             {activeTab === 'report' && (
               <ReportView runs={runs} onToolbarChange={setReportToolbar} />
+            )}
+            {activeTab === 'explorer' && (
+              <FileExplorerView />
             )}
             {activeTab === 'journey' && (
               <JourneyView

--- a/components/file-explorer-view.tsx
+++ b/components/file-explorer-view.tsx
@@ -1,0 +1,484 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import {
+  AlertCircle,
+  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  FileCode2,
+  Folder,
+  FolderOpen,
+  Loader2,
+  RefreshCcw,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { cn } from '@/lib/utils'
+
+type ExplorerNodeType = 'file' | 'directory'
+
+interface ExplorerNode {
+  name: string
+  path: string
+  type: ExplorerNodeType
+  hidden: boolean
+}
+
+interface ExplorerTreeResponse {
+  path: string
+  entries: ExplorerNode[]
+}
+
+interface ExplorerFileResponse {
+  path: string
+  content: string | null
+  binary: boolean
+  truncated: boolean
+  size: number
+}
+
+type PreviewState = 'idle' | 'loading' | 'ready' | 'error'
+
+async function parseErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await response.json()) as { error?: unknown }
+    if (typeof payload.error === 'string' && payload.error.trim()) {
+      return payload.error
+    }
+  } catch {
+    // Ignore parse errors and use fallback.
+  }
+
+  return fallback
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) return `${value} B`
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function getFileName(path: string | null): string {
+  if (!path) return 'No file selected'
+  const parts = path.split('/')
+  return parts[parts.length - 1] || path
+}
+
+export function FileExplorerView() {
+  const [treeByPath, setTreeByPath] = useState<Record<string, ExplorerNode[]>>({})
+  const treeByPathRef = useRef<Record<string, ExplorerNode[]>>({})
+  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(() => new Set())
+  const [loadingDirs, setLoadingDirs] = useState<Set<string>>(() => new Set())
+  const [treeError, setTreeError] = useState<string | null>(null)
+
+  const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null)
+  const [filePreview, setFilePreview] = useState<ExplorerFileResponse | null>(null)
+  const [previewState, setPreviewState] = useState<PreviewState>('idle')
+  const [fileError, setFileError] = useState<string | null>(null)
+  const [mobileMode, setMobileMode] = useState<'tree' | 'preview'>('tree')
+
+  useEffect(() => {
+    treeByPathRef.current = treeByPath
+  }, [treeByPath])
+
+  const loadDirectory = useCallback(async (directoryPath: string, force = false) => {
+    if (!force && Object.prototype.hasOwnProperty.call(treeByPathRef.current, directoryPath)) {
+      return
+    }
+
+    setLoadingDirs((prev) => {
+      const next = new Set(prev)
+      next.add(directoryPath)
+      return next
+    })
+    if (directoryPath === '') {
+      setTreeError(null)
+    }
+
+    try {
+      const response = await fetch(`/api/file-explorer/tree?path=${encodeURIComponent(directoryPath)}`, {
+        cache: 'no-store',
+      })
+
+      if (!response.ok) {
+        const message = await parseErrorMessage(response, 'Failed to load file tree')
+        throw new Error(message)
+      }
+
+      const payload = (await response.json()) as ExplorerTreeResponse
+      setTreeByPath((prev) => ({
+        ...prev,
+        [directoryPath]: payload.entries,
+      }))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load file tree'
+      if (directoryPath === '') {
+        setTreeError(message)
+      }
+    } finally {
+      setLoadingDirs((prev) => {
+        const next = new Set(prev)
+        next.delete(directoryPath)
+        return next
+      })
+    }
+  }, [])
+
+  const loadFile = useCallback(async (filePath: string, force = false) => {
+    const sameFile = filePreview?.path === filePath && previewState === 'ready'
+    setSelectedFilePath(filePath)
+    if (!force && sameFile) {
+      return
+    }
+
+    setPreviewState('loading')
+    setFileError(null)
+
+    try {
+      const response = await fetch(`/api/file-explorer/file?path=${encodeURIComponent(filePath)}`, {
+        cache: 'no-store',
+      })
+
+      if (!response.ok) {
+        const message = await parseErrorMessage(response, 'Failed to load file')
+        throw new Error(message)
+      }
+
+      const payload = (await response.json()) as ExplorerFileResponse
+      setFilePreview(payload)
+      setPreviewState('ready')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load file'
+      setPreviewState('error')
+      setFileError(message)
+    }
+  }, [filePreview?.path, previewState])
+
+  useEffect(() => {
+    void loadDirectory('', true)
+  }, [loadDirectory])
+
+  const handleDirectoryToggle = useCallback((directoryPath: string) => {
+    setExpandedDirs((prev) => {
+      const next = new Set(prev)
+      if (next.has(directoryPath)) {
+        next.delete(directoryPath)
+      } else {
+        next.add(directoryPath)
+      }
+      return next
+    })
+
+    if (!Object.prototype.hasOwnProperty.call(treeByPathRef.current, directoryPath)) {
+      void loadDirectory(directoryPath)
+    }
+  }, [loadDirectory])
+
+  const handleSelectFile = useCallback((filePath: string) => {
+    setMobileMode('preview')
+    void loadFile(filePath)
+  }, [loadFile])
+
+  const handleRefresh = useCallback(() => {
+    setTreeByPath({})
+    treeByPathRef.current = {}
+    setExpandedDirs(new Set())
+    setTreeError(null)
+    void loadDirectory('', true)
+
+    if (selectedFilePath) {
+      void loadFile(selectedFilePath, true)
+    }
+  }, [loadDirectory, loadFile, selectedFilePath])
+
+  const previewLines = useMemo(() => {
+    if (!filePreview?.content) {
+      return []
+    }
+    return filePreview.content.split('\n')
+  }, [filePreview?.content])
+
+  const renderTreeNodes = useCallback((parentPath: string, depth: number): ReactNode => {
+    const entries = treeByPath[parentPath] || []
+    if (entries.length === 0) {
+      return null
+    }
+
+    return entries.map((entry) => {
+      const leftPadding = 10 + depth * 14
+      const isSelected = selectedFilePath === entry.path
+
+      if (entry.type === 'directory') {
+        const isExpanded = expandedDirs.has(entry.path)
+        const isLoading = loadingDirs.has(entry.path)
+        const childEntries = treeByPath[entry.path] || []
+
+        return (
+          <div key={entry.path}>
+            <button
+              type="button"
+              onClick={() => handleDirectoryToggle(entry.path)}
+              className="w-full text-left"
+            >
+              <div
+                className={cn(
+                  'flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-secondary/70',
+                  isExpanded && 'bg-secondary/40'
+                )}
+                style={{ paddingLeft: `${leftPadding}px` }}
+              >
+                {isExpanded ? (
+                  <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                )}
+                {isExpanded ? (
+                  <FolderOpen className="h-4 w-4 shrink-0 text-primary" />
+                ) : (
+                  <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
+                <span className={cn('truncate', entry.hidden && 'text-muted-foreground')}>
+                  {entry.name}
+                </span>
+              </div>
+            </button>
+
+            {isExpanded && isLoading && (
+              <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground" style={{ paddingLeft: `${leftPadding + 18}px` }}>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Loading...
+              </div>
+            )}
+
+            {isExpanded && !isLoading && childEntries.length === 0 && (
+              <div className="px-2 py-1.5 text-xs text-muted-foreground" style={{ paddingLeft: `${leftPadding + 18}px` }}>
+                Empty folder
+              </div>
+            )}
+
+            {isExpanded && !isLoading && renderTreeNodes(entry.path, depth + 1)}
+          </div>
+        )
+      }
+
+      return (
+        <button
+          key={entry.path}
+          type="button"
+          onClick={() => handleSelectFile(entry.path)}
+          className="w-full text-left"
+        >
+          <div
+            className={cn(
+              'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-secondary/70',
+              isSelected && 'bg-secondary text-foreground'
+            )}
+            style={{ paddingLeft: `${leftPadding + 16}px` }}
+          >
+            <FileCode2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className={cn('truncate', entry.hidden && 'text-muted-foreground')}>
+              {entry.name}
+            </span>
+          </div>
+        </button>
+      )
+    })
+  }, [expandedDirs, handleDirectoryToggle, handleSelectFile, loadingDirs, selectedFilePath, treeByPath])
+
+  const selectedFileName = getFileName(selectedFilePath)
+  const rootLoading = loadingDirs.has('')
+  const rootEntries = treeByPath[''] || []
+
+  const treePane = (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center justify-between border-b border-border/70 px-3 py-2.5">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-foreground">File Explorer</p>
+          <p className="text-[11px] text-muted-foreground">Hidden files included</p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={handleRefresh}
+          title="Refresh file tree"
+        >
+          <RefreshCcw className={cn('h-3.5 w-3.5', rootLoading && 'animate-spin')} />
+          <span className="sr-only">Refresh file tree</span>
+        </Button>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1 px-2 py-2">
+        {treeError ? (
+          <div className="mx-1 flex flex-col gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
+            <div className="flex items-start gap-2">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>{treeError}</p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void loadDirectory('', true)}
+              className="h-7 w-fit"
+            >
+              Retry
+            </Button>
+          </div>
+        ) : null}
+
+        {!treeError && rootLoading && rootEntries.length === 0 && (
+          <div className="mx-1 flex items-center gap-2 rounded-md border border-border/70 bg-card/70 px-3 py-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading workspace files...
+          </div>
+        )}
+
+        {!treeError && !rootLoading && rootEntries.length === 0 && (
+          <div className="mx-1 rounded-md border border-dashed border-border/80 bg-card/60 px-3 py-4 text-sm text-muted-foreground">
+            No files found.
+          </div>
+        )}
+
+        {!treeError && rootEntries.length > 0 && (
+          <div className="space-y-0.5">
+            {renderTreeNodes('', 0)}
+          </div>
+        )}
+      </ScrollArea>
+    </div>
+  )
+
+  const previewBody = (
+    <ScrollArea className="min-h-0 flex-1 bg-card/20">
+      {!selectedFilePath && (
+        <div className="flex h-full min-h-[240px] flex-col items-center justify-center px-6 text-center">
+          <FileCode2 className="mb-3 h-8 w-8 text-muted-foreground/70" />
+          <p className="text-sm text-foreground">Select a file to preview it.</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Browse folders on the left and pick any file.
+          </p>
+        </div>
+      )}
+
+      {selectedFilePath && previewState === 'loading' && (
+        <div className="flex h-full min-h-[240px] items-center justify-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading preview...
+        </div>
+      )}
+
+      {selectedFilePath && previewState === 'error' && (
+        <div className="mx-4 my-4 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          <div className="mb-2 flex items-start gap-2">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>{fileError || 'Unable to load file preview.'}</p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              if (selectedFilePath) {
+                void loadFile(selectedFilePath, true)
+              }
+            }}
+          >
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {selectedFilePath && previewState === 'ready' && filePreview?.binary && (
+        <div className="mx-4 my-4 rounded-md border border-border/70 bg-card/70 p-4 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">Binary file preview is unavailable.</p>
+          <p className="mt-1">This file appears to contain non-text data.</p>
+        </div>
+      )}
+
+      {selectedFilePath && previewState === 'ready' && !filePreview?.binary && (
+        <div className="min-w-full overflow-x-auto">
+          <div className="min-w-full text-[12px] leading-5">
+            {previewLines.map((line, index) => (
+              <div key={`${selectedFilePath}:${index + 1}`} className="grid grid-cols-[auto_minmax(0,1fr)] border-b border-border/40">
+                <span className="select-none border-r border-border/50 bg-background/70 px-3 py-0.5 text-right text-[10px] text-muted-foreground">
+                  {index + 1}
+                </span>
+                <code className="block whitespace-pre px-3 py-0.5 font-mono text-foreground">
+                  {line || ' '}
+                </code>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </ScrollArea>
+  )
+
+  const previewHeader = (mobile: boolean) => (
+    <div className="flex items-center gap-2 border-b border-border/70 px-3 py-2.5">
+      {mobile && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2"
+          onClick={() => setMobileMode('tree')}
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Files
+        </Button>
+      )}
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-foreground">{selectedFileName}</p>
+        <p className="truncate text-[11px] text-muted-foreground">{selectedFilePath || 'Choose a file from the tree'}</p>
+      </div>
+
+      {filePreview?.size != null && (
+        <Badge variant="outline" className="h-6 rounded-full px-2 text-[10px]">
+          {formatBytes(filePreview.size)}
+        </Badge>
+      )}
+
+      {filePreview?.truncated && (
+        <Badge variant="secondary" className="h-6 rounded-full px-2 text-[10px]">
+          Truncated
+        </Badge>
+      )}
+    </div>
+  )
+
+  return (
+    <div className="mx-auto h-full w-full max-w-6xl overflow-hidden">
+      <div className="hidden h-full min-h-0 md:flex">
+        <aside className="h-full w-[340px] shrink-0 border-r border-border/70 bg-card/15">
+          {treePane}
+        </aside>
+        <section className="min-w-0 flex-1">
+          <div className="flex h-full min-h-0 flex-col">
+            {previewHeader(false)}
+            {previewBody}
+          </div>
+        </section>
+      </div>
+
+      <div className="flex h-full min-h-0 md:hidden">
+        {mobileMode === 'tree' ? (
+          <section className="min-w-0 flex-1">
+            {treePane}
+          </section>
+        ) : (
+          <section className="min-w-0 flex-1">
+            <div className="flex h-full min-h-0 flex-col">
+              {previewHeader(true)}
+              {previewBody}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/floating-nav.tsx
+++ b/components/floating-nav.tsx
@@ -15,9 +15,10 @@ import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { useApiConfig } from '@/lib/api-config'
 import type { ReportCellType } from './report-view'
+import type { HomeTab } from '@/lib/navigation'
 
 interface FloatingNavProps {
-  activeTab: 'chat' | 'runs' | 'charts' | 'memory' | 'events' | 'journey' | 'report' | 'settings'
+  activeTab: HomeTab
   onMenuClick: () => void
   showDesktopSidebarToggle?: boolean
   onDesktopSidebarToggle?: () => void

--- a/components/navigation/nav-items.ts
+++ b/components/navigation/nav-items.ts
@@ -2,6 +2,7 @@ import {
   BarChart3,
   Bell,
   FileText,
+  FolderTree,
   FlaskConical,
   Lightbulb,
   MessageSquare,
@@ -48,6 +49,11 @@ export const PRIMARY_NAV_ITEMS: PrimaryNavItem[] = [
     tab: 'report',
     label: 'Report',
     icon: FileText,
+  },
+  {
+    tab: 'explorer',
+    label: 'Explorer',
+    icon: FolderTree,
   },
   {
     tab: 'contextual',

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -8,6 +8,7 @@ export type HomeTab =
   | 'events'
   | 'journey'
   | 'report'
+  | 'explorer'
   | 'settings'
 
 export type AppTab = HomeTab | 'contextual'
@@ -23,6 +24,7 @@ const HOME_TABS: readonly HomeTab[] = [
   'events',
   'journey',
   'report',
+  'explorer',
   'settings',
 ]
 


### PR DESCRIPTION
Summary
- add explorer entry point, navigation tab, and floating nav typing
- implement tree/file APIs and client explorer view with desktop/mobile layouts
- wire explorer tab into home page and expose file tree preview UI

Testing
<img width="1562" height="959" alt="image" src="https://github.com/user-attachments/assets/850ba164-aac5-4d3b-9ad4-8b1f27fb1834" />
