### PR TITLE
CI: deploy main to Modal endpoint

### DIFF
--- a/.github/workflows/main-modal-deploy.yml
+++ b/.github/workflows/main-modal-deploy.yml
@@ -1,0 +1,70 @@
+name: Main Modal Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: main-modal-deploy
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  MODAL_DEPLOY_FILE: ${{ vars.MODAL_DEPLOY_FILE || 'modal_preview.py' }}
+  MODAL_APP_NAME: ${{ vars.MODAL_MAIN_APP_NAME || 'research-agent-main' }}
+
+jobs:
+  deploy-main:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Modal CLI
+        run: pip install modal
+
+      - name: Generate Modal frontend config
+        run: |
+          SERVER_URL="https://${{ github.repository_owner }}--${MODAL_APP_NAME}-preview-server.modal.run"
+          APP_URL="https://${{ github.repository_owner }}--${MODAL_APP_NAME}-preview-app.modal.run"
+          {
+            echo "NEXT_PUBLIC_DEFAULT_SERVER_URL=${SERVER_URL}"
+            echo "BACKEND_URL=${SERVER_URL}"
+          } > .env.local
+
+          if [ -n "${MAIN_DEFAULT_AUTH_TOKEN}" ]; then
+            echo "NEXT_PUBLIC_DEFAULT_AUTH_TOKEN=${MAIN_DEFAULT_AUTH_TOKEN}" >> .env.local
+          fi
+
+          echo "SERVER_URL=${SERVER_URL}" >> "$GITHUB_ENV"
+          echo "APP_URL=${APP_URL}" >> "$GITHUB_ENV"
+
+      - name: Deploy main app to Modal
+        run: |
+          modal deploy "${MODAL_DEPLOY_FILE}" --name "${MODAL_APP_NAME}"
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+
+      - name: Publish deployment summary
+        run: |
+          {
+            echo "## Main Modal Deployment"
+            echo ""
+            echo "- App name: \`${MODAL_APP_NAME}\`"
+            echo "- Deploy file: \`${MODAL_DEPLOY_FILE}\`"
+            echo "- Backend endpoint: ${SERVER_URL}"
+            echo "- Frontend endpoint: ${APP_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
+    env:
+      MAIN_DEFAULT_AUTH_TOKEN: ${{ secrets.MODAL_MAIN_DEFAULT_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy to Modal on pushes to `main`
- support manual runs via `workflow_dispatch`
- include configurable app/deploy file via repo variables and publish endpoint URLs in run summary

## Workflow file
- `.github/workflows/main-modal-deploy.yml`

## Required secrets
- `MODAL_TOKEN_ID`
- `MODAL_TOKEN_SECRET`

## Optional config
- secret: `MODAL_MAIN_DEFAULT_AUTH_TOKEN`
- vars: `MODAL_MAIN_APP_NAME`, `MODAL_DEPLOY_FILE`
