### PR TITLE
fix: limit queue panel to 5 items and float above main layout

### DIFF
--- a/components/event-queue-panel.tsx
+++ b/components/event-queue-panel.tsx
@@ -1,6 +1,6 @@
-'use client'
+"use client";
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback } from "react";
 import {
   DndContext,
   closestCenter,
@@ -9,23 +9,26 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
-} from '@dnd-kit/core'
+} from "@dnd-kit/core";
 import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { ChevronDown, ChevronRight, GripVertical, X, Plus } from 'lucide-react'
-import type { QueuedEvent } from '@/lib/event-queue'
-import { PRIORITY_LABELS } from '@/lib/event-queue'
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { ChevronDown, ChevronRight, GripVertical, X, Plus } from "lucide-react";
+import type { QueuedEvent } from "@/lib/event-queue";
+import { PRIORITY_LABELS } from "@/lib/event-queue";
 
 // ─── Priority badge ───
 
 function PriorityBadge({ priority }: { priority: number }) {
-  const info = PRIORITY_LABELS[priority] || { label: `P${priority}`, color: '#6b7280' }
+  const info = PRIORITY_LABELS[priority] || {
+    label: `P${priority}`,
+    color: "#6b7280",
+  };
   return (
     <span
       className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none"
@@ -41,24 +44,24 @@ function PriorityBadge({ priority }: { priority: number }) {
       />
       {info.label}
     </span>
-  )
+  );
 }
 
 // ─── Type label ───
 
 const TYPE_ICONS: Record<string, string> = {
-  steer: '🧭',
-  alert: '🔔',
-  run_event: '🏃',
-  analysis: '📊',
-  exploring: '🔍',
-}
+  steer: "🧭",
+  alert: "🔔",
+  run_event: "🏃",
+  analysis: "📊",
+  exploring: "🔍",
+};
 
 // ─── Sortable queue item ───
 
 interface SortableQueueItemProps {
-  event: QueuedEvent
-  onRemove: (id: string) => void
+  event: QueuedEvent;
+  onRemove: (id: string) => void;
 }
 
 function SortableQueueItem({ event, onRemove }: SortableQueueItemProps) {
@@ -69,13 +72,13 @@ function SortableQueueItem({ event, onRemove }: SortableQueueItemProps) {
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: event.id })
+  } = useSortable({ id: event.id });
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-  }
+  };
 
   return (
     <div
@@ -94,7 +97,7 @@ function SortableQueueItem({ event, onRemove }: SortableQueueItemProps) {
 
       <PriorityBadge priority={event.priority} />
 
-      <span className="mr-0.5 text-xs">{TYPE_ICONS[event.type] || '❓'}</span>
+      <span className="mr-0.5 text-xs">{TYPE_ICONS[event.type] || "❓"}</span>
 
       <span className="flex-1 truncate text-xs text-foreground/80">
         {event.title}
@@ -108,32 +111,32 @@ function SortableQueueItem({ event, onRemove }: SortableQueueItemProps) {
         <X className="h-3 w-3" />
       </button>
     </div>
-  )
+  );
 }
 
 // ─── Inline insert form ───
 
 interface InsertFormProps {
-  onInsert: (event: QueuedEvent) => void
-  onCancel: () => void
+  onInsert: (event: QueuedEvent) => void;
+  onCancel: () => void;
 }
 
 function InsertForm({ onInsert, onCancel }: InsertFormProps) {
-  const [title, setTitle] = useState('')
-  const [prompt, setPrompt] = useState('')
-  const [priority, setPriority] = useState(10)
+  const [title, setTitle] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [priority, setPriority] = useState(10);
 
   const handleSubmit = () => {
-    if (!title.trim() || !prompt.trim()) return
+    if (!title.trim() || !prompt.trim()) return;
     onInsert({
       id: `manual-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
       priority,
       title: title.trim(),
       prompt: prompt.trim(),
-      type: 'steer',
+      type: "steer",
       createdAt: Date.now(),
-    })
-  }
+    });
+  };
 
   return (
     <div className="space-y-2 rounded-md border border-border/50 bg-secondary/30 p-2">
@@ -182,17 +185,19 @@ function InsertForm({ onInsert, onCancel }: InsertFormProps) {
         </button>
       </div>
     </div>
-  )
+  );
 }
 
 // ─── Main panel ───
 
 export interface EventQueuePanelProps {
-  events: QueuedEvent[]
-  onReorder: (orderedIds: string[]) => void
-  onRemove: (id: string) => void
-  onInsert: (event: QueuedEvent, index?: number) => void
+  events: QueuedEvent[];
+  onReorder: (orderedIds: string[]) => void;
+  onRemove: (id: string) => void;
+  onInsert: (event: QueuedEvent, index?: number) => void;
 }
+
+const MAX_VISIBLE_ITEMS = 5;
 
 export function EventQueuePanel({
   events,
@@ -200,103 +205,124 @@ export function EventQueuePanel({
   onRemove,
   onInsert,
 }: EventQueuePanelProps) {
-  const [isExpanded, setIsExpanded] = useState(false)
-  const [showInsertForm, setShowInsertForm] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+  const [showInsertForm, setShowInsertForm] = useState(false);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
-    })
-  )
+    }),
+  );
 
-  const handleDragEnd = useCallback((event: DragEndEvent) => {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
 
-    const oldIndex = events.findIndex(e => e.id === active.id)
-    const newIndex = events.findIndex(e => e.id === over.id)
-    if (oldIndex === -1 || newIndex === -1) return
+      const oldIndex = events.findIndex((e) => e.id === active.id);
+      const newIndex = events.findIndex((e) => e.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
 
-    const reordered = arrayMove(events, oldIndex, newIndex)
-    onReorder(reordered.map(e => e.id))
-  }, [events, onReorder])
+      const reordered = arrayMove(events, oldIndex, newIndex);
+      onReorder(reordered.map((e) => e.id));
+    },
+    [events, onReorder],
+  );
 
-  const handleInsert = useCallback((event: QueuedEvent) => {
-    onInsert(event)
-    setShowInsertForm(false)
-  }, [onInsert])
+  const handleInsert = useCallback(
+    (event: QueuedEvent) => {
+      onInsert(event);
+      setShowInsertForm(false);
+    },
+    [onInsert],
+  );
 
-  if (events.length === 0 && !showInsertForm) return null
+  if (events.length === 0 && !showInsertForm) return null;
+
+  const visibleEvents = showAll ? events : events.slice(0, MAX_VISIBLE_ITEMS);
+  const hiddenCount = events.length - MAX_VISIBLE_ITEMS;
 
   return (
-    <div className="mx-auto w-full max-w-3xl">
-      <div className="overflow-hidden rounded-t-lg border border-b-0 border-border/40 bg-secondary/20">
-        {/* Header */}
-        <button
-          type="button"
-          onClick={() => setIsExpanded(!isExpanded)}
-          className="flex w-full items-center gap-2 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-secondary/30"
-        >
-          {isExpanded ? (
-            <ChevronDown className="h-3 w-3" />
-          ) : (
-            <ChevronRight className="h-3 w-3" />
-          )}
-          <span>
-            {events.length} queued
-          </span>
-          {!isExpanded && events.length > 0 && (
-            <span className="truncate text-muted-foreground/60">
-              — next: {events[0].title}
-            </span>
-          )}
-          <div className="flex-1" />
+    <div className="relative mx-auto w-full max-w-3xl">
+      <div className="absolute bottom-0 left-0 right-0 z-30">
+        <div className="overflow-hidden rounded-t-lg border border-b-0 border-border/40 bg-secondary/95 shadow-lg backdrop-blur-sm">
+          {/* Header */}
           <button
             type="button"
-            onClick={(e) => {
-              e.stopPropagation()
-              setShowInsertForm(!showInsertForm)
-              if (!isExpanded) setIsExpanded(true)
-            }}
-            className="rounded p-0.5 text-muted-foreground/60 hover:bg-secondary hover:text-foreground"
-            title="Add event to queue"
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-secondary/30"
           >
-            <Plus className="h-3.5 w-3.5" />
-          </button>
-        </button>
-
-        {/* Expanded content */}
-        {isExpanded && (
-          <div className="space-y-1 px-3 pb-2">
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-            >
-              <SortableContext
-                items={events.map(e => e.id)}
-                strategy={verticalListSortingStrategy}
-              >
-                {events.map(event => (
-                  <SortableQueueItem
-                    key={event.id}
-                    event={event}
-                    onRemove={onRemove}
-                  />
-                ))}
-              </SortableContext>
-            </DndContext>
-
-            {showInsertForm && (
-              <InsertForm
-                onInsert={handleInsert}
-                onCancel={() => setShowInsertForm(false)}
-              />
+            {isExpanded ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
             )}
-          </div>
-        )}
+            <span>{events.length} queued</span>
+            {!isExpanded && events.length > 0 && (
+              <span className="truncate text-muted-foreground/60">
+                — next: {events[0].title}
+              </span>
+            )}
+            <div className="flex-1" />
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowInsertForm(!showInsertForm);
+                if (!isExpanded) setIsExpanded(true);
+              }}
+              className="rounded p-0.5 text-muted-foreground/60 hover:bg-secondary hover:text-foreground"
+              title="Add event to queue"
+            >
+              <Plus className="h-3.5 w-3.5" />
+            </button>
+          </button>
+
+          {/* Expanded content */}
+          {isExpanded && (
+            <div className="max-h-[60vh] overflow-y-auto space-y-1 px-3 pb-2">
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={visibleEvents.map((e) => e.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {visibleEvents.map((event) => (
+                    <SortableQueueItem
+                      key={event.id}
+                      event={event}
+                      onRemove={onRemove}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
+
+              {/* Show more / less toggle */}
+              {hiddenCount > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setShowAll(!showAll)}
+                  className="w-full rounded-md py-1 text-center text-[11px] font-medium text-muted-foreground/70 hover:bg-secondary/50 hover:text-muted-foreground transition-colors"
+                >
+                  {showAll ? "Show less" : `+${hiddenCount} more…`}
+                </button>
+              )}
+
+              {showInsertForm && (
+                <InsertForm
+                  onInsert={handleInsert}
+                  onCancel={() => setShowInsertForm(false)}
+                />
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
When the event queue has many items it takes over the screen and pushes the main chat panel out of view.

## Changes
- **Max 5 visible items** — only the first 5 queue items are shown when expanded, with a clickable "+N more…" / "Show less" toggle to reveal the rest
- **Floating overlay** — the expanded panel uses absolute positioning to float above the chat input instead of pushing layout down
- **Scroll cap** — `max-h-[60vh]` with overflow scroll as a safety net even when all items are shown
- **Visual polish** — backdrop blur, shadow, and opaque background for the floating panel