### PR TITLE
ui: Add workdir and OpenCode details to wild loop debug panel

### DIFF
--- a/components/wild-loop-debug-panel.tsx
+++ b/components/wild-loop-debug-panel.tsx
@@ -499,6 +499,27 @@ export function WildLoopDebugPanel({ onClose }: WildLoopDebugPanelProps) {
                                     </div>
                                 )}
 
+                                {/* Workdir */}
+                                {v2Status.workdir && (
+                                    <div>
+                                        <div className="text-[10px] text-muted-foreground mb-1 font-medium">Workdir</div>
+                                        <code className="text-[10px] text-blue-400 break-all">{v2Status.workdir}</code>
+                                    </div>
+                                )}
+
+                                {/* OpenCode cwd (best-effort) */}
+                                <div>
+                                    <div className="text-[10px] text-muted-foreground mb-1 font-medium">OpenCode pwd</div>
+                                    {v2Status.opencode_pwd ? (
+                                        <code className="text-[10px] text-blue-400 break-all">{v2Status.opencode_pwd}</code>
+                                    ) : (
+                                        <div className="text-[10px] text-muted-foreground">
+                                            unavailable
+                                            {v2Status.opencode_pwd_note ? ` — ${v2Status.opencode_pwd_note}` : ''}
+                                        </div>
+                                    )}
+                                </div>
+
                                 {/* 📄 tasks.md */}
                                 {v2Status.plan && (
                                     <Collapsible open={v2TasksOpen} onOpenChange={setV2TasksOpen}>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1110,6 +1110,9 @@ export interface WildV2Status {
     plan?: string
     iteration_log?: string
     session_dir?: string
+    workdir?: string
+    opencode_pwd?: string | null
+    opencode_pwd_note?: string
     history?: WildV2IterationHistory[]
     started_at?: number
     finished_at?: number | null


### PR DESCRIPTION
Summary:
- surface the agent workdir and best-effort OpenCode cwd in `WildLoopDebugPanel`
- extend `WildV2Status`/engine metadata so the panel can receive workdir/opencode pwd info and notes
- clarify the planning/run display messages with step number, role, and goal context

Testing:
- Not run (not requested)