### PR TITLE
feat: add bot issue->PR automation with feedback loop

### DIFF
--- a/.github/workflows/agent-solver.yml
+++ b/.github/workflows/agent-solver.yml
@@ -1,20 +1,19 @@
-name: Agent Issue Solver
+name: Bot Issue Solver
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
-# Only one solver per issue at a time
+# Only one solver run per issue at a time.
 concurrency:
   group: solver-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   solve-issue:
-    # Only trigger when an issue has the 'agent-solve' label
-    if: contains(github.event.issue.labels.*.name, 'agent-solve')
+    if: github.event.label.name == 'bot'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       issues: write
       pull-requests: write
@@ -22,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
 
       - uses: actions/setup-python@v5
         with:
@@ -30,38 +31,149 @@ jobs:
       - name: Install dependencies
         run: pip install modal httpx
 
-      - name: Write issue body to file
+      - name: Persist issue body
         run: |
           cat > /tmp/issue_body.txt << 'ISSUE_BODY_EOF'
           ${{ github.event.issue.body }}
           ISSUE_BODY_EOF
 
-      - name: Comment that the agent is working
+      - name: Build issue session URLs and setup link
+        run: |
+          set -euo pipefail
+          APP_SLUG="research-agent-issue-${{ github.event.issue.number }}"
+          SERVER_URL="https://${{ github.repository_owner }}--${APP_SLUG}-preview-server.modal.run"
+          APP_URL="https://${{ github.repository_owner }}--${APP_SLUG}-preview-app.modal.run"
+          OPENCODE_URL="https://${{ github.repository_owner }}--${APP_SLUG}-preview-opencode.modal.run"
+          ISSUE_AUTH_TOKEN="$(python - <<'PY'
+          import secrets
+          print(secrets.token_hex(32))
+          PY
+          )"
+          SETUP_URL="$(python - <<'PY'
+          import base64
+          import json
+          import os
+          payload = {
+            "apiUrl": os.environ["SERVER_URL"],
+            "authToken": os.environ["ISSUE_AUTH_TOKEN"],
+          }
+          token = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8").rstrip("=")
+          print(f'{os.environ["APP_URL"]}/#setup={token}')
+          PY
+          )"
+
+          echo "APP_SLUG=${APP_SLUG}" >> "$GITHUB_ENV"
+          echo "SERVER_URL=${SERVER_URL}" >> "$GITHUB_ENV"
+          echo "APP_URL=${APP_URL}" >> "$GITHUB_ENV"
+          echo "OPENCODE_URL=${OPENCODE_URL}" >> "$GITHUB_ENV"
+          echo "ISSUE_AUTH_TOKEN=${ISSUE_AUTH_TOKEN}" >> "$GITHUB_ENV"
+          echo "SETUP_URL=${SETUP_URL}" >> "$GITHUB_ENV"
+
+      - name: Deploy per-issue Modal workspace
+        run: |
+          modal deploy modal_preview.py --name "${APP_SLUG}"
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          MODAL_PREVIEW_OPENCODE_URL: ${{ env.OPENCODE_URL }}
+          RESEARCH_AGENT_USER_AUTH_TOKEN: ${{ env.ISSUE_AUTH_TOKEN }}
+
+      - name: Verify issue workspace health
+        run: |
+          set -euo pipefail
+          check_url() {
+            local name="$1"
+            local url="$2"
+            local expected_regex="${3:-}"
+            for attempt in $(seq 1 30); do
+              response="$(curl -sS -L --max-time 15 -w '\n%{http_code}' "${url}" || true)"
+              body="$(echo "${response}" | sed '$d')"
+              code="$(echo "${response}" | tail -n 1)"
+              if [[ "${code}" == "200" ]]; then
+                if [[ -z "${expected_regex}" ]] || echo "${body}" | grep -Eq "${expected_regex}"; then
+                  echo "✅ ${name} healthy (attempt ${attempt})"
+                  return 0
+                fi
+              fi
+              echo "Attempt ${attempt}/30: ${name} not ready yet (status: ${code})"
+              sleep 6
+            done
+            echo "❌ ${name} failed health check"
+            return 1
+          }
+
+          check_url "Issue app" "${APP_URL}"
+          check_url "Issue server" "${SERVER_URL}/health" '"status"[[:space:]]*:[[:space:]]*"ok"'
+          unauth_code="$(curl -sS -o /dev/null -w '%{http_code}' "${SERVER_URL}/sessions" || true)"
+          auth_code="$(curl -sS -o /dev/null -w '%{http_code}' -H "X-Auth-Token: ${ISSUE_AUTH_TOKEN}" "${SERVER_URL}/sessions" || true)"
+          [[ "${unauth_code}" == "401" ]]
+          [[ "${auth_code}" == "200" ]]
+
+      - name: Publish issue session comment
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.createComment({
+            const issueNumber = context.payload.issue.number
+            const marker = '<!-- issue-bot-session -->'
+            const body = [
+              marker,
+              '## 🤖 Bot Session Ready',
+              '',
+              `This issue is now attached to an isolated bot workspace.`,
+              '',
+              `| | |`,
+              `|---|---|`,
+              `| **Open Session (auto-setup)** | [Launch](${process.env.SETUP_URL}) |`,
+              `| **App URL** | [Open App](${process.env.APP_URL}) |`,
+              `| **Server URL** | [API](${process.env.SERVER_URL}) |`,
+              `| **OpenCode URL** | [Endpoint](${process.env.OPENCODE_URL}) |`,
+              `| **Workspace** | \`${process.env.APP_SLUG}\` |`,
+              '',
+              '> The setup link preloads endpoint + token in your browser app settings.',
+              '> Do not share this setup link publicly.',
+              `> Updated at ${new Date().toISOString()}`,
+            ].join('\n')
+
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              body: [
-                '🤖 **Agent Solver Started**',
-                '',
-                `Working on issue #${context.payload.issue.number}...`,
-                `Commit: \`${context.sha.slice(0,7)}\``,
-                `Time: ${new Date().toISOString()}`,
-              ].join('\n'),
-            });
+              issue_number: issueNumber,
+            })
+            const existing = comments.find(c => c.user.type === 'Bot' && c.body.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body,
+              })
+            }
+        env:
+          APP_SLUG: ${{ env.APP_SLUG }}
+          APP_URL: ${{ env.APP_URL }}
+          SERVER_URL: ${{ env.SERVER_URL }}
+          OPENCODE_URL: ${{ env.OPENCODE_URL }}
+          SETUP_URL: ${{ env.SETUP_URL }}
 
