### PR TITLE
security: harden ngrok tunnels and backend server

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -780,6 +780,7 @@ wait_for_ngrok_url() {
 }
 
 start_tunnels() {
+  local auth_token="${1:-}"
   require_cmd tmux
   require_cmd ngrok
   require_cmd python3
@@ -795,7 +796,14 @@ start_tunnels() {
     die "tmux session ${TMUX_SESSION_NAME} is not running. Start services first."
   fi
 
-  tmux_replace_window "$TMUX_SESSION_NAME" "ngrok-backend" "ngrok http 127.0.0.1:${BACKEND_PORT}"
+  # Build ngrok auth flag — if an auth token is available, require HTTP basic-auth
+  # at the ngrok edge so the public URL is not accessible without credentials.
+  local ngrok_auth_flag=""
+  if [ -n "$auth_token" ]; then
+    ngrok_auth_flag="--basic-auth ra:${auth_token}"
+  fi
+
+  tmux_replace_window "$TMUX_SESSION_NAME" "ngrok-backend" "ngrok http ${ngrok_auth_flag} 127.0.0.1:${BACKEND_PORT}"
   BACKEND_PUBLIC_URL="$(wait_for_ngrok_url "$BACKEND_PORT" 30 || true)"
   if [ -z "$BACKEND_PUBLIC_URL" ]; then
     die "Could not read backend ngrok URL from http://127.0.0.1:4040/api/tunnels"
@@ -816,7 +824,7 @@ start_tunnels() {
     tmux_replace_window "$TMUX_SESSION_NAME" "frontend" "$(build_frontend_command "$FRONTEND_API_URL")"
     wait_for_http_ok "http://127.0.0.1:${FRONTEND_PORT}" 45 "Frontend" || true
 
-    tmux_replace_window "$TMUX_SESSION_NAME" "ngrok-frontend" "ngrok http 127.0.0.1:${FRONTEND_PORT}"
+    tmux_replace_window "$TMUX_SESSION_NAME" "ngrok-frontend" "ngrok http ${ngrok_auth_flag} 127.0.0.1:${FRONTEND_PORT}"
     FRONTEND_PUBLIC_URL="$(wait_for_ngrok_url "$FRONTEND_PORT" 30 || true)"
     if [ -z "$FRONTEND_PUBLIC_URL" ]; then
       die "Could not read frontend ngrok URL from http://127.0.0.1:4040/api/tunnels"
@@ -1216,7 +1224,7 @@ cmd_start() {
   write_runtime_file
 
   if [ "$with_tunnel" -eq 1 ]; then
-    start_tunnels
+    start_tunnels "$auth_token"
     write_runtime_file
   fi
 
@@ -1254,7 +1262,10 @@ cmd_tunnel() {
   init_project_context "$project_root"
   load_runtime_file_if_exists
 
-  start_tunnels
+  ensure_auth_token
+  local auth_token
+  auth_token="$(get_auth_token)"
+  start_tunnels "$auth_token"
   write_runtime_file
 
   cat <<EOF

--- a/scripts/research-agent
+++ b/scripts/research-agent
@@ -749,6 +749,7 @@ wait_for_ngrok_url() {
 }
 
 start_tunnels() {
+  local auth_token="${1:-}"
   require_cmd tmux
   require_cmd ngrok
   require_cmd python3
@@ -764,7 +765,14 @@ start_tunnels() {
     die "tmux session ${TMUX_SESSION_NAME} is not running. Start services first."
   fi
 
-  tmux_replace_window "$TMUX_SESSION_NAME" "ngrok-backend" "ngrok http 127.0.0.1:${BACKEND_PORT}"
+  # Build ngrok auth flag — if an auth token is available, require HTTP basic-auth
+  # at the ngrok edge so the public URL is not accessible without credentials.
+  local ngrok_auth_flag=""
+  if [ -n "$auth_token" ]; then
+    ngrok_auth_flag="--basic-auth ra:${auth_token}"
+  fi
+
+  tmux_replace_window "$TMUX_SESSION_NAME" "ngrok-backend" "ngrok http ${ngrok_auth_flag} 127.0.0.1:${BACKEND_PORT}"
   BACKEND_PUBLIC_URL="$(wait_for_ngrok_url "$BACKEND_PORT" 30 || true)"
   if [ -z "$BACKEND_PUBLIC_URL" ]; then
     die "Could not read backend ngrok URL from http://127.0.0.1:4040/api/tunnels"
@@ -785,7 +793,7 @@ start_tunnels() {
     tmux_replace_window "$TMUX_SESSION_NAME" "frontend" "$(build_frontend_command "$FRONTEND_API_URL")"
     wait_for_http_ok "http://127.0.0.1:${FRONTEND_PORT}" 45 "Frontend" || true
 
-    tmux_replace_window "$TMUX_SESSION_NAME" "ngrok-frontend" "ngrok http 127.0.0.1:${FRONTEND_PORT}"
+    tmux_replace_window "$TMUX_SESSION_NAME" "ngrok-frontend" "ngrok http ${ngrok_auth_flag} 127.0.0.1:${FRONTEND_PORT}"
     FRONTEND_PUBLIC_URL="$(wait_for_ngrok_url "$FRONTEND_PORT" 30 || true)"
     if [ -z "$FRONTEND_PUBLIC_URL" ]; then
       die "Could not read frontend ngrok URL from http://127.0.0.1:4040/api/tunnels"
@@ -1185,7 +1193,7 @@ cmd_start() {
   write_runtime_file
 
   if [ "$with_tunnel" -eq 1 ]; then
-    start_tunnels
+    start_tunnels "$auth_token"
     write_runtime_file
   fi
 
@@ -1223,7 +1231,10 @@ cmd_tunnel() {
   init_project_context "$project_root"
   load_runtime_file_if_exists
 
-  start_tunnels
+  ensure_auth_token
+  local auth_token
+  auth_token="$(get_auth_token)"
+  start_tunnels "$auth_token"
   write_runtime_file
 
   cat <<EOF


### PR DESCRIPTION
## Summary

This PR adds four layers of security hardening to the research-agent server and ngrok tunnel setup.

### Changes

1. **Ngrok HTTP Basic Auth** — Ngrok tunnels now require basic authentication (username: `ra`, password: the generated auth token). Applied to both backend and frontend tunnels in `scripts/research-agent` and `install.sh`.

2. **Security Response Headers** — New middleware in `server.py` adds security headers to every response:
   - `X-Content-Type-Options: nosniff`
   - `X-Frame-Options: DENY`
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy: camera=(), microphone=(), geolocation=()`

3. **CORS Restriction** — `allow_origins` changed from `["*"]` to localhost-only (`http://localhost`, `http://127.0.0.1`). Additional origins can be whitelisted via the `RESEARCH_AGENT_CORS_ORIGINS` environment variable (comma-separated). A regex also permits any port on localhost/127.0.0.1.

4. **Health Endpoint Hardening** — `/` and `/health` no longer expose the `workdir` path unless the caller provides a valid `X-Auth-Token` header.

### Breaking Changes

> **Warning**: Users who access ngrok tunnel URLs will now be prompted for credentials. Username: `ra`, password: the auth token printed at startup.

### Files Changed

- `scripts/research-agent` — ngrok auth + tunnel call sites
- `install.sh` — ngrok auth + tunnel call sites (mirrored)
- `server/server.py` — CORS, security headers, health endpoints
