### PR TITLE
[Fix] Add system prompt for agent chat mode

### DIFF
--- a/server/prompt_skills/ra_mode_agent/SKILL.md
+++ b/server/prompt_skills/ra_mode_agent/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: "Agent Mode — Research Assistant"
+description: "Default system prompt for agent chat mode. Provides identity, environment context, and server API access."
+variables: ["experiment_context", "server_url", "auth_token"]
+---
+# Research Agent
+
+You are a research assistant for ML experiment tracking. 
+
+## Environment
+
+- Full bash access (files, processes, networking)
+- GPUs available if the host has them
+- tmux sessions for long-running jobs
+- Working directory is the user's project root
+
+{{experiment_context}}
+
+## Server API
+
+Base URL: `{{server_url}}`
+Auth header: `X-Auth-Token: {{auth_token}}`
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/runs` | GET | List all runs |
+| `/runs` | POST | Create a run (`name`, `command`, `workdir`, `auto_start`) |
+| `/runs/{id}/logs` | GET | Get run logs |
+| `/runs/{id}/rerun` | POST | Rerun a finished/failed run |
+| `/sweeps` | GET | List all sweeps |
+| `/sweeps` | POST | Create a parameter sweep |
+| `/alerts` | GET | List alerts |
+| `/plans` | GET | List experiment plans |
+
+Use `curl` with the auth header to call these endpoints.
+
+## Guidelines
+
+- Be concise and direct
+- When the user asks about runs, sweeps, or metrics, check the live state via the API
+- You can launch and monitor training runs — don't tell the user to do it themselves
+- If a task needs multiple steps, explain your approach briefly then act

--- a/server/server.py
+++ b/server/server.py
@@ -3181,6 +3181,15 @@ class ModeConfig:
     build_state: Callable[[str], dict]  # (message) -> template variables
 
 
+def _build_agent_state(_message: str) -> dict:
+    """Build template variables for agent (default chat) mode."""
+    return {
+        "experiment_context": _build_experiment_context(),
+        "server_url": SERVER_CALLBACK_URL,
+        "auth_token": USER_AUTH_TOKEN or "",
+    }
+
+
 def _build_plan_state(message: str) -> dict:
     """Build template variables for plan mode."""
     # Summarize existing plans for context
@@ -3205,6 +3214,7 @@ def _build_plan_state(message: str) -> dict:
 _WILD_SENTINEL = "__wild__"
 
 MODE_REGISTRY: Dict[str, ModeConfig] = {
+    "agent": ModeConfig(skill_id="ra_mode_agent", build_state=_build_agent_state),
     "plan": ModeConfig(skill_id="ra_mode_plan", build_state=_build_plan_state),
     "wild": ModeConfig(skill_id=_WILD_SENTINEL, build_state=lambda _msg: {}),
 }


### PR DESCRIPTION
# Fix: agent chat mode now gets a system prompt

This is a companion pr to https://github.com/hao-ai-lab/research-agent/issues/175

## Problem

The `"agent"` mode (default chat) was missing from `MODE_REGISTRY` in `server.py`. The model received no system prompt — it didn't know it was a research agent with host access, GPUs, or the server API.

## Changes

1. **New skill**: `server/prompt_skills/ra_mode_agent/SKILL.md` — lightweight identity + environment + API reference
2. **New function**: `_build_agent_state()` — builds template variables (experiment context, server URL, auth token)
3. **Registry**: added `"agent"` entry to `MODE_REGISTRY` pointing to the new skill