### PR TITLE
bug: Fetch backend workspace root for file explorer

### DIFF
--- a/app/api/file-explorer/file/route.ts
+++ b/app/api/file-explorer/file/route.ts
@@ -50,7 +50,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const workspaceRoot = await getWorkspaceRoot()
+    const workspaceRoot = await getWorkspaceRoot(request)
     const relativePath = normalizeExplorerPath(request.nextUrl.searchParams.get('path'))
     if (!relativePath) {
       return NextResponse.json({ error: 'A file path is required' }, { status: 400 })
@@ -96,4 +96,3 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: message }, { status })
   }
 }
-

--- a/app/api/file-explorer/tree/route.ts
+++ b/app/api/file-explorer/tree/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const workspaceRoot = await getWorkspaceRoot()
+    const workspaceRoot = await getWorkspaceRoot(request)
     const relativePath = normalizeExplorerPath(request.nextUrl.searchParams.get('path'))
     const absolutePath = resolveExplorerPath(relativePath, workspaceRoot)
     const dirEntries = await readdir(absolutePath, { withFileTypes: true })
@@ -59,4 +59,3 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: message }, { status })
   }
 }
-

--- a/components/file-explorer-view.tsx
+++ b/components/file-explorer-view.tsx
@@ -17,7 +17,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
-import { getAuthToken, getResearchAgentKey } from '@/lib/api-config'
+import { getApiUrl, getAuthToken, getResearchAgentKey } from '@/lib/api-config'
 
 type ExplorerNodeType = 'file' | 'directory'
 
@@ -108,7 +108,10 @@ export function FileExplorerView({
     }
 
     try {
-      const headers: HeadersInit = { 'X-Auth-Token': getAuthToken() }
+      const headers: HeadersInit = {
+        'X-Auth-Token': getAuthToken(),
+        'X-Backend-Url': getApiUrl(),
+      }
       const researchAgentKey = getResearchAgentKey()
       if (researchAgentKey) {
         headers['X-Research-Agent-Key'] = researchAgentKey
@@ -154,7 +157,10 @@ export function FileExplorerView({
     setFileError(null)
 
     try {
-      const headers: HeadersInit = { 'X-Auth-Token': getAuthToken() }
+      const headers: HeadersInit = {
+        'X-Auth-Token': getAuthToken(),
+        'X-Backend-Url': getApiUrl(),
+      }
       const researchAgentKey = getResearchAgentKey()
       if (researchAgentKey) {
         headers['X-Research-Agent-Key'] = researchAgentKey


### PR DESCRIPTION
Summary
- query the active backend for the current working directory when resolving file explorer paths, caching per backend URL
- fall back to `RESEARCH_AGENT_WORKDIR` only for local/dev setups and propagate auth/backend headers from the client
- ensure the file and tree routes pass the request so the utility can use the headers

Testing
- Not run (not requested)