### PR TITLE
fix(ci): unblock bot issue workflow setup-link env vars

### DIFF
--- a/.github/workflows/agent-solver.yml
+++ b/.github/workflows/agent-solver.yml
@@ -49,7 +49,7 @@ jobs:
           print(secrets.token_hex(32))
           PY
           )"
-          SETUP_URL="$(python - <<'PY'
+          SETUP_URL="$(SERVER_URL="${SERVER_URL}" ISSUE_AUTH_TOKEN="${ISSUE_AUTH_TOKEN}" APP_URL="${APP_URL}" python - <<'PY'
           import base64
           import json
           import os


### PR DESCRIPTION
## Summary
- fix `Bot Issue Solver` setup-link generation by passing shell vars into the inline Python process
- unblocks issue `bot` label runs before the `modal deploy` step

## Root Cause
`SERVER_URL`, `APP_URL`, and `ISSUE_AUTH_TOKEN` were shell variables, but the Python snippet read them from `os.environ` without exporting/passing them.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/agent-solver.yml")'`
- `python -m py_compile agent_solver.py`

## Related failure
- https://github.com/hao-ai-lab/research-agent/actions/runs/22084535786
