### PR TITLE
chore: reproduce preview deploy failure on second commit

### DIFF
--- a/docs/ci/preview-multi-commit-repro.md
+++ b/docs/ci/preview-multi-commit-repro.md
@@ -3,3 +3,4 @@ PR preview multi-commit reproduction marker.
 Commit 1 marker for preview deploy token repro.
 
 Commit 2 marker for synchronize run.
+Commit 3 marker for additional synchronize run.


### PR DESCRIPTION
This PR is for reproducing preview deploy behavior when multiple commits are pushed to the same PR.\n\nPlan:\n- Commit 1: baseline no-op\n- Commit 2: another no-op to trigger synchronize run\n\nUsing this PR only to validate the CI failure mode before shipping a fix in a separate PR.