### PR TITLE
fix: auto-start runs in tmux and match Runs header style to Events

### DIFF
--- a/components/runs-view.tsx
+++ b/components/runs-view.tsx
@@ -1815,7 +1815,7 @@ export function RunsView({
     <>
       <div className="flex flex-col h-full overflow-hidden">
         {/* Top Nav Bar */}
-        <div className="flex items-center justify-between border-b border-border bg-card/80 px-3 py-1.5 backdrop-blur-sm shrink-0">
+        <div className="flex items-center justify-between border-b border-border bg-card/80 px-4 py-3 backdrop-blur-sm shrink-0">
           <div className="flex items-center gap-2">
             {showDesktopSidebarToggle && onDesktopSidebarToggle && (
               <Button
@@ -1829,7 +1829,12 @@ export function RunsView({
                 <span className="sr-only">Show sidebar</span>
               </Button>
             )}
-            <h2 className="text-xs font-medium text-foreground">Runs</h2>
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Runs</h2>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {overview.total} run{overview.total !== 1 ? 's' : ''} total
+              </p>
+            </div>
           </div>
           <div className="flex items-center gap-1.5">
             <Tooltip>


### PR DESCRIPTION
## Changes

### Auto-Start Fix (server.py)
The `create_run` endpoint correctly set `status=queued` when `auto_start=True`, but never actually launched the run in tmux. This mirrors the working pattern from `rerun_run`:

```python
if initial_status == "queued":
    launch_run_in_tmux(run_id, run_data)
    if run_data.get("sweep_id"):
        recompute_sweep_state(run_data["sweep_id"])
    save_runs_state()
```

### Runs Header Styling (runs-view.tsx)
Updated the Runs overview page header to match the Events page:
- Title: `text-xs font-medium` → `text-lg font-semibold`
- Added subtitle showing total run count
- Adjusted container padding (`px-3 py-1.5` → `px-4 py-3`)