-      - name: Run agent solver
+      - name: Run solver for issue
         id: solver
+        continue-on-error: true
         run: |
           python agent_solver.py \
+            --mode solve-issue \
             --issue-number "${{ github.event.issue.number }}" \
             --issue-title "${{ github.event.issue.title }}" \
             --issue-body-file /tmp/issue_body.txt \
             --repo "${{ github.repository }}" \
-            --base-branch "${{ github.event.repository.default_branch }}"
+            --base-branch "${{ github.event.repository.default_branch }}" \
+            --output-file /tmp/solver_result.json
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
@@ -69,32 +181,50 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           RESEARCH_AGENT_KEY: ${{ secrets.RESEARCH_AGENT_KEY }}
 
-      - name: Comment result on issue
+      - name: Publish solver result comment
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
-            const outcome = '${{ steps.solver.outcome }}';
-            const issueNumber = context.payload.issue.number;
-            let body;
-            if (outcome === 'success') {
-              body = [
-                '✅ **Agent Solver Completed**',
-                '',
-                `A PR has been created for issue #${issueNumber}.`,
-                `Check the pull requests tab for branch \`agent/issue-${issueNumber}\`.`,
-              ].join('\n');
-            } else {
-              body = [
-                '❌ **Agent Solver Failed**',
-                '',
-                'The automated solver encountered an error.',
-                'Check the [Actions log](' + context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions) for details.',
-              ].join('\n');
+            const fs = require('fs')
+            const issueNumber = context.payload.issue.number
+            const outcome = '${{ steps.solver.outcome }}'
+            let parsed = {}
+            try {
+              if (fs.existsSync('/tmp/solver_result.json')) {
+                parsed = JSON.parse(fs.readFileSync('/tmp/solver_result.json', 'utf8'))
+              }
+            } catch (err) {
+              parsed = { parse_error: String(err) }
             }
