### PR TITLE
feat: add chat session rename functionality

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -227,6 +227,7 @@ export default function ResearchChat() {
     selectSession,
     saveSession,
     unsaveSession,
+    renameSession,
     archiveSession,
     currentSessionId,
     currentSession,
@@ -649,6 +650,9 @@ export default function ResearchChat() {
           }}
           onArchiveSession={async (sessionId) => {
             await archiveSession(sessionId)
+          }}
+          onRenameSession={async (sessionId, title) => {
+            await renameSession(sessionId, title)
           }}
           onNavigateToRun={handleNavigateToRun}
           onInsertReference={handleInsertChatReference}

--- a/hooks/use-chat-session.ts
+++ b/hooks/use-chat-session.ts
@@ -6,6 +6,7 @@ import {
     createSession,
     getSession,
     deleteSession,
+    renameSession as renameSessionApi,
     streamChat,
     streamSession,
     checkApiHealth,
@@ -73,6 +74,7 @@ export interface UseChatSessionResult {
     selectSession: (sessionId: string) => Promise<void>
     saveSession: (sessionId: string) => Promise<void>
     unsaveSession: (sessionId: string) => Promise<void>
+    renameSession: (sessionId: string, title: string) => Promise<void>
     archiveSession: (sessionId: string) => Promise<void>
     removeSession: (sessionId: string) => Promise<void>
     refreshSessions: () => Promise<void>
@@ -745,6 +747,18 @@ export function useChatSession(): UseChatSessionResult {
         }
     }, [currentSessionId])
 
+    // Rename a session
+    const renameSession = useCallback(async (sessionId: string, title: string) => {
+        try {
+            setError(null)
+            await renameSessionApi(sessionId, title)
+            setSessions(prev => prev.map(s => s.id === sessionId ? { ...s, title } : s))
+        } catch (err) {
+            console.error('Failed to rename session:', err)
+            setError(err instanceof Error ? err.message : 'Failed to rename session')
+        }
+    }, [])
+
     // Archive a session client-side (keeps backend data intact)
     const archiveSession = useCallback(async (sessionId: string) => {
         setError(null)
@@ -982,6 +996,7 @@ export function useChatSession(): UseChatSessionResult {
         selectSession,
         saveSession,
         unsaveSession,
+        renameSession,
         archiveSession,
         removeSession,
         refreshSessions,

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -61,6 +61,9 @@ export const createSession = (...args: Parameters<typeof realApi.createSession>)
 export const getSession = (...args: Parameters<typeof realApi.getSession>) =>
     getApi().getSession(...args)
 
+export const renameSession = (...args: Parameters<typeof realApi.renameSession>) =>
+    getApi().renameSession(...args)
+
 export const deleteSession = (...args: Parameters<typeof realApi.deleteSession>) =>
     getApi().deleteSession(...args)
 

--- a/lib/api-mock.ts
+++ b/lib/api-mock.ts
@@ -482,6 +482,14 @@ export async function getSession(sessionId: string): Promise<SessionWithMessages
     return session
 }
 
+export async function renameSession(sessionId: string, title: string): Promise<ChatSession> {
+    await delay(100)
+    const session = mockSessions.get(sessionId)
+    if (!session) throw new Error('Session not found')
+    session.title = title
+    return { id: sessionId, title: session.title, created_at: session.created_at, message_count: session.messages.length }
+}
+
 export async function deleteSession(sessionId: string): Promise<void> {
     await delay(100)
     mockSessions.delete(sessionId)

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -142,6 +142,21 @@ export async function getSession(sessionId: string): Promise<SessionWithMessages
 }
 
 /**
+ * Rename a chat session
+ */
+export async function renameSession(sessionId: string, title: string): Promise<ChatSession> {
+    const response = await fetch(`${API_URL()}/sessions/${sessionId}`, {
+        method: 'PATCH',
+        headers: getHeaders(true),
+        body: JSON.stringify({ title }),
+    })
+    if (!response.ok) {
+        throw new Error(`Failed to rename session: ${response.statusText}`)
+    }
+    return response.json()
+}
+
+/**
  * Delete a chat session
  */
 export async function deleteSession(sessionId: string): Promise<void> {

--- a/server/server.py
+++ b/server/server.py
@@ -221,6 +221,10 @@ class CreateSessionRequest(BaseModel):
     title: Optional[str] = None
 
 
+class UpdateSessionRequest(BaseModel):
+    title: str
+
+
 class SystemPromptUpdate(BaseModel):
     system_prompt: str = ""
 
@@ -2562,6 +2566,22 @@ async def get_session(session_id: str):
         "messages": session.get("messages", []),
         "system_prompt": session.get("system_prompt", ""),
         "active_stream": active_stream,
+    }
+
+
+@app.patch("/sessions/{session_id}")
+async def update_session(session_id: str, req: UpdateSessionRequest):
+    """Update a chat session (e.g. rename)."""
+    if session_id not in chat_sessions:
+        raise HTTPException(status_code=404, detail="Session not found")
+    chat_sessions[session_id]["title"] = req.title
+    save_chat_state()
+    session = chat_sessions[session_id]
+    return {
+        "id": session_id,
+        "title": session.get("title", "New Chat"),
+        "created_at": session.get("created_at"),
+        "message_count": len(session.get("messages", [])),
     }
 
 


### PR DESCRIPTION
Add inline title editing in the sidebar via a new "Rename" menu item. Includes a PATCH /sessions/{session_id} backend endpoint to persist the new title.


https://github.com/user-attachments/assets/cb4a9ab9-4b1c-4749-9277-fbef983a4bb3

