### PR TITLE
ui: Add chat status indicators to left sidebar sessions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -634,6 +634,9 @@ export default function ResearchChat() {
           runs={runs}
           sweeps={sweeps}
           pendingAlertsByRun={pendingAlertsByRun}
+          alerts={alerts}
+          currentSessionId={currentSessionId}
+          isCurrentSessionStreaming={chatSession.streamingState.isStreaming}
           onTabChange={handleTabChange}
           onNewChat={() => {
             startNewChat()  // Just clear state, session created when message is sent

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -23,11 +23,20 @@ function getHeaders(includeContentType: boolean = false): HeadersInit {
 }
 
 // Types
+export type ChatSessionStatus =
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'questionable'
+    | 'awaiting_human'
+    | 'idle'
+
 export interface ChatSession {
     id: string
     title: string
     created_at: number
     message_count: number
+    status?: ChatSessionStatus
 }
 
 export interface ChatMessageData {

--- a/server/server.py
+++ b/server/server.py
@@ -2817,12 +2817,34 @@ async def get_repo_file(
 @app.get("/sessions")
 async def list_sessions():
     """List all chat sessions."""
+    def resolve_session_status(session_id: str, session: dict[str, Any]) -> str:
+        has_pending_human_input = any(
+            alert.get("status") == "pending" and alert.get("session_id") == session_id
+            for alert in active_alerts.values()
+        )
+        if has_pending_human_input:
+            return "awaiting_human"
+
+        runtime = active_chat_streams.get(session_id)
+        if runtime and runtime.status == "running":
+            return "running"
+
+        raw_status = (runtime.status if runtime else None) or session.get("last_status")
+        if raw_status in {"failed", "error"}:
+            return "failed"
+        if raw_status in {"stopped", "interrupted"}:
+            return "questionable"
+        if session.get("messages"):
+            return "completed"
+        return "idle"
+
     sessions = [
         {
             "id": sid,
             "title": session.get("title", "New Chat"),
             "created_at": session.get("created_at"),
-            "message_count": len(session.get("messages", []))
+            "message_count": len(session.get("messages", [])),
+            "status": resolve_session_status(sid, session),
         }
         for sid, session in chat_sessions.items()
     ]
@@ -2841,9 +2863,16 @@ async def create_session(req: Optional[CreateSessionRequest] = None):
         "messages": [],
         "opencode_session_id": None,
         "system_prompt": "",
+        "last_status": "idle",
     }
     save_chat_state()
-    return {"id": session_id, "title": title, "created_at": chat_sessions[session_id]["created_at"], "message_count": 0}
+    return {
+        "id": session_id,
+        "title": title,
+        "created_at": chat_sessions[session_id]["created_at"],
+        "message_count": 0,
+        "status": "idle",
+    }
 
 
 @app.get("/sessions/{session_id}")
@@ -3076,6 +3105,8 @@ async def _chat_worker(session_id: str, content: str, runtime: ChatStreamRuntime
 
         session = chat_sessions.get(session_id)
         if isinstance(session, dict):
+            session["last_status"] = runtime.status
+            session["last_error"] = runtime.error
             session.pop("active_stream", None)
         save_chat_state()
 


### PR DESCRIPTION
## Summary
- add a normalized `status` field to chat sessions (`running`, `completed`, `failed`, `questionable`, `awaiting_human`, `idle`)
- compute session status in the backend `/sessions` endpoint using active stream state + pending alert linkage by `session_id`
- persist each session's last stream status to keep post-run state visible in the list
- update the desktop sidebar chat rows to render status icons/colors for both saved and recent chats
- prioritize live/current stream and pending human-response alerts in UI status rendering
- pass alert/session-stream context from the page container to the sidebar
- mirror the new status contract in mock API responses for demo mode

## Testing
- `npm run lint` *(fails in this environment: `eslint: command not found`)*

## Notes
- no PR template was found in this repo, so this PR uses the default structure
