### PR TITLE
Add support for RESEARCH_AGENT_KEY and use minimax default

### DIFF
--- a/components/file-explorer-view.tsx
+++ b/components/file-explorer-view.tsx
@@ -17,7 +17,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
-import { getAuthToken } from '@/lib/api-config'
+import { getAuthToken, getResearchAgentKey } from '@/lib/api-config'
 
 type ExplorerNodeType = 'file' | 'directory'
 
@@ -108,9 +108,15 @@ export function FileExplorerView({
     }
 
     try {
+      const headers: HeadersInit = { 'X-Auth-Token': getAuthToken() }
+      const researchAgentKey = getResearchAgentKey()
+      if (researchAgentKey) {
+        headers['X-Research-Agent-Key'] = researchAgentKey
+      }
+
       const response = await fetch(`/api/file-explorer/tree?path=${encodeURIComponent(directoryPath)}`, {
         cache: 'no-store',
-        headers: { 'X-Auth-Token': getAuthToken() },
+        headers,
       })
 
       if (!response.ok) {
@@ -148,9 +154,15 @@ export function FileExplorerView({
     setFileError(null)
 
     try {
+      const headers: HeadersInit = { 'X-Auth-Token': getAuthToken() }
+      const researchAgentKey = getResearchAgentKey()
+      if (researchAgentKey) {
+        headers['X-Research-Agent-Key'] = researchAgentKey
+      }
+
       const response = await fetch(`/api/file-explorer/file?path=${encodeURIComponent(filePath)}`, {
         cache: 'no-store',
-        headers: { 'X-Auth-Token': getAuthToken() },
+        headers,
       })
 
       if (!response.ok) {

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -68,11 +68,25 @@ export function SettingsDialog({
   const [showSlackApiKey, setShowSlackApiKey] = useState(false)
 
   // API Configuration
-  const { apiUrl, useMock, authToken, setApiUrl, setUseMock, setAuthToken, resetToDefaults, testConnection } = useApiConfig()
+  const {
+    apiUrl,
+    useMock,
+    authToken,
+    researchAgentKey,
+    setApiUrl,
+    setUseMock,
+    setAuthToken,
+    setResearchAgentKey,
+    resetToDefaults,
+    testConnection,
+  } = useApiConfig()
   const [apiUrlInput, setApiUrlInput] = useState(apiUrl)
   const [authTokenInput, setAuthTokenInput] = useState(authToken)
+  const [researchAgentKeyInput, setResearchAgentKeyInput] = useState(researchAgentKey)
   const [showAuthToken, setShowAuthToken] = useState(false)
+  const [showResearchAgentKey, setShowResearchAgentKey] = useState(false)
   const [authTokenCopied, setAuthTokenCopied] = useState(false)
+  const [researchAgentKeyCopied, setResearchAgentKeyCopied] = useState(false)
   const [setupLinkCopied, setSetupLinkCopied] = useState(false)
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'connected' | 'failed'>('idle')
   const authTokenInputRef = React.useRef<HTMLInputElement>(null)
@@ -167,6 +181,10 @@ export function SettingsDialog({
     setAuthTokenInput(authToken)
   }, [authToken])
 
+  React.useEffect(() => {
+    setResearchAgentKeyInput(researchAgentKey)
+  }, [researchAgentKey])
+
   // Auto-focus auth token input when requested
   React.useEffect(() => {
     if (focusAuthToken && open) {
@@ -185,6 +203,7 @@ export function SettingsDialog({
     const isConnected = await testConnection({
       apiUrl: nextApiUrl,
       authToken: nextAuthToken,
+      researchAgentKey: researchAgentKeyInput.trim(),
     })
     if (isConnected) {
       setApiUrl(nextApiUrl)
@@ -207,6 +226,11 @@ export function SettingsDialog({
     onRefresh?.()
   }
 
+  const handleSaveResearchAgentKey = () => {
+    setResearchAgentKey(researchAgentKeyInput.trim())
+    onRefresh?.()
+  }
+
   const handleCopyAuthToken = async () => {
     if (!authTokenInput.trim()) return
     try {
@@ -215,6 +239,17 @@ export function SettingsDialog({
       setTimeout(() => setAuthTokenCopied(false), 1500)
     } catch (error) {
       console.error('Failed to copy auth token:', error)
+    }
+  }
+
+  const handleCopyResearchAgentKey = async () => {
+    if (!researchAgentKeyInput.trim()) return
+    try {
+      await navigator.clipboard.writeText(researchAgentKeyInput)
+      setResearchAgentKeyCopied(true)
+      setTimeout(() => setResearchAgentKeyCopied(false), 1500)
+    } catch (error) {
+      console.error('Failed to copy RESEARCH_AGENT_KEY:', error)
     }
   }
 
@@ -1224,6 +1259,49 @@ export function SettingsDialog({
                         size="sm"
                         onClick={handleSaveAuthToken}
                         disabled={authTokenInput === authToken}
+                      >
+                        Save
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="research-agent-key" className="text-xs">RESEARCH_AGENT_KEY</Label>
+                    <p className="text-xs text-muted-foreground">Gateway key used by model provider requests</p>
+                    <div className="flex gap-2">
+                      <Input
+                        id="research-agent-key"
+                        type={showResearchAgentKey ? 'text' : 'password'}
+                        placeholder="Enter RESEARCH_AGENT_KEY..."
+                        value={researchAgentKeyInput}
+                        onChange={(e) => setResearchAgentKeyInput(e.target.value)}
+                        className="flex-1"
+                      />
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setShowResearchAgentKey((prev) => !prev)}
+                        className="px-2"
+                        title={showResearchAgentKey ? 'Hide key' : 'Show key'}
+                      >
+                        {showResearchAgentKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                        <span className="sr-only">{showResearchAgentKey ? 'Hide key' : 'Show key'}</span>
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleCopyResearchAgentKey}
+                        disabled={!researchAgentKeyInput.trim()}
+                        className="px-2"
+                        title="Copy RESEARCH_AGENT_KEY"
+                      >
+                        {researchAgentKeyCopied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleSaveResearchAgentKey}
+                        disabled={researchAgentKeyInput.trim() === researchAgentKey}
                       >
                         Save
                       </Button>

--- a/components/settings-page-content.tsx
+++ b/components/settings-page-content.tsx
@@ -55,11 +55,25 @@ export function SettingsPageContent({
   const [slackChannel, setSlackChannel] = useState(settings.integrations.slack?.channel || '')
   const [showSlackApiKey, setShowSlackApiKey] = useState(false)
 
-  const { apiUrl, useMock, authToken, setApiUrl, setUseMock, setAuthToken, resetToDefaults, testConnection } = useApiConfig()
+  const {
+    apiUrl,
+    useMock,
+    authToken,
+    researchAgentKey,
+    setApiUrl,
+    setUseMock,
+    setAuthToken,
+    setResearchAgentKey,
+    resetToDefaults,
+    testConnection,
+  } = useApiConfig()
   const [apiUrlInput, setApiUrlInput] = useState(apiUrl)
   const [authTokenInput, setAuthTokenInput] = useState(authToken)
+  const [researchAgentKeyInput, setResearchAgentKeyInput] = useState(researchAgentKey)
   const [showAuthToken, setShowAuthToken] = useState(false)
+  const [showResearchAgentKey, setShowResearchAgentKey] = useState(false)
   const [authTokenCopied, setAuthTokenCopied] = useState(false)
+  const [researchAgentKeyCopied, setResearchAgentKeyCopied] = useState(false)
   const [setupLinkCopied, setSetupLinkCopied] = useState(false)
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'connected' | 'failed'>('idle')
   const authTokenInputRef = React.useRef<HTMLInputElement>(null)
@@ -106,6 +120,10 @@ export function SettingsPageContent({
   React.useEffect(() => {
     setAuthTokenInput(authToken)
   }, [authToken])
+
+  React.useEffect(() => {
+    setResearchAgentKeyInput(researchAgentKey)
+  }, [researchAgentKey])
 
   // Sync local inputs when settings change externally (e.g. reset)
   React.useEffect(() => {
@@ -167,6 +185,7 @@ export function SettingsPageContent({
     const isConnected = await testConnection({
       apiUrl: nextApiUrl,
       authToken: nextAuthToken,
+      researchAgentKey: researchAgentKeyInput.trim(),
     })
     if (isConnected) {
       setApiUrl(nextApiUrl)
@@ -185,6 +204,10 @@ export function SettingsPageContent({
     setAuthToken(authTokenInput)
   }
 
+  const handleSaveResearchAgentKey = () => {
+    setResearchAgentKey(researchAgentKeyInput.trim())
+  }
+
   const handleCopyAuthToken = async () => {
     if (!authTokenInput.trim()) return
     try {
@@ -193,6 +216,17 @@ export function SettingsPageContent({
       setTimeout(() => setAuthTokenCopied(false), 1500)
     } catch (error) {
       console.error('Failed to copy auth token:', error)
+    }
+  }
+
+  const handleCopyResearchAgentKey = async () => {
+    if (!researchAgentKeyInput.trim()) return
+    try {
+      await navigator.clipboard.writeText(researchAgentKeyInput)
+      setResearchAgentKeyCopied(true)
+      setTimeout(() => setResearchAgentKeyCopied(false), 1500)
+    } catch (error) {
+      console.error('Failed to copy RESEARCH_AGENT_KEY:', error)
     }
   }
 
@@ -1206,6 +1240,49 @@ export function SettingsPageContent({
                       size="sm"
                       onClick={handleSaveAuthToken}
                       disabled={authTokenInput === authToken}
+                    >
+                      Save
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="research-agent-key" className="text-xs">RESEARCH_AGENT_KEY</Label>
+                  <p className="text-xs text-muted-foreground">Gateway key used by model provider requests</p>
+                  <div className="flex gap-2">
+                    <Input
+                      id="research-agent-key"
+                      type={showResearchAgentKey ? 'text' : 'password'}
+                      placeholder="Enter RESEARCH_AGENT_KEY..."
+                      value={researchAgentKeyInput}
+                      onChange={(e) => setResearchAgentKeyInput(e.target.value)}
+                      className="flex-1"
+                    />
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setShowResearchAgentKey((prev) => !prev)}
+                      className="px-2"
+                      title={showResearchAgentKey ? 'Hide key' : 'Show key'}
+                    >
+                      {showResearchAgentKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      <span className="sr-only">{showResearchAgentKey ? 'Hide key' : 'Show key'}</span>
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleCopyResearchAgentKey}
+                      disabled={!researchAgentKeyInput.trim()}
+                      className="px-2"
+                      title="Copy RESEARCH_AGENT_KEY"
+                    >
+                      {researchAgentKeyCopied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleSaveResearchAgentKey}
+                      disabled={researchAgentKeyInput.trim() === researchAgentKey}
                     >
                       Save
                     </Button>

--- a/lib/api-config.tsx
+++ b/lib/api-config.tsx
@@ -6,6 +6,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback } fr
 const STORAGE_KEY_API_URL = 'research-agent-api-url'
 const STORAGE_KEY_USE_MOCK = 'research-agent-use-mock'
 const STORAGE_KEY_AUTH_TOKEN = 'research-agent-auth-token'
+const STORAGE_KEY_RESEARCH_AGENT_KEY = 'research-agent-key'
 
 // Default values (can be overridden via env vars for CI)
 const DEFAULT_API_URL = process.env.NEXT_PUBLIC_DEFAULT_SERVER_URL || 'http://localhost:10000'
@@ -124,11 +125,13 @@ interface ApiConfig {
     apiUrl: string
     useMock: boolean
     authToken: string
+    researchAgentKey: string
     setApiUrl: (url: string) => void
     setUseMock: (useMock: boolean) => void
     setAuthToken: (token: string) => void
+    setResearchAgentKey: (key: string) => void
     resetToDefaults: () => void
-    testConnection: (overrides?: { apiUrl?: string; authToken?: string }) => Promise<boolean>
+    testConnection: (overrides?: { apiUrl?: string; authToken?: string; researchAgentKey?: string }) => Promise<boolean>
 }
 
 const ApiConfigContext = createContext<ApiConfig | null>(null)
@@ -174,10 +177,22 @@ export function getAuthToken(): string {
     return localStorage.getItem(STORAGE_KEY_AUTH_TOKEN) || ''
 }
 
+/**
+ * Get the RESEARCH_AGENT_KEY from localStorage
+ * This can be called outside of React components
+ */
+export function getResearchAgentKey(): string {
+    if (typeof window === 'undefined') {
+        return ''
+    }
+    return localStorage.getItem(STORAGE_KEY_RESEARCH_AGENT_KEY) || ''
+}
+
 export function ApiConfigProvider({ children }: { children: React.ReactNode }) {
     const [apiUrl, setApiUrlState] = useState<string>(DEFAULT_API_URL)
     const [useMock, setUseMockState] = useState<boolean>(DEFAULT_USE_MOCK)
     const [authToken, setAuthTokenState] = useState<string>(DEFAULT_AUTH_TOKEN)
+    const [researchAgentKey, setResearchAgentKeyState] = useState<string>('')
     const [isHydrated, setIsHydrated] = useState(false)
 
     // Load from localStorage on mount
@@ -185,6 +200,7 @@ export function ApiConfigProvider({ children }: { children: React.ReactNode }) {
         const storedUrl = localStorage.getItem(STORAGE_KEY_API_URL)
         const storedMock = localStorage.getItem(STORAGE_KEY_USE_MOCK)
         const storedToken = localStorage.getItem(STORAGE_KEY_AUTH_TOKEN)
+        const storedResearchAgentKey = localStorage.getItem(STORAGE_KEY_RESEARCH_AGENT_KEY)
         const setupConfig = parseLinkSetupConfig()
 
         if (setupConfig?.apiUrl) {
@@ -223,6 +239,10 @@ export function ApiConfigProvider({ children }: { children: React.ReactNode }) {
             localStorage.setItem(STORAGE_KEY_AUTH_TOKEN, DEFAULT_AUTH_TOKEN)
         }
 
+        if (storedResearchAgentKey) {
+            setResearchAgentKeyState(storedResearchAgentKey)
+        }
+
         if (setupConfig) {
             clearLinkSetupHash()
         }
@@ -249,17 +269,28 @@ export function ApiConfigProvider({ children }: { children: React.ReactNode }) {
         }
     }, [])
 
+    const setResearchAgentKey = useCallback((key: string) => {
+        setResearchAgentKeyState(key)
+        if (key) {
+            localStorage.setItem(STORAGE_KEY_RESEARCH_AGENT_KEY, key)
+        } else {
+            localStorage.removeItem(STORAGE_KEY_RESEARCH_AGENT_KEY)
+        }
+    }, [])
+
     const resetToDefaults = useCallback(() => {
         localStorage.removeItem(STORAGE_KEY_API_URL)
         localStorage.removeItem(STORAGE_KEY_USE_MOCK)
         localStorage.removeItem(STORAGE_KEY_AUTH_TOKEN)
+        localStorage.removeItem(STORAGE_KEY_RESEARCH_AGENT_KEY)
         setApiUrlState(resolveEnvApiUrl() || DEFAULT_API_URL)
         setUseMockState(DEFAULT_USE_MOCK)
         setAuthTokenState('')
+        setResearchAgentKeyState('')
     }, [])
 
     const testConnection = useCallback(async (
-        overrides?: { apiUrl?: string; authToken?: string }
+        overrides?: { apiUrl?: string; authToken?: string; researchAgentKey?: string }
     ): Promise<boolean> => {
         if (useMock) {
             return true // Mock is always "connected"
@@ -267,11 +298,15 @@ export function ApiConfigProvider({ children }: { children: React.ReactNode }) {
 
         const targetApiUrl = (overrides?.apiUrl ?? apiUrl).trim()
         const targetAuthToken = overrides?.authToken ?? authToken
+        const targetResearchAgentKey = (overrides?.researchAgentKey ?? researchAgentKey).trim()
 
         try {
             const headers: HeadersInit = {}
             if (targetAuthToken) {
                 headers['X-Auth-Token'] = targetAuthToken
+            }
+            if (targetResearchAgentKey) {
+                headers['X-Research-Agent-Key'] = targetResearchAgentKey
             }
 
             const response = await fetch(`${targetApiUrl}/sessions`, {
@@ -283,7 +318,7 @@ export function ApiConfigProvider({ children }: { children: React.ReactNode }) {
         } catch {
             return false
         }
-    }, [apiUrl, authToken, useMock])
+    }, [apiUrl, authToken, researchAgentKey, useMock])
 
     // Don't render children until hydrated to avoid hydration mismatch
     if (!isHydrated) {
@@ -295,9 +330,11 @@ export function ApiConfigProvider({ children }: { children: React.ReactNode }) {
             apiUrl,
             useMock,
             authToken,
+            researchAgentKey,
             setApiUrl,
             setUseMock,
             setAuthToken,
+            setResearchAgentKey,
             resetToDefaults,
             testConnection,
         }}>

--- a/lib/api-mock.ts
+++ b/lib/api-mock.ts
@@ -64,7 +64,7 @@ const MOCK_MODEL_OPTIONS: ChatModelOption[] = [
         name: 'Kimi K2.5 (Free)',
         context_limit: 200000,
         output_limit: 8192,
-        is_default: true,
+        is_default: false,
     },
     {
         provider_id: 'opencode',
@@ -88,7 +88,7 @@ const MOCK_MODEL_OPTIONS: ChatModelOption[] = [
         provider_id: 'opencode',
         model_id: 'minimax-m2.5-free',
         name: 'minimax-m2.5-free',
-        is_default: false,
+        is_default: true,
     },
     {
         provider_id: 'opencode',
@@ -116,7 +116,7 @@ const MOCK_MODEL_OPTIONS: ChatModelOption[] = [
 
 const DEFAULT_MODEL_SELECTION: SessionModelSelection = {
     provider_id: 'opencode',
-    model_id: 'kimi-k2.5-free',
+    model_id: 'minimax-m2.5-free',
 }
 
 const mockSessions: Map<string, SessionWithMessages> = new Map([

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { getApiUrl, getAuthToken } from './api-config'
+import { getApiUrl, getAuthToken, getResearchAgentKey } from './api-config'
 import type { PromptProvenance } from '@/lib/types'
 
 // Get API URL dynamically at runtime (supports localStorage override)
@@ -17,6 +17,11 @@ function getHeaders(includeContentType: boolean = false): HeadersInit {
     const authToken = getAuthToken()
     if (authToken) {
         headers['X-Auth-Token'] = authToken
+    }
+
+    const researchAgentKey = getResearchAgentKey()
+    if (researchAgentKey) {
+        headers['X-Research-Agent-Key'] = researchAgentKey
     }
 
     return headers

--- a/server/job_sidecar.py
+++ b/server/job_sidecar.py
@@ -300,7 +300,7 @@ def run_alert_judge(context: str, workdir: str | None = None) -> dict | None:
         "If action is ignore, keep message empty.\n"
         f"Context:\n{context}"
     )
-    cmd = ["opencode", "run", "--model", "opencode/kimi-k2.5-free", prompt]
+    cmd = ["opencode", "run", "--model", "opencode/minimax-m2.5-free", prompt]
     try:
         res = subprocess.run(
             cmd,

--- a/server/wild_loop_v2.py
+++ b/server/wild_loop_v2.py
@@ -122,7 +122,7 @@ class WildV2Engine:
         *,
         opencode_url: str = "http://127.0.0.1:4096",
         model_provider: str = "opencode",
-        model_id: str = "kimi-k2.5-free",
+        model_id: str = "minimax-m2.5-free",
         get_workdir: Optional[Callable[[], str]] = None,
         server_url: str = "http://127.0.0.1:10000",
         auth_token: Optional[str] = None,


### PR DESCRIPTION
Summary
- let users set RESEARCH_AGENT_KEY from settings UI, persist it, and surface it on the frontend API calls
- forward the optional key to server middleware so it can update OpenCode configuration at runtime
- change the default model to `minimax-m2.5-free` across API mock, job sidecar, and engine configs
- default API connection test and session creation now include the runtime key when supplied

Testing
- Not run (not requested)