### PR TITLE
ci: Verify preview deployment health before posting URL

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -48,6 +48,45 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
 
+      - name: Verify deployed preview health
+        run: |
+          set -euo pipefail
+
+          APP_SLUG="research-agent-preview-pr-${{ github.event.pull_request.number }}"
+          APP_URL="https://${{ github.repository_owner }}--${APP_SLUG}-preview-app.modal.run"
+          SERVER_URL="https://${{ github.repository_owner }}--${APP_SLUG}-preview-server.modal.run"
+
+          echo "Checking preview app: ${APP_URL}"
+          echo "Checking preview server health: ${SERVER_URL}/health"
+
+          check_url() {
+            local name="$1"
+            local url="$2"
+            local expected_regex="${3:-}"
+
+            for attempt in $(seq 1 30); do
+              response="$(curl -sS -L --max-time 15 -w '\n%{http_code}' "${url}" || true)"
+              body="$(echo "${response}" | sed '$d')"
+              code="$(echo "${response}" | tail -n 1)"
+
+              if [[ "${code}" == "200" ]]; then
+                if [[ -z "${expected_regex}" ]] || echo "${body}" | grep -Eq "${expected_regex}"; then
+                  echo "✅ ${name} healthy (attempt ${attempt})"
+                  return 0
+                fi
+              fi
+
+              echo "Attempt ${attempt}/30: ${name} not ready yet (status: ${code})"
+              sleep 10
+            done
+
+            echo "❌ ${name} failed health check after 30 attempts"
+            return 1
+          }
+
+          check_url "Preview app" "${APP_URL}"
+          check_url "Preview server" "${SERVER_URL}/health" '"status"[[:space:]]*:[[:space:]]*"ok"'
+
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Summary
- add health checks in the preview deployment workflow to poll both the app and server endpoints
- ensure server /health response contains an OK status before proceeding

Testing
- Not run (not requested)