+
+            const prUrl = parsed.pr_url
+            const logTail = String(parsed.agent_output_tail || '').trim()
+            let body
+            if (outcome === 'success' && prUrl) {
+              body = [
+                '✅ **Bot Solver Completed**',
+                '',
+                `Draft PR opened: ${prUrl}`,
+                '',
+                'Use `/bot <instructions>` in PR comments to continue the loop.',
+                logTail ? `\n### Operations tail\n\`\`\`\n${logTail.slice(-1800)}\n\`\`\`` : '',
+              ].join('\n')
+            } else {
+              const errText = parsed.error || 'The automated solver failed.'
+              body = [
+                '❌ **Bot Solver Failed**',
+                '',
+                `${errText}`,
+                '',
+                `Check [Actions logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions).`,
+                logTail ? `\n### Operations tail\n\`\`\`\n${logTail.slice(-1800)}\n\`\`\`` : '',
+              ].join('\n')
+            }
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               body,
-            });
+            })

--- a/.github/workflows/bot-pr-feedback.yml
+++ b/.github/workflows/bot-pr-feedback.yml
@@ -1,0 +1,159 @@
+name: Bot PR Feedback Loop
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# Keep one active worker per PR.
+concurrency:
+  group: bot-feedback-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  handle-feedback:
+    if: >
+      github.event.comment.user.type != 'Bot' &&
+      startsWith(github.event.comment.body, '/bot') &&
+      (
+        github.event_name == 'pull_request_review_comment' ||
+        github.event.issue.pull_request != null
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install modal httpx
+
+      - name: Resolve PR number and persist feedback prompt
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+            PR_NUMBER="${{ github.event.issue.number }}"
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          fi
+          echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_ENV"
+
+          cat > /tmp/bot_feedback.txt << 'BOT_FEEDBACK_EOF'
+          ${{ github.event.comment.body }}
+          BOT_FEEDBACK_EOF
+
+      - name: Mark comment as picked up
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commentId = context.payload.comment.id
+            if (context.eventName === 'issue_comment') {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                content: 'eyes',
+              })
+              return
+            }
+            await github.rest.reactions.createForPullRequestReviewComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: commentId,
+              content: 'eyes',
+            })
+
+      - name: Run follow-up solver on PR branch
+        id: followup
+        continue-on-error: true
+        run: |
+          python agent_solver.py \
+            --mode followup-pr \
+            --pr-number "${PR_NUMBER}" \
+            --feedback-file /tmp/bot_feedback.txt \
+            --repo "${{ github.repository }}" \
+            --output-file /tmp/followup_result.json
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RESEARCH_AGENT_KEY: ${{ secrets.RESEARCH_AGENT_KEY }}
+
+      - name: Post follow-up status to PR
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        with:
+          script: |
+            const fs = require('fs')
+            const prNumber = Number(process.env.PR_NUMBER)
+            const outcome = '${{ steps.followup.outcome }}'
+            const promptRaw = String(process.env.COMMENT_BODY || '').trim()
+            let parsed = {}
+            try {
+              if (fs.existsSync('/tmp/followup_result.json')) {
+                parsed = JSON.parse(fs.readFileSync('/tmp/followup_result.json', 'utf8'))
+              }
+            } catch (err) {
+              parsed = { parse_error: String(err) }
+            }
+
+            const noChanges = Boolean(parsed.no_changes)
+            const logTail = String(parsed.agent_output_tail || '').trim()
+            const diffStat = String(parsed.diff_stat || '').trim()
+            let body
+
+            if (outcome === 'success') {
+              body = [
+                '🤖 **Bot Feedback Run Completed**',
+                '',
+                `Processed command from @${context.payload.comment.user.login}:`,
+                '',
+                '```text',
+                promptRaw.slice(0, 1600),
+                '```',
+                '',
+                noChanges
+                  ? 'No code changes were needed for this feedback.'
+                  : 'Changes were pushed to this PR branch.',
+                diffStat ? `\n### Diff stat\n\`\`\`\n${diffStat}\n\`\`\`` : '',
+                logTail ? `\n### Operations tail\n\`\`\`\n${logTail.slice(-1800)}\n\`\`\`` : '',
+              ].join('\n')
+            } else {
+              const errText = parsed.error || 'The bot failed while processing this command.'
+              body = [
+                '❌ **Bot Feedback Run Failed**',
+                '',
+                `Command from @${context.payload.comment.user.login}:`,
+                '',
+                '```text',
+                promptRaw.slice(0, 1200),
+                '```',
+                '',
+                `${errText}`,
+                '',
+                `Check [Actions logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions).`,
+                logTail ? `\n### Operations tail\n\`\`\`\n${logTail.slice(-1800)}\n\`\`\`` : '',
+              ].join('\n')
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            })

