### PR TITLE
ui: Show original user goal in wild loop planning + debug panel

### DIFF
--- a/components/wild-loop-debug-panel.tsx
+++ b/components/wild-loop-debug-panel.tsx
@@ -490,7 +490,7 @@ export function WildLoopDebugPanel({ onClose }: WildLoopDebugPanelProps) {
                                 {/* Goal */}
                                 <div>
                                     <div className="text-[10px] text-muted-foreground mb-1 font-medium">Goal</div>
-                                    <div className="text-foreground">{v2Status.goal || '—'}</div>
+                                    <div className="text-foreground whitespace-pre-wrap break-words">{v2Status.goal || '—'}</div>
                                 </div>
 
                                 {/* Session Dir */}
@@ -861,7 +861,7 @@ export function WildLoopDebugPanel({ onClose }: WildLoopDebugPanelProps) {
                                     <span>{status.iteration}</span>
 
                                     <span className="text-muted-foreground">Goal:</span>
-                                    <span className="truncate" title={status.goal || undefined}>{status.goal || '—'}</span>
+                                    <span className="whitespace-pre-wrap break-words" title={status.goal || undefined}>{status.goal || '—'}</span>
 
                                     <span className="text-muted-foreground">Session:</span>
                                     <span className="font-mono text-[10px] truncate" title={status.session_id || undefined}>

--- a/server/wild_loop_v2.py
+++ b/server/wild_loop_v2.py
@@ -415,7 +415,8 @@ class WildV2Engine:
             display_msg = (
                 "[Wild V2 — Step #0]\n"
                 "Role: plan\n"
-                "Goal: Explore the codebase and write a concrete task checklist in tasks.md."
+                f"Goal: {session.goal}\n"
+                "Task: Create a concrete step-by-step plan."
             )
             logger.debug("[wild-v2] Planning prompt built, length=%d chars", len(planning_prompt))
 

--- a/tests/wild_loop_v2_test.py
+++ b/tests/wild_loop_v2_test.py
@@ -396,3 +396,53 @@ def test_loop_waiting_signal():
         assert engine.session.history[2]["promise"] == "DONE"
 
     asyncio.run(_run())
+
+
+def test_planning_display_message_uses_user_goal():
+    """Planning display message should show the original user goal."""
+
+    async def _run():
+        tmpdir = tempfile.mkdtemp()
+        captured_display_messages = []
+
+        async def mock_send_chat(_chat_session_id, _prompt, display_message):
+            captured_display_messages.append(display_message)
+            if len(captured_display_messages) == 1:
+                return (
+                    "<plan>\n# Tasks\n- [ ] Execute the plan\n</plan>\n"
+                    "<summary>Planning done.</summary>"
+                )
+            return "<summary>Done.</summary>\n<promise>DONE</promise>"
+
+        def mock_render(_skill_id, variables):
+            return f"prompt for {variables['goal']}"
+
+        engine = WildV2Engine(
+            get_workdir=lambda: tmpdir,
+            server_url="http://localhost:10000",
+            send_chat_message=mock_send_chat,
+            render_fn=mock_render,
+        )
+        engine._git_commit = AsyncMock()
+
+        user_goal = "Find the best model setup for CIFAR-10 with reproducible runs."
+        engine.start(goal=user_goal, chat_session_id="chat-test", max_iterations=1)
+
+        # Cancel auto-started task and run manually for deterministic assertions.
+        if engine._task:
+            engine._task.cancel()
+            try:
+                await engine._task
+            except asyncio.CancelledError:
+                pass
+
+        await engine._run_loop()
+
+        assert captured_display_messages
+        planning_display = captured_display_messages[0]
+        assert "Role: plan" in planning_display
+        assert f"Goal: {user_goal}" in planning_display
+        assert "Task: Create a concrete step-by-step plan." in planning_display
+        assert "Explore the codebase and write a concrete task checklist in tasks.md." not in planning_display
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- show the original user prompt as the planning step `Goal` in Wild V2 iteration 0 display text
- keep planning intent explicit by labeling the planning objective as `Task: Create a concrete step-by-step plan.`
- render `Goal` in the debug panel without truncation so long prompts are visible in full
- add a regression test for planning display text to prevent reintroducing the hardcoded fallback goal string

## Validation
- `pytest -q tests/wild_loop_v2_test.py::test_planning_display_message_uses_user_goal`

## Notes
- full `tests/wild_loop_v2_test.py` currently has existing unrelated fallback/render_fn failures on this branch; this change does not introduce those failures.
