### PR TITLE
Add contextual git explorer modal for diffs and files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ An AI-powered research assistant for ML experiment tracking. Provides a mobile-f
 
 ### 1. YOLO install
 
+Don't do YOLO install if you are a developer since you will get staled code. Go to manual setup below if you are a developer.
+
 ```bash
 curl -fL "https://drive.google.com/uc?export=download&id=1mjKPk8lYI8YCdwYbdIrgLGDb_PWNIwGS" | bash
 ```

--- a/app/contextual/page.tsx
+++ b/app/contextual/page.tsx
@@ -7,6 +7,7 @@ import {
   Bell,
   Clock3,
   Cpu,
+  FileText,
   LayoutGrid,
   Menu,
   PanelLeftClose,
@@ -19,6 +20,7 @@ import {
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -32,6 +34,7 @@ import { NavPage } from '@/components/nav-page'
 import { ConnectedChatView, useChatSession } from '@/components/connected-chat-view'
 import { ContextualOperationsPanel } from '@/components/contextual-operations-panel'
 import { ContextualContextCanvas } from '@/components/contextual-context-canvas'
+import { ContextualDiffExplorer } from '@/components/contextual-diff-explorer'
 import { useRuns } from '@/hooks/use-runs'
 import { useAlerts } from '@/hooks/use-alerts'
 import { listSweeps, type Sweep as ApiSweep } from '@/lib/api-client'
@@ -62,6 +65,7 @@ export default function ContextualChatPage() {
   const [collapseArtifactsInChat, setCollapseArtifactsInChat] = useState(false)
   const [showOpsPanel, setShowOpsPanel] = useState(true)
   const [showContextPanel, setShowContextPanel] = useState(true)
+  const [diffExplorerOpen, setDiffExplorerOpen] = useState(false)
   const [chatDraftInsert, setChatDraftInsert] = useState<{ id: number; text: string } | null>(null)
 
   const fetchSweeps = useCallback(async () => {
@@ -214,6 +218,15 @@ export default function ContextualChatPage() {
               </div>
 
               <div className="flex items-center gap-1">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-1.5 px-2 text-xs"
+                  onClick={() => setDiffExplorerOpen(true)}
+                >
+                  <FileText className="h-3.5 w-3.5" />
+                  Git Explorer
+                </Button>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button
@@ -472,7 +485,12 @@ export default function ContextualChatPage() {
                   variant="outline"
                   size="icon"
                   className="absolute right-2 top-2 z-20 h-7 w-7 bg-background/95 backdrop-blur"
-                  onClick={() => setShowContextPanel((prev) => !prev)}
+                  onClick={() =>
+                    setShowContextPanel((prev) => {
+                      const next = !prev
+                      return next
+                    })
+                  }
                   title={showContextPanel ? 'Hide context panel' : 'Show context panel'}
                 >
                   {showContextPanel ? <PanelRightClose className="h-3.5 w-3.5" /> : <PanelRightOpen className="h-3.5 w-3.5" />}
@@ -536,6 +554,16 @@ export default function ContextualChatPage() {
               await selectSession(sessionId)
             }}
           />
+
+          <Dialog open={diffExplorerOpen} onOpenChange={setDiffExplorerOpen}>
+            <DialogContent
+              className="h-[94vh] w-[96vw] max-h-none max-w-none overflow-hidden p-0 gap-0"
+              showCloseButton={false}
+            >
+              <DialogTitle className="sr-only">Git Explorer</DialogTitle>
+              <ContextualDiffExplorer onClose={() => setDiffExplorerOpen(false)} />
+            </DialogContent>
+          </Dialog>
         </section>
       </main>
     </div>

--- a/components/contextual-diff-explorer.tsx
+++ b/components/contextual-diff-explorer.tsx
@@ -1,0 +1,522 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { ChevronDown, ChevronRight, FileText, FolderTree, GitCompare, Loader2, RefreshCw, X } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { getRepoDiff, getRepoFile, getRepoFiles, type RepoDiffFile } from '@/lib/api-client'
+
+type ExplorerMode = 'diff' | 'files'
+type DiffFile = RepoDiffFile
+
+type DirectoryNode = {
+  kind: 'directory'
+  name: string
+  path: string
+  children: TreeNode[]
+}
+
+type FileNode = {
+  kind: 'file'
+  name: string
+  path: string
+  diffFile?: DiffFile
+}
+
+type TreeNode = DirectoryNode | FileNode
+
+interface ContextualDiffExplorerProps {
+  files?: DiffFile[]
+  onClose?: () => void
+}
+
+const DEFAULT_DIFF_FILES: DiffFile[] = [
+  {
+    path: 'app/contextual/page.tsx',
+    status: 'modified',
+    additions: 10,
+    deletions: 2,
+    lines: [
+      { type: 'hunk', text: '@@ -62,6 +62,7 @@', oldLine: null, newLine: null },
+      { type: 'context', text: '  const [showContextPanel, setShowContextPanel] = useState(true)', oldLine: 66, newLine: 66 },
+      { type: 'add', text: '  const [diffExplorerOpen, setDiffExplorerOpen] = useState(false)', oldLine: null, newLine: 67 },
+    ],
+  },
+  {
+    path: 'components/contextual-diff-explorer.tsx',
+    status: 'added',
+    additions: 60,
+    deletions: 0,
+    lines: [
+      { type: 'hunk', text: '@@ -0,0 +1,60 @@', oldLine: null, newLine: null },
+      { type: 'add', text: "'use client'", oldLine: null, newLine: 1 },
+      { type: 'add', text: 'export function ContextualDiffExplorer() {', oldLine: null, newLine: 12 },
+    ],
+  },
+]
+
+function statusBadgeClass(status: DiffFile['status']) {
+  if (status === 'added') return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+  if (status === 'deleted') return 'border-rose-500/40 bg-rose-500/10 text-rose-700 dark:text-rose-300'
+  return 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+}
+
+function lineRowTone(type: DiffFile['lines'][number]['type']) {
+  if (type === 'add') return 'bg-emerald-500/10'
+  if (type === 'remove') return 'bg-rose-500/10'
+  if (type === 'hunk') return 'bg-primary/10'
+  return 'bg-transparent'
+}
+
+function lineTextTone(type: DiffFile['lines'][number]['type']) {
+  if (type === 'add') return 'text-emerald-700 dark:text-emerald-300'
+  if (type === 'remove') return 'text-rose-700 dark:text-rose-300'
+  if (type === 'hunk') return 'text-primary'
+  return 'text-foreground'
+}
+
+function buildTree(paths: string[], diffByPath?: Map<string, DiffFile>): DirectoryNode {
+  const root: DirectoryNode = { kind: 'directory', name: '', path: '', children: [] }
+
+  paths.forEach((fullPath) => {
+    const parts = fullPath.split('/')
+    let current = root
+
+    parts.forEach((part, index) => {
+      const isFile = index === parts.length - 1
+      const nodePath = parts.slice(0, index + 1).join('/')
+
+      if (isFile) {
+        if (!current.children.find((child) => child.kind === 'file' && child.path === nodePath)) {
+          current.children.push({
+            kind: 'file',
+            name: part,
+            path: nodePath,
+            diffFile: diffByPath?.get(nodePath),
+          })
+        }
+        return
+      }
+
+      let directory = current.children.find(
+        (child): child is DirectoryNode => child.kind === 'directory' && child.path === nodePath
+      )
+
+      if (!directory) {
+        directory = { kind: 'directory', name: part, path: nodePath, children: [] }
+        current.children.push(directory)
+      }
+
+      current = directory
+    })
+  })
+
+  const sortTree = (node: DirectoryNode) => {
+    node.children.sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === 'directory' ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+    node.children.forEach((child) => {
+      if (child.kind === 'directory') sortTree(child)
+    })
+  }
+
+  sortTree(root)
+  return root
+}
+
+export function ContextualDiffExplorer({ files = DEFAULT_DIFF_FILES, onClose }: ContextualDiffExplorerProps) {
+  const [mode, setMode] = useState<ExplorerMode>('diff')
+  const [collapsedDirectories, setCollapsedDirectories] = useState<Record<string, boolean>>({})
+
+  const [apiDiffFiles, setApiDiffFiles] = useState<DiffFile[] | null>(null)
+  const [diffError, setDiffError] = useState(false)
+  const [diffLoading, setDiffLoading] = useState(false)
+  const [selectedDiffPath, setSelectedDiffPath] = useState(files[0]?.path ?? '')
+
+  const [repoFilePaths, setRepoFilePaths] = useState<string[]>([])
+  const [repoFilesLoading, setRepoFilesLoading] = useState(false)
+  const [repoFilesError, setRepoFilesError] = useState(false)
+  const [selectedRepoPath, setSelectedRepoPath] = useState('')
+  const [repoFileContent, setRepoFileContent] = useState('')
+  const [repoFileBinary, setRepoFileBinary] = useState(false)
+  const [repoFileTruncated, setRepoFileTruncated] = useState(false)
+  const [repoFileLoading, setRepoFileLoading] = useState(false)
+
+  const usesInternalDiffSource = files === DEFAULT_DIFF_FILES
+
+  const loadDiffFiles = useCallback(async () => {
+    if (!usesInternalDiffSource) return
+
+    setDiffLoading(true)
+    try {
+      const response = await getRepoDiff(3)
+      setApiDiffFiles(response.files)
+      setDiffError(false)
+    } catch (error) {
+      console.error('Failed to load repo diff:', error)
+      setDiffError(true)
+    } finally {
+      setDiffLoading(false)
+    }
+  }, [usesInternalDiffSource])
+
+  const loadRepoPaths = useCallback(async () => {
+    setRepoFilesLoading(true)
+    try {
+      const response = await getRepoFiles(5000)
+      setRepoFilePaths(response.files)
+      setRepoFilesError(false)
+    } catch (error) {
+      console.error('Failed to load repo files:', error)
+      setRepoFilesError(true)
+    } finally {
+      setRepoFilesLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!usesInternalDiffSource) return
+
+    let active = true
+    const load = async () => {
+      if (!active) return
+      await loadDiffFiles()
+    }
+
+    load()
+    const intervalId = window.setInterval(load, 8000)
+
+    return () => {
+      active = false
+      window.clearInterval(intervalId)
+    }
+  }, [loadDiffFiles, usesInternalDiffSource])
+
+  useEffect(() => {
+    if (mode !== 'files') return
+
+    let active = true
+    const load = async () => {
+      if (!active) return
+      await loadRepoPaths()
+    }
+
+    load()
+    const intervalId = window.setInterval(load, 20000)
+
+    return () => {
+      active = false
+      window.clearInterval(intervalId)
+    }
+  }, [loadRepoPaths, mode])
+
+  const effectiveDiffFiles = useMemo(() => {
+    if (!usesInternalDiffSource) return files
+    if (apiDiffFiles) return apiDiffFiles
+    return diffError ? DEFAULT_DIFF_FILES : []
+  }, [apiDiffFiles, diffError, files, usesInternalDiffSource])
+
+  useEffect(() => {
+    if (!effectiveDiffFiles.some((file) => file.path === selectedDiffPath)) {
+      setSelectedDiffPath(effectiveDiffFiles[0]?.path ?? '')
+    }
+  }, [effectiveDiffFiles, selectedDiffPath])
+
+  useEffect(() => {
+    if (!repoFilePaths.some((path) => path === selectedRepoPath)) {
+      setSelectedRepoPath(repoFilePaths[0] ?? '')
+    }
+  }, [repoFilePaths, selectedRepoPath])
+
+  useEffect(() => {
+    if (mode !== 'files' || !selectedRepoPath) return
+
+    let active = true
+    const loadFile = async () => {
+      setRepoFileLoading(true)
+      try {
+        const response = await getRepoFile(selectedRepoPath, 120000)
+        if (!active) return
+        setRepoFileContent(response.content)
+        setRepoFileBinary(response.binary)
+        setRepoFileTruncated(response.truncated)
+      } catch (error) {
+        if (!active) return
+        console.error('Failed to load repo file:', error)
+        setRepoFileContent('Unable to load file content.')
+        setRepoFileBinary(false)
+        setRepoFileTruncated(false)
+      } finally {
+        if (active) setRepoFileLoading(false)
+      }
+    }
+
+    loadFile()
+
+    return () => {
+      active = false
+    }
+  }, [mode, selectedRepoPath])
+
+  const selectedDiffFile = useMemo(
+    () => effectiveDiffFiles.find((file) => file.path === selectedDiffPath) ?? null,
+    [effectiveDiffFiles, selectedDiffPath]
+  )
+
+  const diffPathMap = useMemo(
+    () => new Map(effectiveDiffFiles.map((file) => [file.path, file])),
+    [effectiveDiffFiles]
+  )
+
+  const diffTree = useMemo(
+    () => buildTree(effectiveDiffFiles.map((file) => file.path), diffPathMap),
+    [effectiveDiffFiles, diffPathMap]
+  )
+
+  const fileTree = useMemo(
+    () => buildTree(repoFilePaths),
+    [repoFilePaths]
+  )
+
+  const totalAdditions = useMemo(
+    () => effectiveDiffFiles.reduce((sum, file) => sum + file.additions, 0),
+    [effectiveDiffFiles]
+  )
+
+  const totalDeletions = useMemo(
+    () => effectiveDiffFiles.reduce((sum, file) => sum + file.deletions, 0),
+    [effectiveDiffFiles]
+  )
+
+  const renderTree = (nodes: TreeNode[], depth = 0): ReactNode =>
+    nodes.map((node) => {
+      if (node.kind === 'directory') {
+        const collapsed = Boolean(collapsedDirectories[node.path])
+        return (
+          <div key={node.path}>
+            <button
+              type="button"
+              className="flex w-full items-center gap-1 rounded-md py-1 pr-2 text-left text-xs text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
+              style={{ paddingLeft: `${8 + depth * 14}px` }}
+              onClick={() =>
+                setCollapsedDirectories((prev) => ({
+                  ...prev,
+                  [node.path]: !prev[node.path],
+                }))
+              }
+            >
+              {collapsed ? <ChevronRight className="h-3 w-3 shrink-0" /> : <ChevronDown className="h-3 w-3 shrink-0" />}
+              <span className="truncate">{node.name}</span>
+            </button>
+            {!collapsed && <div>{renderTree(node.children, depth + 1)}</div>}
+          </div>
+        )
+      }
+
+      const isSelected = mode === 'diff'
+        ? selectedDiffPath === node.path
+        : selectedRepoPath === node.path
+
+      return (
+        <button
+          key={node.path}
+          type="button"
+          onClick={() => {
+            if (mode === 'diff') {
+              setSelectedDiffPath(node.path)
+            } else {
+              setSelectedRepoPath(node.path)
+            }
+          }}
+          className={`flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left text-xs transition-colors ${
+            isSelected
+              ? 'bg-primary/15 text-foreground'
+              : 'text-muted-foreground hover:bg-secondary/70 hover:text-foreground'
+          }`}
+          style={{ paddingLeft: `${10 + depth * 14}px` }}
+        >
+          <FileText className="h-3 w-3 shrink-0" />
+          <span className="min-w-0 flex-1 truncate">{node.name}</span>
+          {mode === 'diff' && node.diffFile && (
+            <>
+              <span className="text-[10px] text-emerald-600">+{node.diffFile.additions}</span>
+              <span className="text-[10px] text-rose-600">-{node.diffFile.deletions}</span>
+            </>
+          )}
+        </button>
+      )
+    })
+
+  const handleRefresh = useCallback(() => {
+    if (mode === 'diff') {
+      void loadDiffFiles()
+    } else {
+      void loadRepoPaths()
+    }
+  }, [loadDiffFiles, loadRepoPaths, mode])
+
+  const loading = mode === 'diff' ? diffLoading : repoFilesLoading
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <header className="shrink-0 border-b border-border/80 px-3 py-2">
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-foreground">Git Explorer</p>
+            <p className="text-[11px] text-muted-foreground">
+              {mode === 'diff' ? 'Review changed files and hunks.' : 'Browse repository files and open contents.'}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <Button
+              size="sm"
+              variant={mode === 'diff' ? 'default' : 'outline'}
+              className="h-7 gap-1.5 px-2 text-xs"
+              onClick={() => setMode('diff')}
+            >
+              <GitCompare className="h-3.5 w-3.5" />
+              Diff
+            </Button>
+            <Button
+              size="sm"
+              variant={mode === 'files' ? 'default' : 'outline'}
+              className="h-7 gap-1.5 px-2 text-xs"
+              onClick={() => setMode('files')}
+            >
+              <FolderTree className="h-3.5 w-3.5" />
+              Files
+            </Button>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-7 w-7"
+              onClick={handleRefresh}
+              title="Refresh explorer"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              <span className="sr-only">Refresh explorer</span>
+            </Button>
+            {onClose && (
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-7 w-7"
+                onClick={onClose}
+                title="Close explorer"
+              >
+                <X className="h-3.5 w-3.5" />
+                <span className="sr-only">Close explorer</span>
+              </Button>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex flex-1 overflow-hidden">
+        <section className="flex min-w-0 flex-1 flex-col border-r border-border/80 bg-background/40">
+          {mode === 'diff' ? (
+            <>
+              <header className="border-b border-border/80 px-3 py-2">
+                <p className="truncate text-xs font-semibold text-foreground">
+                  {selectedDiffFile?.path ?? 'Select a changed file'}
+                </p>
+                {selectedDiffFile && (
+                  <div className="mt-1 flex items-center gap-1.5">
+                    <Badge variant="outline" className={`h-4 px-1.5 text-[9px] uppercase ${statusBadgeClass(selectedDiffFile.status)}`}>
+                      {selectedDiffFile.status}
+                    </Badge>
+                    <span className="text-[10px] text-emerald-600">+{selectedDiffFile.additions}</span>
+                    <span className="text-[10px] text-rose-600">-{selectedDiffFile.deletions}</span>
+                  </div>
+                )}
+              </header>
+
+              <div className="min-h-0 flex-1 overflow-auto">
+                {!selectedDiffFile ? (
+                  <div className="p-4 text-xs text-muted-foreground">No changed file selected.</div>
+                ) : (
+                  <div className="min-w-[700px] font-mono text-[11px] leading-5">
+                    {selectedDiffFile.lines.map((line, index) => (
+                      <div
+                        key={`${selectedDiffFile.path}-${index}`}
+                        className={`grid grid-cols-[52px_52px_minmax(0,1fr)] border-b border-border/30 ${lineRowTone(line.type)}`}
+                      >
+                        <div className="border-r border-border/20 px-2 text-right text-muted-foreground">{line.oldLine ?? ''}</div>
+                        <div className="border-r border-border/20 px-2 text-right text-muted-foreground">{line.newLine ?? ''}</div>
+                        <div className={`px-2 whitespace-pre ${lineTextTone(line.type)}`}>
+                          {line.type === 'add' ? '+' : line.type === 'remove' ? '-' : ' '}
+                          {line.text}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            <>
+              <header className="border-b border-border/80 px-3 py-2">
+                <p className="truncate text-xs font-semibold text-foreground">{selectedRepoPath || 'Select a repository file'}</p>
+                <div className="mt-1 flex items-center gap-1.5">
+                  {repoFileBinary && <Badge variant="outline" className="h-4 px-1.5 text-[9px] uppercase">binary</Badge>}
+                  {repoFileTruncated && <Badge variant="outline" className="h-4 px-1.5 text-[9px] uppercase">truncated</Badge>}
+                </div>
+              </header>
+
+              <div className="min-h-0 flex-1 overflow-auto bg-background/60">
+                {!selectedRepoPath ? (
+                  <div className="p-4 text-xs text-muted-foreground">No file selected.</div>
+                ) : repoFileLoading ? (
+                  <div className="flex h-full items-center justify-center gap-2 text-xs text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Loading file...
+                  </div>
+                ) : repoFileBinary ? (
+                  <div className="p-4 text-xs text-muted-foreground">Binary file preview is not supported.</div>
+                ) : (
+                  <pre className="min-w-full p-3 font-mono text-[11px] leading-5 whitespace-pre">{repoFileContent}</pre>
+                )}
+              </div>
+            </>
+          )}
+        </section>
+
+        <aside className="w-[280px] shrink-0 bg-card/80">
+          <header className="border-b border-border/80 px-3 py-2">
+            <p className="text-xs font-semibold text-foreground">{mode === 'diff' ? 'Changed Files' : 'Repository Files'}</p>
+            <p className="mt-0.5 text-[10px] text-muted-foreground">
+              {mode === 'diff' ? (
+                <>
+                  {effectiveDiffFiles.length} files · <span className="text-emerald-600">+{totalAdditions}</span>{' '}
+                  <span className="text-rose-600">-{totalDeletions}</span>
+                </>
+              ) : (
+                <>
+                  {repoFilePaths.length} files
+                  {repoFilesError && ' · failed to sync'}
+                </>
+              )}
+            </p>
+          </header>
+
+          <div className="h-[calc(100%-49px)] overflow-y-auto px-1.5 py-1.5">
+            {loading ? (
+              <div className="flex items-center gap-2 px-2 py-1 text-[11px] text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Loading...
+              </div>
+            ) : mode === 'diff' && effectiveDiffFiles.length === 0 ? (
+              <p className="px-2 py-1 text-[11px] text-muted-foreground">No changed files.</p>
+            ) : mode === 'files' && repoFilePaths.length === 0 ? (
+              <p className="px-2 py-1 text-[11px] text-muted-foreground">No repository files available.</p>
+            ) : (
+              renderTree(mode === 'diff' ? diffTree.children : fileTree.children)
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -37,6 +37,12 @@ export type {
     ClusterStatusResponse,
     ClusterUpdateRequest,
     ClusterDetectRequest,
+    RepoDiffFileStatus,
+    RepoDiffLine,
+    RepoDiffFile,
+    RepoDiffResponse,
+    RepoFilesResponse,
+    RepoFileResponse,
 } from './api'
 
 // Dynamic API selection based on runtime config
@@ -125,6 +131,15 @@ export const getRunArtifacts = (...args: Parameters<typeof realApi.getRunArtifac
 
 export const queueRun = (...args: Parameters<typeof realApi.queueRun>) =>
     getApi().queueRun(...args)
+
+export const getRepoDiff = (...args: Parameters<typeof realApi.getRepoDiff>) =>
+    getApi().getRepoDiff(...args)
+
+export const getRepoFiles = (...args: Parameters<typeof realApi.getRepoFiles>) =>
+    getApi().getRepoFiles(...args)
+
+export const getRepoFile = (...args: Parameters<typeof realApi.getRepoFile>) =>
+    getApi().getRepoFile(...args)
 
 export const listSweeps = (...args: Parameters<typeof realApi.listSweeps>) =>
     getApi().listSweeps(...args)

--- a/server/server.py
+++ b/server/server.py
@@ -13,6 +13,7 @@ Run with: python server.py --workdir /path/to/project
 import argparse
 import json
 import os
+import re
 import shlex
 import sys
 import time
@@ -101,6 +102,7 @@ AUTH_PROTECTED_PREFIXES = (
     "/wild",
     "/sweeps",
     "/cluster",
+    "/git",
 )
 
 
@@ -1325,6 +1327,339 @@ async def health():
 async def health_json():
     """JSON health endpoint."""
     return {"status": "ok", "service": "research-agent-server", "workdir": WORKDIR}
+
+
+# =============================================================================
+# Git Diff Endpoints
+# =============================================================================
+
+GIT_DIFF_MAX_LINES_PER_FILE = 400
+GIT_DIFF_DEFAULT_FILE_LIMIT = 200
+GIT_FILES_DEFAULT_LIMIT = 5000
+GIT_FILE_MAX_BYTES = 120000
+_HUNK_HEADER_RE = re.compile(r"^@@ -(?P<old>\d+)(?:,\d+)? \+(?P<new>\d+)(?:,\d+)? @@")
+
+
+def _run_git_command(args: List[str], timeout_seconds: int = 10) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", WORKDIR, *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+
+
+def _is_git_repo() -> bool:
+    try:
+        result = _run_git_command(["rev-parse", "--is-inside-work-tree"], timeout_seconds=5)
+    except Exception:
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _collect_changed_files(limit: int) -> List[Dict[str, str]]:
+    files_by_path: Dict[str, str] = {}
+
+    diff_names = _run_git_command(["diff", "--name-status", "-z", "HEAD", "--"], timeout_seconds=15)
+    if diff_names.returncode != 0:
+        raise RuntimeError(diff_names.stderr.strip() or "Failed to list git diff files")
+
+    tokens = [token for token in diff_names.stdout.split("\x00") if token]
+    index = 0
+    while index < len(tokens):
+        status_token = tokens[index]
+        status_code = status_token[:1] if status_token else "M"
+        index += 1
+
+        path = ""
+        if status_code in {"R", "C"}:
+            if index + 1 >= len(tokens):
+                break
+            index += 1  # Skip old path
+            path = tokens[index]
+            index += 1
+            status_code = "M"
+        else:
+            if index >= len(tokens):
+                break
+            path = tokens[index]
+            index += 1
+
+        if not path:
+            continue
+
+        status = "modified"
+        if status_code == "A":
+            status = "added"
+        elif status_code == "D":
+            status = "deleted"
+        files_by_path[path] = status
+
+    untracked = _run_git_command(["ls-files", "--others", "--exclude-standard", "-z"], timeout_seconds=10)
+    if untracked.returncode == 0:
+        for path in untracked.stdout.split("\x00"):
+            if path:
+                files_by_path[path] = "added"
+
+    changed = [
+        {"path": path, "status": files_by_path[path]}
+        for path in sorted(files_by_path.keys())
+    ]
+    return changed[:limit]
+
+
+def _parse_unified_diff(diff_text: str, max_lines: int = GIT_DIFF_MAX_LINES_PER_FILE) -> List[Dict[str, Any]]:
+    parsed: List[Dict[str, Any]] = []
+    old_line: Optional[int] = None
+    new_line: Optional[int] = None
+
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith(("diff --git ", "index ", "--- ", "+++ ")):
+            continue
+
+        if raw_line.startswith("Binary files "):
+            parsed.append(
+                {"type": "hunk", "text": "Binary file changed.", "oldLine": None, "newLine": None}
+            )
+            break
+
+        if raw_line.startswith("\\ No newline at end of file"):
+            continue
+
+        if raw_line.startswith("@@"):
+            match = _HUNK_HEADER_RE.match(raw_line)
+            if match:
+                old_line = int(match.group("old"))
+                new_line = int(match.group("new"))
+            else:
+                old_line = None
+                new_line = None
+
+            parsed.append({"type": "hunk", "text": raw_line, "oldLine": None, "newLine": None})
+
+        elif raw_line.startswith("+"):
+            parsed.append({"type": "add", "text": raw_line[1:], "oldLine": None, "newLine": new_line})
+            if new_line is not None:
+                new_line += 1
+
+        elif raw_line.startswith("-"):
+            parsed.append({"type": "remove", "text": raw_line[1:], "oldLine": old_line, "newLine": None})
+            if old_line is not None:
+                old_line += 1
+
+        elif raw_line.startswith(" "):
+            parsed.append({"type": "context", "text": raw_line[1:], "oldLine": old_line, "newLine": new_line})
+            if old_line is not None:
+                old_line += 1
+            if new_line is not None:
+                new_line += 1
+
+        if len(parsed) >= max_lines:
+            parsed.append(
+                {
+                    "type": "hunk",
+                    "text": f"... diff truncated to {max_lines} lines ...",
+                    "oldLine": None,
+                    "newLine": None,
+                }
+            )
+            break
+
+    return parsed
+
+
+def _build_untracked_file_lines(path: str, max_lines: int = GIT_DIFF_MAX_LINES_PER_FILE) -> List[Dict[str, Any]]:
+    workdir_real = os.path.realpath(WORKDIR)
+    file_path = os.path.realpath(os.path.join(WORKDIR, path))
+
+    if not (file_path == workdir_real or file_path.startswith(workdir_real + os.sep)):
+        return [{"type": "hunk", "text": "Invalid path outside repository.", "oldLine": None, "newLine": None}]
+
+    if not os.path.exists(file_path):
+        return [{"type": "hunk", "text": "File not found in working tree.", "oldLine": None, "newLine": None}]
+
+    try:
+        with open(file_path, "rb") as handle:
+            content = handle.read()
+    except Exception as exc:
+        return [{"type": "hunk", "text": f"Unable to read file: {exc}", "oldLine": None, "newLine": None}]
+
+    if b"\x00" in content:
+        return [{"type": "hunk", "text": "Binary file added.", "oldLine": None, "newLine": None}]
+
+    lines = content.decode("utf-8", errors="replace").splitlines()
+    parsed: List[Dict[str, Any]] = [
+        {"type": "hunk", "text": f"@@ -0,0 +1,{len(lines)} @@", "oldLine": None, "newLine": None}
+    ]
+
+    if not lines:
+        parsed.append({"type": "add", "text": "", "oldLine": None, "newLine": 1})
+        return parsed
+
+    for line_number, line_text in enumerate(lines[:max_lines], start=1):
+        parsed.append({"type": "add", "text": line_text, "oldLine": None, "newLine": line_number})
+
+    if len(lines) > max_lines:
+        parsed.append(
+            {
+                "type": "hunk",
+                "text": f"... file truncated to {max_lines} lines ...",
+                "oldLine": None,
+                "newLine": None,
+            }
+        )
+
+    return parsed
+
+
+def _build_file_diff(path: str, status: str, unified: int) -> Dict[str, Any]:
+    lines: List[Dict[str, Any]] = []
+
+    if status == "added":
+        tracked_check = _run_git_command(["ls-files", "--error-unmatch", "--", path], timeout_seconds=5)
+        if tracked_check.returncode == 0:
+            diff_result = _run_git_command(
+                ["diff", "--no-color", f"--unified={unified}", "HEAD", "--", path],
+                timeout_seconds=20,
+            )
+            if diff_result.returncode == 0:
+                lines = _parse_unified_diff(diff_result.stdout)
+            else:
+                lines = [{"type": "hunk", "text": "Unable to render file diff.", "oldLine": None, "newLine": None}]
+        else:
+            lines = _build_untracked_file_lines(path)
+    else:
+        diff_result = _run_git_command(
+            ["diff", "--no-color", f"--unified={unified}", "HEAD", "--", path],
+            timeout_seconds=20,
+        )
+        if diff_result.returncode == 0:
+            lines = _parse_unified_diff(diff_result.stdout)
+        else:
+            lines = [{"type": "hunk", "text": "Unable to render file diff.", "oldLine": None, "newLine": None}]
+
+    if not lines:
+        if status == "deleted":
+            lines = [{"type": "hunk", "text": "File deleted with no textual hunks.", "oldLine": None, "newLine": None}]
+        elif status == "added":
+            lines = [{"type": "hunk", "text": "New file with no textual content.", "oldLine": None, "newLine": None}]
+        else:
+            lines = [{"type": "hunk", "text": "No textual diff available.", "oldLine": None, "newLine": None}]
+
+    additions = sum(1 for line in lines if line.get("type") == "add")
+    deletions = sum(1 for line in lines if line.get("type") == "remove")
+
+    return {
+        "path": path,
+        "status": status,
+        "additions": additions,
+        "deletions": deletions,
+        "lines": lines,
+    }
+
+
+def _resolve_repo_path(relative_path: str) -> Optional[str]:
+    """Resolve repository-relative file path and block traversal outside WORKDIR."""
+    if not relative_path:
+        return None
+
+    normalized = relative_path.strip().replace("\\", "/")
+    if normalized.startswith("/") or normalized.startswith("../") or "/../" in normalized:
+        return None
+
+    repo_root = os.path.realpath(WORKDIR)
+    target = os.path.realpath(os.path.join(WORKDIR, normalized))
+
+    if target == repo_root or target.startswith(repo_root + os.sep):
+        return target
+    return None
+
+
+@app.get("/git/diff")
+async def get_repo_diff(
+    unified: int = Query(3, ge=0, le=12, description="Unified context lines per diff hunk"),
+    limit: int = Query(GIT_DIFF_DEFAULT_FILE_LIMIT, ge=1, le=500, description="Maximum number of files to return"),
+):
+    """Return the repository diff for changed files in the current workdir."""
+    if not _is_git_repo():
+        return {"repo_path": WORKDIR, "head": None, "files": []}
+
+    head_result = _run_git_command(["rev-parse", "--short", "HEAD"], timeout_seconds=5)
+    head = head_result.stdout.strip() if head_result.returncode == 0 else None
+
+    try:
+        changed_files = _collect_changed_files(limit)
+    except Exception as exc:
+        logger.error(f"Failed to collect git diff files: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to load repository diff")
+
+    files = [_build_file_diff(item["path"], item["status"], unified) for item in changed_files]
+    return {"repo_path": WORKDIR, "head": head, "files": files}
+
+
+@app.get("/git/files")
+async def get_repo_files(
+    limit: int = Query(GIT_FILES_DEFAULT_LIMIT, ge=1, le=20000, description="Maximum number of files to return"),
+):
+    """Return repository files for file explorer mode."""
+    if not _is_git_repo():
+        return {"repo_path": WORKDIR, "files": []}
+
+    files_result = _run_git_command(
+        ["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        timeout_seconds=20,
+    )
+    if files_result.returncode != 0:
+        logger.error(f"Failed to list git files: {files_result.stderr.strip()}")
+        raise HTTPException(status_code=500, detail="Failed to list repository files")
+
+    files = sorted({path for path in files_result.stdout.split("\x00") if path})
+    return {"repo_path": WORKDIR, "files": files[:limit]}
+
+
+@app.get("/git/file")
+async def get_repo_file(
+    path: str = Query(..., description="Repository-relative file path"),
+    max_bytes: int = Query(
+        GIT_FILE_MAX_BYTES,
+        ge=1024,
+        le=500000,
+        description="Maximum bytes to read",
+    ),
+):
+    """Return text content for a repository file."""
+    if not _is_git_repo():
+        raise HTTPException(status_code=404, detail="Not a git repository")
+
+    resolved = _resolve_repo_path(path)
+    if not resolved:
+        raise HTTPException(status_code=400, detail="Invalid file path")
+
+    if not os.path.exists(resolved):
+        raise HTTPException(status_code=404, detail="File not found")
+    if os.path.isdir(resolved):
+        raise HTTPException(status_code=400, detail="Path is a directory")
+
+    try:
+        with open(resolved, "rb") as handle:
+            data = handle.read(max_bytes + 1)
+    except Exception as exc:
+        logger.error(f"Failed to read file {path}: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to read file")
+
+    truncated = len(data) > max_bytes
+    if truncated:
+        data = data[:max_bytes]
+
+    if b"\x00" in data:
+        return {"path": path, "content": "", "binary": True, "truncated": truncated}
+
+    return {
+        "path": path,
+        "content": data.decode("utf-8", errors="replace"),
+        "binary": False,
+        "truncated": truncated,
+    }
 
 
 @app.get("/sessions")


### PR DESCRIPTION
Summary
- add a nav bar button and dialog wrapper that surfaces the new contextual diff explorer at 90% width/height with separate close/refresh controls
- create `ContextualDiffExplorer` so the pane can switch between diff and file-explorer modes, render trees, and fetch git data via the new API surface
- extend the API, mocks, and server routes to expose diff/file/file-content endpoints and document the setup caveat in the README

Testing
<img width="1458" height="773" alt="image" src="https://github.com/user-attachments/assets/ee815fb8-6d9b-4304-bb98-671e1d5cec9e" />
