### PR TITLE
ui: Add collapsible user messages and adjustable wild loop heights

### DIFF
--- a/components/chat-message.tsx
+++ b/components/chat-message.tsx
@@ -120,6 +120,7 @@ export function ChatMessage({
 }: ChatMessageProps) {
   const [isThinkingOpen, setIsThinkingOpen] = useState(false)
   const [isChartOpen, setIsChartOpen] = useState(true)
+  const [isUserMessageExpanded, setIsUserMessageExpanded] = useState(false)
   const [selectionReplyUi, setSelectionReplyUi] = useState<{
     text: string
     x: number
@@ -556,10 +557,14 @@ export function ChatMessage({
     const hasExcerptCard = Boolean(parsedUserReply.excerpt)
     const userBody = hasExcerptCard ? parsedUserReply.body : message.content
     const excerptLineCount = parsedUserReply.excerpt ? parsedUserReply.excerpt.split('\n').length : 0
+    const collapsedPreviewSource = (userBody || parsedUserReply.excerpt || message.content)
+      .replace(/\s+/g, ' ')
+      .trim()
+    const collapsedPreview = collapsedPreviewSource || 'User message'
 
     return (
       <div className="px-0.5 py-2 min-w-0 overflow-hidden">
-        {hasExcerptCard && parsedUserReply.excerpt && (
+        {isUserMessageExpanded && hasExcerptCard && parsedUserReply.excerpt && (
           <div className="mb-2 flex justify-start">
             <div className="w-[220px] rounded-2xl border border-border/80 bg-card/80 p-3 shadow-sm">
               <p className="text-sm font-medium leading-tight text-foreground break-words">
@@ -575,9 +580,25 @@ export function ChatMessage({
           </div>
         )}
         <div className="border-l-4 border-primary px-3 py-1">
-          <div className="space-y-1 text-base leading-relaxed text-foreground break-words">
-            {renderMarkdown(userBody)}
-          </div>
+          <button
+            type="button"
+            onClick={() => setIsUserMessageExpanded((prev) => !prev)}
+            className="flex w-full items-start gap-1.5 text-left"
+          >
+            {isUserMessageExpanded ? (
+              <ChevronDown className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            )}
+            <span className={`${isUserMessageExpanded ? 'whitespace-pre-wrap break-words' : 'truncate'} flex-1 text-base leading-relaxed text-foreground`}>
+              {collapsedPreview}
+            </span>
+          </button>
+          {isUserMessageExpanded && (
+            <div className="mt-1.5 space-y-1 text-base leading-relaxed text-foreground break-words">
+              {renderMarkdown(userBody)}
+            </div>
+          )}
         </div>
       </div>
     )

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -105,6 +105,12 @@ export function SettingsDialog({
   const [wildLoopHistoryFontSizeInput, setWildLoopHistoryFontSizeInput] = useState<string>(
     settings.appearance.wildLoopHistoryFontSizePx?.toString() ?? ''
   )
+  const [wildLoopTasksBoxHeightInput, setWildLoopTasksBoxHeightInput] = useState<string>(
+    settings.appearance.wildLoopTasksBoxHeightPx?.toString() ?? ''
+  )
+  const [wildLoopHistoryBoxHeightInput, setWildLoopHistoryBoxHeightInput] = useState<string>(
+    settings.appearance.wildLoopHistoryBoxHeightPx?.toString() ?? ''
+  )
 
   // Sync local inputs when settings change externally (e.g. reset)
   React.useEffect(() => {
@@ -142,6 +148,14 @@ export function SettingsDialog({
   React.useEffect(() => {
     setWildLoopHistoryFontSizeInput(settings.appearance.wildLoopHistoryFontSizePx?.toString() ?? '')
   }, [settings.appearance.wildLoopHistoryFontSizePx])
+
+  React.useEffect(() => {
+    setWildLoopTasksBoxHeightInput(settings.appearance.wildLoopTasksBoxHeightPx?.toString() ?? '')
+  }, [settings.appearance.wildLoopTasksBoxHeightPx])
+
+  React.useEffect(() => {
+    setWildLoopHistoryBoxHeightInput(settings.appearance.wildLoopHistoryBoxHeightPx?.toString() ?? '')
+  }, [settings.appearance.wildLoopHistoryBoxHeightPx])
 
   // Sync apiUrlInput when apiUrl changes (e.g. on reset)
   React.useEffect(() => {
@@ -612,6 +626,58 @@ export function SettingsDialog({
     updateAppearanceSettings({ wildLoopHistoryFontSizePx: clamped })
     setWildLoopHistoryFontSizeInput(clamped.toString())
   }
+
+  const handleWildLoopTasksBoxHeightChange = (value: string, currentInput: string) => {
+    if (!currentInput && value === '160') {
+      setWildLoopTasksBoxHeightInput('420')
+      updateAppearanceSettings({ wildLoopTasksBoxHeightPx: 420 })
+      return
+    }
+    setWildLoopTasksBoxHeightInput(value)
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed) && parsed >= 160 && parsed <= 1200) {
+      updateAppearanceSettings({ wildLoopTasksBoxHeightPx: parsed })
+    }
+  }
+
+  const handleWildLoopTasksBoxHeightBlur = (value: string) => {
+    if (!value.trim()) {
+      updateAppearanceSettings({ wildLoopTasksBoxHeightPx: null })
+      setWildLoopTasksBoxHeightInput('')
+      return
+    }
+    const parsed = Number(value)
+    if (Number.isNaN(parsed)) return
+    const clamped = Math.max(160, Math.min(1200, parsed))
+    updateAppearanceSettings({ wildLoopTasksBoxHeightPx: clamped })
+    setWildLoopTasksBoxHeightInput(clamped.toString())
+  }
+
+  const handleWildLoopHistoryBoxHeightChange = (value: string, currentInput: string) => {
+    if (!currentInput && value === '120') {
+      setWildLoopHistoryBoxHeightInput('300')
+      updateAppearanceSettings({ wildLoopHistoryBoxHeightPx: 300 })
+      return
+    }
+    setWildLoopHistoryBoxHeightInput(value)
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed) && parsed >= 120 && parsed <= 1000) {
+      updateAppearanceSettings({ wildLoopHistoryBoxHeightPx: parsed })
+    }
+  }
+
+  const handleWildLoopHistoryBoxHeightBlur = (value: string) => {
+    if (!value.trim()) {
+      updateAppearanceSettings({ wildLoopHistoryBoxHeightPx: null })
+      setWildLoopHistoryBoxHeightInput('')
+      return
+    }
+    const parsed = Number(value)
+    if (Number.isNaN(parsed)) return
+    const clamped = Math.max(120, Math.min(1000, parsed))
+    updateAppearanceSettings({ wildLoopHistoryBoxHeightPx: clamped })
+    setWildLoopHistoryBoxHeightInput(clamped.toString())
+  }
   const handleAlertsToggle = (enabled: boolean) => {
     onSettingsChange({
       ...settings,
@@ -942,6 +1008,24 @@ export function SettingsDialog({
 
                   <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
+                      <Label htmlFor="wild-loop-tasks-box-height-dialog" className="text-xs">Wild Loop Tasks Box Height (px) <span className="font-normal text-muted-foreground">160–1200</span></Label>
+                      <p className="text-[11px] text-muted-foreground">Max height of the tasks.md scroll area in the Wild Loop Debug panel</p>
+                    </div>
+                    <Input
+                      id="wild-loop-tasks-box-height-dialog"
+                      type="number"
+                      min={160}
+                      max={1200}
+                      value={wildLoopTasksBoxHeightInput}
+                      onChange={(e) => handleWildLoopTasksBoxHeightChange(e.target.value, wildLoopTasksBoxHeightInput)}
+                      onBlur={(e) => handleWildLoopTasksBoxHeightBlur(e.target.value)}
+                      placeholder="420"
+                      className="h-8 w-24 text-xs"
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                    <div>
                       <Label htmlFor="custom-accent-color-dialog" className="text-xs">Accent Color</Label>
                       <p className="text-[11px] text-muted-foreground">Hex color for --accent (example: #fb923c)</p>
                     </div>
@@ -973,6 +1057,24 @@ export function SettingsDialog({
                     />
                   </div>
 
+                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                    <div>
+                      <Label htmlFor="wild-loop-history-box-height-dialog" className="text-xs">Wild Loop History Box Height (px) <span className="font-normal text-muted-foreground">120–1000</span></Label>
+                      <p className="text-[11px] text-muted-foreground">Max height of iteration history list in the Wild Loop Debug panel</p>
+                    </div>
+                    <Input
+                      id="wild-loop-history-box-height-dialog"
+                      type="number"
+                      min={120}
+                      max={1000}
+                      value={wildLoopHistoryBoxHeightInput}
+                      onChange={(e) => handleWildLoopHistoryBoxHeightChange(e.target.value, wildLoopHistoryBoxHeightInput)}
+                      onBlur={(e) => handleWildLoopHistoryBoxHeightBlur(e.target.value)}
+                      placeholder="300"
+                      className="h-8 w-24 text-xs"
+                    />
+                  </div>
+
                   <div className="flex justify-end">
                     <Button
                       variant="ghost"
@@ -988,6 +1090,8 @@ export function SettingsDialog({
                           customAccentColor: null,
                           wildLoopTasksFontSizePx: null,
                           wildLoopHistoryFontSizePx: null,
+                          wildLoopTasksBoxHeightPx: null,
+                          wildLoopHistoryBoxHeightPx: null,
                         })
                       }
                     >

--- a/components/settings-page-content.tsx
+++ b/components/settings-page-content.tsx
@@ -92,6 +92,12 @@ export function SettingsPageContent({
   const [wildLoopHistoryFontSizeInput, setWildLoopHistoryFontSizeInput] = useState<string>(
     settings.appearance.wildLoopHistoryFontSizePx?.toString() ?? ''
   )
+  const [wildLoopTasksBoxHeightInput, setWildLoopTasksBoxHeightInput] = useState<string>(
+    settings.appearance.wildLoopTasksBoxHeightPx?.toString() ?? ''
+  )
+  const [wildLoopHistoryBoxHeightInput, setWildLoopHistoryBoxHeightInput] = useState<string>(
+    settings.appearance.wildLoopHistoryBoxHeightPx?.toString() ?? ''
+  )
 
   React.useEffect(() => {
     setApiUrlInput(apiUrl)
@@ -137,6 +143,14 @@ export function SettingsPageContent({
   React.useEffect(() => {
     setWildLoopHistoryFontSizeInput(settings.appearance.wildLoopHistoryFontSizePx?.toString() ?? '')
   }, [settings.appearance.wildLoopHistoryFontSizePx])
+
+  React.useEffect(() => {
+    setWildLoopTasksBoxHeightInput(settings.appearance.wildLoopTasksBoxHeightPx?.toString() ?? '')
+  }, [settings.appearance.wildLoopTasksBoxHeightPx])
+
+  React.useEffect(() => {
+    setWildLoopHistoryBoxHeightInput(settings.appearance.wildLoopHistoryBoxHeightPx?.toString() ?? '')
+  }, [settings.appearance.wildLoopHistoryBoxHeightPx])
 
   React.useEffect(() => {
     if (!focusAuthToken) return
@@ -594,6 +608,58 @@ export function SettingsPageContent({
     updateAppearanceSettings({ wildLoopHistoryFontSizePx: clamped })
     setWildLoopHistoryFontSizeInput(clamped.toString())
   }
+
+  const handleWildLoopTasksBoxHeightChange = (value: string, currentInput: string) => {
+    if (!currentInput && value === '160') {
+      setWildLoopTasksBoxHeightInput('420')
+      updateAppearanceSettings({ wildLoopTasksBoxHeightPx: 420 })
+      return
+    }
+    setWildLoopTasksBoxHeightInput(value)
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed) && parsed >= 160 && parsed <= 1200) {
+      updateAppearanceSettings({ wildLoopTasksBoxHeightPx: parsed })
+    }
+  }
+
+  const handleWildLoopTasksBoxHeightBlur = (value: string) => {
+    if (!value.trim()) {
+      updateAppearanceSettings({ wildLoopTasksBoxHeightPx: null })
+      setWildLoopTasksBoxHeightInput('')
+      return
+    }
+    const parsed = Number(value)
+    if (Number.isNaN(parsed)) return
+    const clamped = Math.max(160, Math.min(1200, parsed))
+    updateAppearanceSettings({ wildLoopTasksBoxHeightPx: clamped })
+    setWildLoopTasksBoxHeightInput(clamped.toString())
+  }
+
+  const handleWildLoopHistoryBoxHeightChange = (value: string, currentInput: string) => {
+    if (!currentInput && value === '120') {
+      setWildLoopHistoryBoxHeightInput('300')
+      updateAppearanceSettings({ wildLoopHistoryBoxHeightPx: 300 })
+      return
+    }
+    setWildLoopHistoryBoxHeightInput(value)
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed) && parsed >= 120 && parsed <= 1000) {
+      updateAppearanceSettings({ wildLoopHistoryBoxHeightPx: parsed })
+    }
+  }
+
+  const handleWildLoopHistoryBoxHeightBlur = (value: string) => {
+    if (!value.trim()) {
+      updateAppearanceSettings({ wildLoopHistoryBoxHeightPx: null })
+      setWildLoopHistoryBoxHeightInput('')
+      return
+    }
+    const parsed = Number(value)
+    if (Number.isNaN(parsed)) return
+    const clamped = Math.max(120, Math.min(1000, parsed))
+    updateAppearanceSettings({ wildLoopHistoryBoxHeightPx: clamped })
+    setWildLoopHistoryBoxHeightInput(clamped.toString())
+  }
   const handleAlertsToggle = (enabled: boolean) => {
     onSettingsChange({
       ...settings,
@@ -920,6 +986,24 @@ export function SettingsPageContent({
 
                   <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
+                      <Label htmlFor="wild-loop-tasks-box-height" className="text-xs">Wild Loop Tasks Box Height (px) <span className="font-normal text-muted-foreground">160–1200</span></Label>
+                      <p className="text-[11px] text-muted-foreground">Max height of the tasks.md scroll area in the Wild Loop Debug panel</p>
+                    </div>
+                    <Input
+                      id="wild-loop-tasks-box-height"
+                      type="number"
+                      min={160}
+                      max={1200}
+                      value={wildLoopTasksBoxHeightInput}
+                      onChange={(e) => handleWildLoopTasksBoxHeightChange(e.target.value, wildLoopTasksBoxHeightInput)}
+                      onBlur={(e) => handleWildLoopTasksBoxHeightBlur(e.target.value)}
+                      placeholder="420"
+                      className="h-8 w-24 text-xs"
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                    <div>
                       <Label htmlFor="custom-accent-color" className="text-xs">Accent Color</Label>
                       <p className="text-[11px] text-muted-foreground">Hex color for --accent (example: #fb923c)</p>
                     </div>
@@ -951,6 +1035,24 @@ export function SettingsPageContent({
                     />
                   </div>
 
+                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                    <div>
+                      <Label htmlFor="wild-loop-history-box-height" className="text-xs">Wild Loop History Box Height (px) <span className="font-normal text-muted-foreground">120–1000</span></Label>
+                      <p className="text-[11px] text-muted-foreground">Max height of iteration history list in the Wild Loop Debug panel</p>
+                    </div>
+                    <Input
+                      id="wild-loop-history-box-height"
+                      type="number"
+                      min={120}
+                      max={1000}
+                      value={wildLoopHistoryBoxHeightInput}
+                      onChange={(e) => handleWildLoopHistoryBoxHeightChange(e.target.value, wildLoopHistoryBoxHeightInput)}
+                      onBlur={(e) => handleWildLoopHistoryBoxHeightBlur(e.target.value)}
+                      placeholder="300"
+                      className="h-8 w-24 text-xs"
+                    />
+                  </div>
+
                   <div className="flex justify-end">
                     <Button
                       variant="ghost"
@@ -966,6 +1068,8 @@ export function SettingsPageContent({
                           customAccentColor: null,
                           wildLoopTasksFontSizePx: null,
                           wildLoopHistoryFontSizePx: null,
+                          wildLoopTasksBoxHeightPx: null,
+                          wildLoopHistoryBoxHeightPx: null,
                         })
                       }
                     >

--- a/components/wild-loop-debug-panel.tsx
+++ b/components/wild-loop-debug-panel.tsx
@@ -203,6 +203,8 @@ export function WildLoopDebugPanel({ onClose }: WildLoopDebugPanelProps) {
     const refreshInterval = settings.developer?.debugRefreshIntervalSeconds ?? 2
     const tasksFontSizePx = Math.max(12, Math.min(28, settings.appearance.wildLoopTasksFontSizePx ?? 16))
     const historyFontSizePx = Math.max(12, Math.min(28, settings.appearance.wildLoopHistoryFontSizePx ?? 15))
+    const tasksBoxHeightPx = Math.max(160, Math.min(1200, settings.appearance.wildLoopTasksBoxHeightPx ?? 420))
+    const historyBoxHeightPx = Math.max(120, Math.min(1000, settings.appearance.wildLoopHistoryBoxHeightPx ?? 300))
     const parsedPlan = useMemo(
         () => parseTasksMarkdown(v2Status?.plan ?? ''),
         [v2Status?.plan]
@@ -543,7 +545,7 @@ export function WildLoopDebugPanel({ onClose }: WildLoopDebugPanelProps) {
                                                         {planCounts.todo} todo
                                                     </span>
                                                 </div>
-                                                <div className="max-h-[320px] overflow-y-auto px-2 py-1.5">
+                                                <div className="overflow-y-auto px-2 py-1.5" style={{ maxHeight: `${tasksBoxHeightPx}px` }}>
                                                     <div className="space-y-0.5" style={{ fontSize: `${tasksFontSizePx}px`, lineHeight: 1.55 }}>
                                                         {parsedPlan.map((line) => {
                                                             if (line.kind === 'spacer') {
@@ -713,7 +715,7 @@ export function WildLoopDebugPanel({ onClose }: WildLoopDebugPanelProps) {
                                                 {allHistoryExpanded ? 'Collapse all' : 'Expand all'}
                                             </button>
                                         </div>
-                                        <div className="space-y-1.5 max-h-[220px] overflow-y-auto pr-1">
+                                        <div className="space-y-1.5 overflow-y-auto pr-1" style={{ maxHeight: `${historyBoxHeightPx}px` }}>
                                             {reversedHistory.map((h) => {
                                                 const isExpanded = expandedHistoryRows[h.iteration] === true
                                                 const summaryPreview = stripMarkdownSyntax(h.summary || '')

--- a/lib/app-settings.tsx
+++ b/lib/app-settings.tsx
@@ -48,6 +48,8 @@ export const defaultAppSettings: AppSettings = {
     chatInputInitialHeightPx: null,
     wildLoopTasksFontSizePx: null,
     wildLoopHistoryFontSizePx: null,
+    wildLoopTasksBoxHeightPx: null,
+    wildLoopHistoryBoxHeightPx: null,
     showStarterCards: false,
     showSidebarNewChatButton: false,
   },
@@ -251,6 +253,12 @@ function readStoredSettings(): AppSettings {
     const wildLoopHistoryFontSizePxFromBlob = sanitizePositiveNumber(
       parsed?.appearance?.wildLoopHistoryFontSizePx,
     );
+    const wildLoopTasksBoxHeightPxFromBlob = sanitizePositiveNumber(
+      parsed?.appearance?.wildLoopTasksBoxHeightPx,
+    );
+    const wildLoopHistoryBoxHeightPxFromBlob = sanitizePositiveNumber(
+      parsed?.appearance?.wildLoopHistoryBoxHeightPx,
+    );
 
     const storedTheme = localStorage.getItem(STORAGE_KEY_APPEARANCE_THEME);
     const storedFontSize = localStorage.getItem(
@@ -350,6 +358,12 @@ function readStoredSettings(): AppSettings {
         wildLoopHistoryFontSizePx:
           wildLoopHistoryFontSizePxFromBlob ??
           defaultAppSettings.appearance.wildLoopHistoryFontSizePx,
+        wildLoopTasksBoxHeightPx:
+          wildLoopTasksBoxHeightPxFromBlob ??
+          defaultAppSettings.appearance.wildLoopTasksBoxHeightPx,
+        wildLoopHistoryBoxHeightPx:
+          wildLoopHistoryBoxHeightPxFromBlob ??
+          defaultAppSettings.appearance.wildLoopHistoryBoxHeightPx,
         showStarterCards:
           parsed?.appearance?.showStarterCards ??
           defaultAppSettings.appearance.showStarterCards,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -98,6 +98,8 @@ export interface AppSettings {
     customAccentColor?: string | null;
     wildLoopTasksFontSizePx?: number | null;
     wildLoopHistoryFontSizePx?: number | null;
+    wildLoopTasksBoxHeightPx?: number | null;
+    wildLoopHistoryBoxHeightPx?: number | null;
     showStarterCards?: boolean;
     showSidebarNewChatButton?: boolean;
     starterCardTemplates?: Record<string, string>;


### PR DESCRIPTION
Summary
- add a toggle-able, one-line preview for user messages that expands into the full markdown content when clicked
- expose new settings for configuring the Wild Loop tasks/history box heights with validation and sensible defaults
- apply the configurable heights in the Wild Loop debug panel and persist the values through app settings

Testing
- Not run (not requested)