--- a/.github/workflows/bot-session-cleanup.yml
+++ b/.github/workflows/bot-session-cleanup.yml
@@ -1,0 +1,76 @@
+name: Bot Session Cleanup
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    if: >
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'bot')) ||
+      (github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'agent/issue-'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Modal CLI
+        run: pip install modal
+
+      - name: Resolve issue number and stop workspace
+        id: stop
+        run: |
+          set -euo pipefail
+          ISSUE_NUMBER=""
+          if [[ "${{ github.event_name }}" == "issues" ]]; then
+            ISSUE_NUMBER="${{ github.event.issue.number }}"
+          else
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+            ISSUE_NUMBER="$(echo "${BRANCH}" | sed -nE 's/^agent\/issue-([0-9]+)$/\1/p')"
+          fi
+
+          if [[ -z "${ISSUE_NUMBER}" ]]; then
+            echo "No matching issue number; skipping stop."
+            exit 0
+          fi
+
+          APP_NAME="research-agent-issue-${ISSUE_NUMBER}"
+          echo "ISSUE_NUMBER=${ISSUE_NUMBER}" >> "$GITHUB_ENV"
+          echo "APP_NAME=${APP_NAME}" >> "$GITHUB_ENV"
+          modal app stop "${APP_NAME}" || true
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+
+      - name: Comment cleanup status
+        if: env.ISSUE_NUMBER != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isIssue = context.eventName === 'issues'
+            const targetNumber = Number(process.env.ISSUE_NUMBER)
+            const appName = process.env.APP_NAME
+            const body = [
+              '🧹 **Bot Session Cleaned Up**',
+              '',
+              `Stopped Modal workspace: \`${appName}\``,
+              `Timestamp: ${new Date().toISOString()}`,
+            ].join('\n')
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: isIssue ? targetNumber : context.payload.pull_request.number,
+              body,
+            })
+        env:
+          ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
+          APP_NAME: ${{ env.APP_NAME }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -39,7 +39,6 @@ jobs:
           PY
           )"
           echo "PREVIEW_AUTH_TOKEN=${PREVIEW_AUTH_TOKEN}" >> "$GITHUB_ENV"
-          echo "PREVIEW_AUTH_TOKEN=${PREVIEW_AUTH_TOKEN}"
 
       - name: Generate CI frontend config
         run: |
@@ -186,7 +185,6 @@ jobs:
               `| **Preview (Clean)** | [Open App](${previewUrl}) |`,
               `| **OpenCode** | [${opencodeUrl}](${opencodeUrl}) |`,
               `| **Server** | [${serverUrl}](${serverUrl}) |`,
