### PR TITLE
Add setup-sharing link option to settings

### DIFF
--- a/components/settings-page-content.tsx
+++ b/components/settings-page-content.tsx
@@ -33,7 +33,7 @@ import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Separator } from '@/components/ui/separator'
-import { useApiConfig } from '@/lib/api-config'
+import { createSetupShareLink, useApiConfig } from '@/lib/api-config'
 import type { AppSettings } from '@/lib/types'
 
 interface SettingsPageContentProps {
@@ -60,6 +60,7 @@ export function SettingsPageContent({
   const [authTokenInput, setAuthTokenInput] = useState(authToken)
   const [showAuthToken, setShowAuthToken] = useState(false)
   const [authTokenCopied, setAuthTokenCopied] = useState(false)
+  const [setupLinkCopied, setSetupLinkCopied] = useState(false)
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'connected' | 'failed'>('idle')
   const [appearanceAdvancedOpen, setAppearanceAdvancedOpen] = useState(false)
   const authTokenInputRef = React.useRef<HTMLInputElement>(null)
@@ -193,6 +194,31 @@ export function SettingsPageContent({
       setTimeout(() => setAuthTokenCopied(false), 1500)
     } catch (error) {
       console.error('Failed to copy auth token:', error)
+    }
+  }
+
+  const handleCopySetupLink = async () => {
+    const nextApiUrl = apiUrlInput.trim()
+    const nextAuthToken = authTokenInput.trim()
+    if (!nextApiUrl || !nextAuthToken) return
+
+    const confirmed = window.confirm(
+      'You are copying a setup link with the full auth token. Anyone with this link can access this entire session. Continue?'
+    )
+    if (!confirmed) return
+
+    const setupLink = createSetupShareLink({
+      apiUrl: nextApiUrl,
+      authToken: nextAuthToken,
+    })
+    if (!setupLink) return
+
+    try {
+      await navigator.clipboard.writeText(setupLink)
+      setSetupLinkCopied(true)
+      setTimeout(() => setSetupLinkCopied(false), 1500)
+    } catch (error) {
+      console.error('Failed to copy setup link:', error)
     }
   }
 
@@ -1194,6 +1220,26 @@ export function SettingsPageContent({
                       Save
                     </Button>
                   </div>
+                </div>
+
+                <div className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
+                  <Label className="text-xs">Share Setup Link</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Copy a one-click setup link with this server URL and auth token.
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleCopySetupLink}
+                    disabled={!apiUrlInput.trim() || !authTokenInput.trim()}
+                    className="w-full justify-center gap-2"
+                  >
+                    {setupLinkCopied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+                    {setupLinkCopied ? 'Copied' : 'Copy Setup Link'}
+                  </Button>
+                  <p className="text-xs text-amber-700">
+                    Warning: This includes the full auth token. Anyone with the link gets full session access.
+                  </p>
                 </div>
 
                 <div className="flex items-center gap-2">

--- a/lib/api-config.tsx
+++ b/lib/api-config.tsx
@@ -39,6 +39,33 @@ function decodeBase64Url(value: string): string | null {
     }
 }
 
+function encodeBase64Url(value: string): string {
+    return btoa(value)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/g, '')
+}
+
+export function createSetupShareLink(config: { apiUrl: string; authToken: string }): string | null {
+    if (typeof window === 'undefined') {
+        return null
+    }
+
+    const nextApiUrl = config.apiUrl.trim()
+    const nextAuthToken = config.authToken.trim()
+    if (!nextApiUrl || !nextAuthToken) {
+        return null
+    }
+
+    const encodedSetup = encodeBase64Url(JSON.stringify({
+        apiUrl: nextApiUrl,
+        authToken: nextAuthToken,
+    }))
+
+    const baseUrl = `${window.location.origin}${window.location.pathname}`
+    return `${baseUrl}#setup=${encodedSetup}`
+}
+
 function parseLinkSetupConfig(): LinkSetupConfig | null {
     if (typeof window === 'undefined') {
         return null


### PR DESCRIPTION
## Summary
- add helper to build a shareable setup link that includes the API url and auth token encoded into the URL fragment
- add copy-handlers on the settings dialog and page so users can warn before sharing the full auth token and then copy the link
- surface the new action inside the API section UI alongside a contextual warning about the security risk

## Testing
- Not run (not requested)