### PR TITLE
feat(wild-loop): Wild Loop V2 human-in-loop escalation + OpenEvolve bridge (MVP)

### DIFF
--- a/components/wild-loop-debug-panel.tsx
+++ b/components/wild-loop-debug-panel.tsx
@@ -292,7 +292,47 @@ export function WildLoopDebugPanel({ onClose }: WildLoopDebugPanelProps) {
                                             {(v2Status.pending_events || []).slice(0, 5).map((ev) => (
                                                 <div key={ev.id} className="text-[10px] flex items-start gap-1">
                                                     <Circle className="h-2 w-2 mt-0.5 text-yellow-400 fill-yellow-400/30" />
-                                                    <span className="truncate">{ev.title}</span>
+                                                    <div className="min-w-0">
+                                                        <div className="truncate">{ev.title}</div>
+                                                        <div className="text-[9px] text-muted-foreground truncate">
+                                                            {ev.type}
+                                                            {ev.mode ? ` • ${ev.mode}` : ''}
+                                                            {ev.severity ? ` • ${ev.severity}` : ''}
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+
+                                {/* OpenEvolve Jobs */}
+                                {v2Status.openevolve_jobs && v2Status.openevolve_jobs.length > 0 && (
+                                    <div className="border-t border-border/30 pt-2">
+                                        <div className="text-[10px] text-muted-foreground mb-1 font-medium">
+                                            OpenEvolve Jobs ({v2Status.openevolve_jobs.length})
+                                        </div>
+                                        <div className="space-y-1 max-h-[140px] overflow-y-auto">
+                                            {v2Status.openevolve_jobs.map((job) => (
+                                                <div
+                                                    key={job.id}
+                                                    className="rounded border border-border/30 bg-secondary/20 px-2 py-1 text-[10px]"
+                                                >
+                                                    <div className="flex items-center justify-between gap-2">
+                                                        <span className="truncate text-foreground">{job.name || job.id}</span>
+                                                        <span className={statusColor(job.status)}>{job.status}</span>
+                                                    </div>
+                                                    <div className="text-[9px] text-muted-foreground truncate">
+                                                        {job.mode} • iter {job.last_iteration ?? 'n/a'}
+                                                    </div>
+                                                    {job.latest_checkpoint && (
+                                                        <div className="text-[9px] text-blue-400 truncate" title={job.latest_checkpoint}>
+                                                            {job.latest_checkpoint}
+                                                        </div>
+                                                    )}
+                                                    <div className="text-[9px] text-muted-foreground truncate">
+                                                        best={job.best_program_id ?? 'n/a'} score={job.best_score ?? 'n/a'}
+                                                    </div>
                                                 </div>
                                             ))}
                                         </div>

--- a/server/openevolve_bridge.py
+++ b/server/openevolve_bridge.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""OpenEvolve subprocess bridge.
+
+Modes:
+- smoke: generate synthetic checkpoint artifacts for integration testing
+- real: execute OpenEvolve CLI as a black-box process
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def run_smoke_mode(output_dir: Path, iterations: int) -> int:
+    checkpoints_dir = output_dir / "checkpoints"
+    _ensure_dir(checkpoints_dir)
+
+    best_program_id = "smoke-best-program"
+    for i in range(1, iterations + 1):
+        checkpoint_dir = checkpoints_dir / f"checkpoint_{i}"
+        programs_dir = checkpoint_dir / "programs"
+        _ensure_dir(programs_dir)
+
+        metadata = {
+            "island_feature_maps": [{"0-0": best_program_id}],
+            "islands": [[best_program_id]],
+            "archive": [best_program_id],
+            "best_program_id": best_program_id,
+            "island_best_programs": [best_program_id],
+            "last_iteration": i,
+            "current_island": 0,
+            "island_generations": [i],
+            "last_migration_generation": 0,
+            "feature_stats": {
+                "complexity": {"min": 1.0, "max": 1.0, "values": [1.0]},
+                "diversity": {"min": 1.0, "max": 1.0, "values": [1.0]},
+            },
+        }
+        (checkpoint_dir / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+
+        best_program_info = {
+            "id": best_program_id,
+            "metrics": {
+                "combined_score": float(i),
+            },
+        }
+        (checkpoint_dir / "best_program_info.json").write_text(
+            json.dumps(best_program_info),
+            encoding="utf-8",
+        )
+
+        program_doc = {
+            "id": best_program_id,
+            "code": "# smoke openevolve output\n",
+            "metrics": {"combined_score": float(i)},
+            "generation": i,
+        }
+        (programs_dir / f"{best_program_id}.json").write_text(json.dumps(program_doc), encoding="utf-8")
+
+        print(f"[openevolve-bridge] smoke checkpoint_{i} written at {checkpoint_dir}", flush=True)
+        time.sleep(0.2)
+
+    print(f"[openevolve-bridge] smoke complete: output_dir={output_dir}", flush=True)
+    return 0
+
+
+def run_real_mode(
+    output_dir: Path,
+    initial_program: str,
+    evaluation_file: str,
+    config: str | None,
+    iterations: int | None,
+) -> int:
+    cmd = [
+        sys.executable,
+        "-m",
+        "openevolve.cli",
+        initial_program,
+        evaluation_file,
+        "--output",
+        str(output_dir),
+    ]
+    if config:
+        cmd.extend(["--config", config])
+    if iterations is not None:
+        cmd.extend(["--iterations", str(iterations)])
+
+    print(f"[openevolve-bridge] exec: {' '.join(cmd)}", flush=True)
+    proc = subprocess.run(cmd)
+    return int(proc.returncode)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="OpenEvolve bridge")
+    parser.add_argument("--mode", choices=["smoke", "real"], required=True)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--initial_program", required=True)
+    parser.add_argument("--evaluation_file", required=True)
+    parser.add_argument("--config", default=None)
+    parser.add_argument("--iterations", type=int, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    output_dir = Path(args.output_dir)
+    _ensure_dir(output_dir)
+
+    if args.mode == "smoke":
+        smoke_iterations = args.iterations if args.iterations and args.iterations > 0 else 3
+        return run_smoke_mode(output_dir, smoke_iterations)
+
+    return run_real_mode(
+        output_dir=output_dir,
+        initial_program=args.initial_program,
+        evaluation_file=args.evaluation_file,
+        config=args.config,
+        iterations=args.iterations,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/prompt_skills/wild_v2_iteration/SKILL.md
+++ b/server/prompt_skills/wild_v2_iteration/SKILL.md
@@ -100,6 +100,18 @@ If you need to **wait for runs/experiments** and have nothing else to do:
 <promise>WAITING</promise>
 ```
 
+If you detect a weird signal and want human visibility, emit:
+```json
+<human_signal>{"mode":"advisory","severity":"warning","title":"Something looks off","detail":"I saw X and I will try Y while you review.","source":"wild_v2_agent","metadata":{"iteration":"{{iteration}}"}}</human_signal>
+```
+Use `mode="advisory"` when you can continue safely.
+
+If you cannot proceed safely without human input, emit:
+```json
+<human_signal>{"mode":"blocking","severity":"critical","title":"Blocked on unknown failure","detail":"I cannot safely proceed because ...","source":"wild_v2_agent","metadata":{"iteration":"{{iteration}}"}}</human_signal>
+```
+Use `mode="blocking"` only when you need the system to pause/stop for human input.
+
 ## Environment Setup
 
 If no environment is set up yet, create one before running experiments:

--- a/tests/job_sidecar_test.py
+++ b/tests/job_sidecar_test.py
@@ -1,0 +1,108 @@
+"""Unit tests for sidecar alert mode/timeout behavior."""
+
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'server'))
+
+import job_sidecar as js
+
+
+def test_apply_alert_decision_advisory_does_not_wait():
+    decision = {
+        "action": "alert",
+        "mode": "advisory",
+        "message": "Something looks off",
+        "choices": ["Ignore", "Stop Job"],
+        "severity": "warning",
+        "source": "alert_judge",
+    }
+
+    with patch.object(js, "trigger_alert", return_value="alert-1") as trigger_mock, patch.object(
+        js, "wait_for_response", return_value="Stop Job"
+    ) as wait_mock:
+        should_stop = js.apply_alert_decision(
+            server_url="http://localhost:10000",
+            job_id="run-1",
+            run_dir="/tmp",
+            decision=decision,
+            human_wait_timeout_seconds=5,
+        )
+
+    assert should_stop is False
+    assert trigger_mock.called
+    assert not wait_mock.called
+
+
+def test_apply_alert_decision_blocking_stop_choice():
+    decision = {
+        "action": "alert",
+        "mode": "blocking",
+        "message": "Hard failure",
+        "choices": ["Ignore", "Stop Job"],
+        "severity": "critical",
+        "source": "rulebased",
+    }
+
+    with patch.object(js, "trigger_alert", return_value="alert-2"), patch.object(
+        js, "wait_for_response", return_value="Stop Job"
+    ) as wait_mock:
+        should_stop = js.apply_alert_decision(
+            server_url="http://localhost:10000",
+            job_id="run-2",
+            run_dir="/tmp",
+            decision=decision,
+            human_wait_timeout_seconds=7,
+        )
+
+    assert should_stop is True
+    wait_mock.assert_called_once()
+
+
+def test_apply_alert_decision_blocking_timeout_safe_stop():
+    decision = {
+        "action": "alert",
+        "mode": "blocking",
+        "message": "Need human",
+        "choices": ["Ignore", "Stop Job"],
+        "severity": "warning",
+        "source": "rulebased",
+    }
+
+    with patch.object(js, "trigger_alert", return_value="alert-3"), patch.object(
+        js, "wait_for_response", return_value=None
+    ):
+        should_stop = js.apply_alert_decision(
+            server_url="http://localhost:10000",
+            job_id="run-3",
+            run_dir="/tmp",
+            decision=decision,
+            human_wait_timeout_seconds=2,
+        )
+
+    assert should_stop is True
+
+
+def test_apply_alert_decision_ignore_choice_keeps_running():
+    decision = {
+        "action": "alert",
+        "mode": "blocking",
+        "message": "Need review",
+        "choices": ["Ignore", "Stop Job"],
+        "severity": "warning",
+        "source": "rulebased",
+    }
+
+    with patch.object(js, "trigger_alert", return_value="alert-4"), patch.object(
+        js, "wait_for_response", return_value="Ignore"
+    ):
+        should_stop = js.apply_alert_decision(
+            server_url="http://localhost:10000",
+            job_id="run-4",
+            run_dir="/tmp",
+            decision=decision,
+            human_wait_timeout_seconds=2,
+        )
+
+    assert should_stop is False

--- a/tests/server_wild_v2_api_test.py
+++ b/tests/server_wild_v2_api_test.py
@@ -1,0 +1,200 @@
+"""API-surface tests for Wild V2 status/events/human-signal/OpenEvolve handlers.
+
+These call endpoint handler functions directly to avoid HTTP client version coupling.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'server'))
+
+import server as srv
+
+
+def _reset_state():
+    srv.runs.clear()
+    srv.active_alerts.clear()
+    srv.v2_human_signals.clear()
+    srv.openevolve_jobs.clear()
+    srv.v2_resolved_event_ids.clear()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_wild_v2_status_includes_pending_events_system_health_and_openevolve_jobs():
+    _reset_state()
+
+    srv.runs["run-1"] = {"name": "Run 1", "status": "running", "created_at": time.time()}
+    srv.active_alerts["a1"] = {
+        "id": "a1",
+        "run_id": "run-1",
+        "timestamp": time.time(),
+        "severity": "critical",
+        "mode": "blocking",
+        "source": "rulebased",
+        "message": "Loss exploded",
+        "choices": ["Ignore", "Stop Job"],
+        "status": "pending",
+    }
+    srv.v2_human_signals["sig-1"] = {
+        "id": "sig-1",
+        "mode": "advisory",
+        "severity": "warning",
+        "title": "Something off",
+        "detail": "Trying mitigation",
+        "source": "wild_v2_agent",
+        "session_id": "wild-session",
+        "status": "pending",
+        "created_at": time.time(),
+        "metadata": {},
+    }
+    srv.openevolve_jobs["oe-1"] = {
+        "id": "oe-1",
+        "run_id": "run-1",
+        "status": "running",
+        "mode": "smoke",
+        "output_dir": "/tmp/missing",
+        "latest_checkpoint": None,
+        "last_iteration": None,
+        "best_program_id": None,
+        "best_score": None,
+        "updated_at": time.time(),
+        "created_at": time.time(),
+        "name": "OpenEvolve Smoke",
+    }
+
+    body = _run(srv.wild_v2_status())
+
+    assert "pending_events_count" in body
+    assert "pending_events" in body
+    assert body["pending_events_count"] >= 2
+
+    assert "system_health" in body
+    assert body["system_health"]["running"] >= 1
+
+    assert "openevolve_jobs" in body
+    assert len(body["openevolve_jobs"]) >= 1
+
+
+def test_wild_v2_events_and_resolve_support_alerts_and_signals():
+    _reset_state()
+
+    srv.active_alerts["a2"] = {
+        "id": "a2",
+        "run_id": "run-x",
+        "timestamp": time.time(),
+        "severity": "warning",
+        "mode": "blocking",
+        "source": "rulebased",
+        "message": "Watch this",
+        "choices": ["Ignore", "Stop Job"],
+        "status": "pending",
+    }
+    srv.v2_human_signals["sig-2"] = {
+        "id": "sig-2",
+        "mode": "blocking",
+        "severity": "critical",
+        "title": "Blocked",
+        "detail": "Need human",
+        "source": "wild_v2_agent",
+        "session_id": "wild-s2",
+        "status": "pending",
+        "created_at": time.time(),
+        "metadata": {},
+    }
+
+    events = _run(srv.wild_v2_events("wild-s2"))
+    ids = {e["id"] for e in events}
+    assert "alert-a2" in ids
+    assert "sig-2" in ids
+
+    resolved = _run(
+        srv.wild_v2_resolve_events(
+            "wild-s2",
+            srv.WildV2ResolveRequest(event_ids=["alert-a2", "sig-2"]),
+        )
+    )
+    assert resolved["resolved"] == 2
+    assert srv.active_alerts["a2"]["status"] == "resolved"
+    assert srv.v2_human_signals["sig-2"]["status"] == "resolved"
+
+
+def test_wild_v2_human_signal_endpoint_records_and_pauses_when_blocking():
+    _reset_state()
+
+    started = srv.wild_v2_engine.start(goal="human signal test", human_away_timeout_seconds=60)
+    session_id = started["session_id"]
+
+    body = _run(
+        srv.wild_v2_human_signal(
+            srv.WildV2HumanSignalRequest(
+                mode="blocking",
+                severity="critical",
+                title="Blocked",
+                detail="Cannot continue",
+                source="wild_v2_agent",
+                session_id=session_id,
+                metadata={"case": "test"},
+            )
+        )
+    )
+    assert body["event_id"].startswith("sig-")
+
+    assert srv.wild_v2_engine.session is not None
+    assert srv.wild_v2_engine.session.status == "paused"
+    assert srv.wild_v2_engine.session.blocking_reason == "Cannot continue"
+
+    srv.wild_v2_engine.stop()
+
+
+def test_wild_v2_openevolve_start_smoke_registers_job_and_reads_checkpoint():
+    _reset_state()
+
+    tmpdir = tempfile.mkdtemp(prefix="oe-bridge-test-")
+
+    def fake_launch(run_id, run_data):
+        run_data["status"] = "running"
+        run_data["run_dir"] = os.path.join(tmpdir, "run", run_id)
+        return "tmux-test"
+
+    original_launch = srv.launch_run_in_tmux
+    try:
+        srv.launch_run_in_tmux = fake_launch
+        payload = _run(
+            srv.wild_v2_openevolve_start(
+                srv.WildV2OpenEvolveStartRequest(
+                    mode="smoke",
+                    initial_program="examples/function_minimization/initial_program.py",
+                    evaluation_file="examples/function_minimization/evaluator.py",
+                    iterations=3,
+                    output_dir=tmpdir,
+                    name="Smoke Job",
+                )
+            )
+        )
+    finally:
+        srv.launch_run_in_tmux = original_launch
+
+    job_id = payload["job_id"]
+    assert job_id in srv.openevolve_jobs
+
+    checkpoint_dir = os.path.join(tmpdir, "checkpoints", "checkpoint_3")
+    os.makedirs(os.path.join(checkpoint_dir, "programs"), exist_ok=True)
+    with open(os.path.join(checkpoint_dir, "metadata.json"), "w", encoding="utf-8") as f:
+        json.dump({"last_iteration": 3, "best_program_id": "p-best"}, f)
+    with open(os.path.join(checkpoint_dir, "best_program_info.json"), "w", encoding="utf-8") as f:
+        json.dump({"metrics": {"combined_score": 9.5}}, f)
+
+    status = _run(srv.wild_v2_status())
+    jobs = status.get("openevolve_jobs", [])
+    target = next((j for j in jobs if j.get("id") == job_id), None)
+    assert target is not None
+    assert target.get("last_iteration") == 3
+    assert target.get("best_program_id") == "p-best"
+    assert target.get("best_score") == 9.5


### PR DESCRIPTION
## Summary
This PR implements the Wild Loop V2 MVP for human-in-the-loop escalation and a black-box OpenEvolve bridge.

- Adds two-tier human escalation for weird signals:
  - `advisory`: notify human, continue autonomously.
  - `blocking`: pause/stop path with explicit human resolution or timeout safe-stop.
- Adds V2 system visibility for pending events, health, and OpenEvolve job progress.
- Adds explicit OpenEvolve integration endpoint using subprocess bridge (`smoke` and `real` modes).
- Wires frontend setup/debug/events/notifications so humans can see and act on signals.

## Backend Changes
- Human signal parser + contract updates in V2 prompt layer.
- Wild V2 engine support for setup fields, blocking state, and timeout watchdog.
- Sidecar advisory/blocking behavior with wait timeout and safe-stop default.
- Server-side aggregation for alerts + V2 signals + OpenEvolve job summaries.
- New bridge script: `server/openevolve_bridge.py` (subprocess-based, black-box integration).

## API Changes
- Extended `POST /wild/v2/start` request body:
  - `autonomy_level: "cautious" | "balanced" | "full"` (default `"balanced"`)
  - `queue_modify_enabled: boolean` (default `true`)
  - `human_away_timeout_seconds: number` (default `600`)
- New endpoint: `POST /wild/v2/human-signal`
- New endpoint: `POST /wild/v2/openevolve/start`
- Extended `GET /wild/v2/status` response with:
  - `pending_events_count`
  - `pending_events[]`
  - `system_health`
  - `openevolve_jobs[]`
- Extended alert payload schema with:
  - `mode: "advisory" | "blocking"` (default `"blocking"`)
  - `source?: string`

## Frontend Changes
- Setup values now flow into V2 start payload.
- Debug panel shows pending human signals and OpenEvolve progress.
- Events tab includes non-alert V2 events with dedupe by ID.
- Browser notifications fire once per new pending alert/signal ID.

## Tests
Added/updated tests for:
- Human signal parsing + prompt parse regressions.
- V2 blocking/advisory behavior and timeout handling.
- Sidecar decision logic for advisory vs blocking.
- V2 status/events/resolve APIs and OpenEvolve job tracking.

Validation run:
- `pytest -q tests/wild_loop_v2_test.py tests/job_sidecar_test.py tests/server_wild_v2_api_test.py`
  - `42 passed`
- `pytest -q tests`
  - `128 passed, 1 failed`
  - Remaining failure is pre-existing/unrelated: `tests/wild_loop_test.py::TestWildEventQueue::test_dedup_after_dequeue`