-              `| **Auth Token** | \`${previewAuthToken}\` |`,
               `| **Commit** | \`${sha}\` |`,
               `| **Status** | ✅ Deployed |`,
               '',

--- a/agent_solver.py
+++ b/agent_solver.py
@@ -18,11 +18,9 @@ Usage:
 
 import argparse
 import json
-import os
-import subprocess
 import sys
 import textwrap
-import time
+from typing import Any
 
 
 def run_modal_solver(
@@ -105,7 +103,7 @@ def run_modal_solver(
             "OPENCODE_CONFIG": "/workspace/server/opencode.json",
         }
         result = sp.run(
-            ["opencode", "run", prompt],
+            ["opencode", "run", "--model", "opencode/kimi-k2.5-free", prompt],
             capture_output=True,
             text=True,
             timeout=900,  # 15 min max
@@ -174,17 +172,54 @@ def run_modal_solver(
 
         if resp.status_code in (200, 201):
             pr_data = resp.json()
+            pr_number = pr_data.get("number")
+
+            # Add a structured execution log comment on the PR.
+            log_comment = textwrap.dedent(f"""\
+                🤖 **Agent Solver Log**
+
+                **Source issue:** #{issue_num}
+                **Prompt source:** issue title + body
+
+                ### Prompt excerpt
+                ```
+                {title}
+
+                {(body or "").strip()[:1200]}
+                ```
+
+                ### Operations/output excerpt
+                ```
+                {(agent_output or agent_error or "").strip()[-2000:]}
+                ```
+            """)
+            if pr_number:
+                try:
+                    hx.post(
+                        f"https://api.github.com/repos/{repository}/issues/{pr_number}/comments",
+                        json={"body": log_comment},
+                        headers={
+                            "Authorization": f"Bearer {gh_token}",
+                            "Accept": "application/vnd.github.v3+json",
+                        },
+                        timeout=30,
+                    )
+                except Exception:
+                    pass
+
             return {
                 "success": True,
-                "pr_number": pr_data.get("number"),
+                "pr_number": pr_number,
                 "pr_url": pr_data.get("html_url"),
                 "branch": branch,
+                "agent_output_tail": (agent_output or agent_error or "")[-2000:],
             }
         else:
             return {
                 "success": False,
                 "error": f"PR creation failed ({resp.status_code}): {resp.text[:500]}",
                 "branch": branch,
+                "agent_output_tail": (agent_output or agent_error or "")[-2000:],
             }
 
     # Run the solver
@@ -197,35 +232,204 @@ def run_modal_solver(
             base=base_branch,
         )
 
-    print(json.dumps(result, indent=2))
+    return result
 
-    if not result.get("success"):
-        print(f"ERROR: {result.get('error', 'Unknown error')}", file=sys.stderr)
-        sys.exit(1)
+
+def run_modal_pr_followup(
+    pr_number: int,
+    feedback: str,
+    repo: str,
+):
+    """Run a follow-up agent pass for a PR comment prompt."""
+    import modal
+
+    image = (
+        modal.Image.debian_slim(python_version="3.11")
+        .apt_install("git", "curl", "tmux", "ca-certificates", "gnupg")
+        .run_commands(
+            "mkdir -p /etc/apt/keyrings",
+            "curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg",
+            'echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" > /etc/apt/sources.list.d/nodesource.list',
+            "apt-get update && apt-get install -y nodejs",
+        )
+        .pip_install("httpx")
+        .run_commands("npm install -g opencode || true")
+    )
+
+    app = modal.App(f"research-agent-pr-followup-{pr_number}")
+    secrets = [modal.Secret.from_name("research-agent-solver-secrets")]
+
+    @app.function(image=image, secrets=secrets, timeout=1800, cpu=2.0, memory=2048)
+    def followup(pr_num: int, comment_prompt: str, repository: str) -> dict[str, Any]:
+        import httpx as hx
+        import subprocess as sp
+        import os as _os
+
+        gh_token = _os.environ["GH_PAT"]
+
+        # Discover PR branch.
+        pr_resp = hx.get(
+            f"https://api.github.com/repos/{repository}/pulls/{pr_num}",
+            headers={
+                "Authorization": f"Bearer {gh_token}",
+                "Accept": "application/vnd.github.v3+json",
+            },
+            timeout=30,
+        )
+        if pr_resp.status_code != 200:
+            return {
+                "success": False,
+                "error": f"Unable to load PR #{pr_num}: {pr_resp.status_code}",
+            }
+
+        pr_data = pr_resp.json()
+        branch = (pr_data.get("head") or {}).get("ref")
+        base_branch = (pr_data.get("base") or {}).get("ref")
+        if not branch:
+            return {
+                "success": False,
+                "error": f"PR #{pr_num} has no head branch",
+            }
+
+        clone_url = f"https://x-access-token:{gh_token}@github.com/{repository}.git"
+        sp.run(["git", "clone", "--depth", "50", clone_url, "/workspace"], check=True)
+        _os.chdir("/workspace")
+        sp.run(["git", "config", "user.email", "agent-solver[bot]@users.noreply.github.com"], check=True)
+        sp.run(["git", "config", "user.name", "Agent Solver"], check=True)
+        sp.run(["git", "fetch", "origin", branch], check=True)
+        sp.run(["git", "checkout", branch], check=True)
+        sp.run(["git", "pull", "--ff-only", "origin", branch], check=True)
+
+        prompt = textwrap.dedent(f"""\
+            You are updating an existing pull request based on reviewer feedback.
+
+            ## Pull Request #{pr_num}
+            - Head branch: {branch}
+            - Base branch: {base_branch}
+
+            ## New feedback to address
+            {comment_prompt}
+
+            ## Requirements
+            1. Make only the changes required by the feedback.
+            2. Keep changes minimal and focused.
+            3. Do not modify unrelated files.
+            4. Ensure changes are commit-ready.
+        """)
+
+        opencode_env = {
+            **_os.environ,
+            "OPENCODE_CONFIG": "/workspace/server/opencode.json",
+        }
+        result = sp.run(
+            ["opencode", "run", "--model", "opencode/kimi-k2.5-free", prompt],
+            capture_output=True,
+            text=True,
+            timeout=900,
+            cwd="/workspace",
+            env=opencode_env,
+        )
+        agent_output = result.stdout or ""
+        agent_error = result.stderr or ""
+        output_tail = (agent_output or agent_error or "")[-2000:]
+
+        diff_result = sp.run(["git", "diff", "--stat"], capture_output=True, text=True, cwd="/workspace")
+        untracked = sp.run(["git", "ls-files", "--others", "--exclude-standard"], capture_output=True, text=True, cwd="/workspace")
+        has_changes = bool(diff_result.stdout.strip()) or bool(untracked.stdout.strip())
+
+        if not has_changes:
+            return {
+                "success": True,
+                "pr_number": pr_num,
+                "branch": branch,
+                "no_changes": True,
+                "agent_output_tail": output_tail,
+            }
+
+        sp.run(["git", "add", "-A"], check=True, cwd="/workspace")
+        commit_msg = f"chore: address PR #{pr_num} feedback"
+        sp.run(["git", "commit", "-m", commit_msg], check=True, cwd="/workspace")
+        sp.run(["git", "push", "origin", branch], check=True, cwd="/workspace")
+
+        return {
+            "success": True,
+            "pr_number": pr_num,
+            "branch": branch,
+            "no_changes": False,
+            "agent_output_tail": output_tail,
+            "diff_stat": diff_result.stdout.strip(),
+        }
+
+    with app.run():
+        result = followup.remote(pr_num=pr_number, comment_prompt=feedback, repository=repo)
 
     return result
 
 
+def _clean_feedback_prompt(raw: str) -> str:
+    text = (raw or "").strip()
+    if text.lower().startswith("/bot"):
+        text = text[4:].strip()
+    return text
+
+
 def main():
     parser = argparse.ArgumentParser(description="Agent Solver – solve GitHub issues via Modal")
-    parser.add_argument("--issue-number", type=int, required=True)
-    parser.add_argument("--issue-title", required=True)
-    parser.add_argument("--issue-body-file", required=True, help="Path to file containing issue body")
+    parser.add_argument("--mode", choices=["solve-issue", "followup-pr"], default="solve-issue")
+    parser.add_argument("--issue-number", type=int)
+    parser.add_argument("--issue-title")
+    parser.add_argument("--issue-body-file", help="Path to file containing issue body")
     parser.add_argument("--repo", required=True, help="owner/repo")
     parser.add_argument("--base-branch", default="main")
+    parser.add_argument("--pr-number", type=int)
+    parser.add_argument("--feedback-file", help="Path to file containing follow-up prompt/comment")
+    parser.add_argument("--output-file", help="Optional path to write JSON result")
     args = parser.parse_args()
 
-    # Read issue body from file
-    with open(args.issue_body_file, "r") as f:
-        issue_body = f.read().strip()
+    result: dict[str, Any]
+    if args.mode == "solve-issue":
+        required = [("issue-number", args.issue_number), ("issue-title", args.issue_title), ("issue-body-file", args.issue_body_file)]
+        missing = [name for name, value in required if value in (None, "")]
+        if missing:
+            parser.error(f"Missing required args for solve-issue mode: {', '.join(missing)}")
 
-    run_modal_solver(
-        issue_number=args.issue_number,
-        issue_title=args.issue_title,
-        issue_body=issue_body,
-        repo=args.repo,
-        base_branch=args.base_branch,
-    )
+        with open(args.issue_body_file, "r", encoding="utf-8") as f:
+            issue_body = f.read().strip()
+
+        result = run_modal_solver(
+            issue_number=int(args.issue_number),
+            issue_title=str(args.issue_title),
+            issue_body=issue_body,
+            repo=args.repo,
+            base_branch=args.base_branch,
+        )
+    else:
+        required = [("pr-number", args.pr_number), ("feedback-file", args.feedback_file)]
+        missing = [name for name, value in required if value in (None, "")]
+        if missing:
+            parser.error(f"Missing required args for followup-pr mode: {', '.join(missing)}")
+
+        with open(args.feedback_file, "r", encoding="utf-8") as f:
+            feedback_raw = f.read()
+        feedback = _clean_feedback_prompt(feedback_raw)
+        if not feedback:
+            feedback = "Please review the latest PR comments and make any required updates."
+
+        result = run_modal_pr_followup(
+            pr_number=int(args.pr_number),
+            feedback=feedback,
+            repo=args.repo,
+        )
+
+    rendered = json.dumps(result, indent=2)
+    print(rendered)
+    if args.output_file:
+        with open(args.output_file, "w", encoding="utf-8") as f:
+            f.write(rendered + "\n")
+
+    if not result.get("success"):
+        print(f"ERROR: {result.get('error', 'Unknown error')}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- trigger issue automation when an issue is labeled `bot`
- deploy an isolated per-issue Modal workspace and post an auto-setup link comment
- run the issue solver in Modal using `opencode/kimi-k2.5-free` and open a draft PR
- add a PR feedback loop workflow that processes `/bot ...` comments, reacts with :eyes:, pushes follow-up commits, and posts operation logs
- add cleanup workflow to stop per-issue Modal workspaces on issue/PR close
- remove preview token exposure from PR preview comments/log output

## Usage
1. Open an issue and add the `bot` label.
2. Wait for the bot session comment + draft PR creation.
3. Leave `/bot <instruction>` comments on the PR to request updates.
4. Close issue/PR when done to trigger cleanup.

## Validation
- `python -m py_compile agent_solver.py`
- YAML parse check for all workflow files via Ruby `YAML.load_file`
