### PR TITLE
feat(chat): add sticky auto-scroll behavior for streaming responses

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -64,7 +64,6 @@ export function ChatView({
       autoScrollEnabledRef.current = distanceFromBottom <= SCROLL_BOTTOM_THRESHOLD_PX
     }
 
-    updateAutoScrollState()
     viewport.addEventListener('scroll', updateAutoScrollState, { passive: true })
     return () => viewport.removeEventListener('scroll', updateAutoScrollState)
   }, [messages.length, collapseChats])

--- a/components/connected-chat-view.tsx
+++ b/components/connected-chat-view.tsx
@@ -190,7 +190,6 @@ export function ConnectedChatView({
             autoScrollEnabledRef.current = distanceFromBottom <= SCROLL_BOTTOM_THRESHOLD_PX
         }
 
-        updateAutoScrollState()
         viewport.addEventListener('scroll', updateAutoScrollState, { passive: true })
         return () => {
             viewport.removeEventListener('scroll', updateAutoScrollState)
@@ -210,6 +209,7 @@ export function ConnectedChatView({
 
         return () => cancelAnimationFrame(frame)
     }, [
+        currentSessionId,
         getScrollViewport,
         messages,
         streamingState.textContent,


### PR DESCRIPTION
This PR adds a sticky auto-scroll feature to chat, similar to commercial LLM interfaces.
- Chat now auto-scrolls to follow new/streaming assistant output when the user is at (or near) the bottom.
- If the user scrolls up to read earlier context, auto-scroll pauses and no longer pulls them down.
- Auto-scroll resumes once the user scrolls back near the bottom.
- Switching away and back to a chat that is still streaming now jumps to the latest output and keeps following.
- Behavior is implemented consistently across both chat render paths.

![autoscroll-demo](https://github.com/user-attachments/assets/5be4a817-015d-46bf-b1ee-020b91dfb10d)
