### PR TITLE
Simplify chat controls

### DIFF
--- a/app/contextual/page.tsx
+++ b/app/contextual/page.tsx
@@ -14,21 +14,11 @@ import {
   PanelLeftOpen,
   PanelRightClose,
   PanelRightOpen,
-  Rows3,
-  SlidersHorizontal,
   Sparkles,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import { DesktopSidebar } from '@/components/desktop-sidebar'
 import { NavPage } from '@/components/nav-page'
 import { ConnectedChatView, useChatSession } from '@/components/connected-chat-view'
@@ -43,6 +33,7 @@ import { extractContextReferences } from '@/lib/contextual-chat'
 import type { ChatMode } from '@/components/chat-input'
 import type { Sweep as UiSweep } from '@/lib/types'
 import { mapApiSweepToUiSweep } from '@/lib/sweep-mappers'
+import { useAppSettings } from '@/lib/app-settings'
 
 const DESKTOP_SIDEBAR_MIN_WIDTH = 72
 const DESKTOP_SIDEBAR_MAX_WIDTH = 520
@@ -50,6 +41,7 @@ const DESKTOP_SIDEBAR_DEFAULT_WIDTH = 300
 
 export default function ContextualChatPage() {
   const router = useRouter()
+  const { settings } = useAppSettings()
   const { runs } = useRuns()
   const { alerts } = useAlerts()
   const chatSession = useChatSession()
@@ -71,8 +63,8 @@ export default function ContextualChatPage() {
   const [desktopSidebarHidden, setDesktopSidebarHidden] = useState(false)
   const [desktopSidebarWidth, setDesktopSidebarWidth] = useState(DESKTOP_SIDEBAR_DEFAULT_WIDTH)
   const [sweeps, setSweeps] = useState<ApiSweep[]>([])
-  const [collapseChats, setCollapseChats] = useState(true)
-  const [collapseArtifactsInChat, setCollapseArtifactsInChat] = useState(false)
+  const collapseChats = settings.appearance.chatCollapseAllChats === true
+  const collapseArtifactsInChat = settings.appearance.chatCollapseArtifactsInChat === true
   const [showOpsPanel, setShowOpsPanel] = useState(true)
   const [showContextPanel, setShowContextPanel] = useState(true)
   const [diffExplorerOpen, setDiffExplorerOpen] = useState(false)
@@ -247,37 +239,6 @@ export default function ContextualChatPage() {
                   <FileText className="h-3.5 w-3.5" />
                   Git Explorer
                 </Button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8"
-                      title="Chat view settings"
-                    >
-                      <SlidersHorizontal className="h-4 w-4" />
-                      <span className="sr-only">Chat view settings</span>
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-52">
-                    <DropdownMenuLabel>Chat View</DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuCheckboxItem
-                      checked={collapseChats}
-                      onCheckedChange={(checked) => setCollapseChats(Boolean(checked))}
-                    >
-                      <Rows3 className="mr-1 h-3.5 w-3.5" />
-                      Collapse chats
-                    </DropdownMenuCheckboxItem>
-                    <DropdownMenuCheckboxItem
-                      checked={collapseArtifactsInChat}
-                      onCheckedChange={(checked) => setCollapseArtifactsInChat(Boolean(checked))}
-                    >
-                      <LayoutGrid className="mr-1 h-3.5 w-3.5" />
-                      Collapse artifacts
-                    </DropdownMenuCheckboxItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
               </div>
             </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,9 +47,6 @@ const DESKTOP_SIDEBAR_DEFAULT_WIDTH = 300
 const STORAGE_KEY_DESKTOP_SIDEBAR_WIDTH = 'desktopSidebarWidth'
 const STORAGE_KEY_DESKTOP_SIDEBAR_COLLAPSED = 'desktopSidebarCollapsed'
 const STORAGE_KEY_JOURNEY_SUB_TAB = 'journeySubTab'
-const STORAGE_KEY_CHAT_SHOW_ARTIFACTS = 'chatShowArtifacts'
-const STORAGE_KEY_CHAT_COLLAPSE_CHATS = 'chatCollapseChats'
-const STORAGE_KEY_CHAT_COLLAPSE_ARTIFACTS = 'chatCollapseArtifactsInChat'
 const DESKTOP_SIDEBAR_ICON_RAIL_TRIGGER_WIDTH = 136
 
 export default function ResearchChat() {
@@ -108,10 +105,9 @@ export default function ResearchChat() {
   const [showSweepForm, setShowSweepForm] = useState(false)
   const [editingSweepConfig, setEditingSweepConfig] = useState<SweepConfig | null>(null)
 
-  // Chat panel state
-  const [showArtifacts, setShowArtifacts] = useState(false)
-  const [collapseChats, setCollapseChats] = useState(false)
-  const [collapseArtifactsInChat, setCollapseArtifactsInChat] = useState(false)
+  // Chat panel state from app settings (Appearance section)
+  const collapseChats = settings.appearance.chatCollapseAllChats === true
+  const collapseArtifactsInChat = settings.appearance.chatCollapseArtifactsInChat === true
   const [chatDraftInsert, setChatDraftInsert] = useState<{ id: number; text: string } | null>(null)
   const [focusAuthTokenInApp, setFocusAuthTokenInApp] = useState(false)
 
@@ -142,20 +138,6 @@ export default function ResearchChat() {
       setJourneySubTab(storedJourneySubTab)
     }
 
-    const storedShowArtifacts = window.localStorage.getItem(STORAGE_KEY_CHAT_SHOW_ARTIFACTS)
-    if (storedShowArtifacts != null) {
-      setShowArtifacts(storedShowArtifacts === 'true')
-    }
-
-    const storedCollapseChats = window.localStorage.getItem(STORAGE_KEY_CHAT_COLLAPSE_CHATS)
-    if (storedCollapseChats != null) {
-      setCollapseChats(storedCollapseChats === 'true')
-    }
-
-    const storedCollapseArtifacts = window.localStorage.getItem(STORAGE_KEY_CHAT_COLLAPSE_ARTIFACTS)
-    if (storedCollapseArtifacts != null) {
-      setCollapseArtifactsInChat(storedCollapseArtifacts === 'true')
-    }
   }, [])
 
   useEffect(() => {
@@ -169,18 +151,6 @@ export default function ResearchChat() {
   useEffect(() => {
     window.localStorage.setItem(STORAGE_KEY_JOURNEY_SUB_TAB, journeySubTab)
   }, [journeySubTab])
-
-  useEffect(() => {
-    window.localStorage.setItem(STORAGE_KEY_CHAT_SHOW_ARTIFACTS, String(showArtifacts))
-  }, [showArtifacts])
-
-  useEffect(() => {
-    window.localStorage.setItem(STORAGE_KEY_CHAT_COLLAPSE_CHATS, String(collapseChats))
-  }, [collapseChats])
-
-  useEffect(() => {
-    window.localStorage.setItem(STORAGE_KEY_CHAT_COLLAPSE_ARTIFACTS, String(collapseArtifactsInChat))
-  }, [collapseArtifactsInChat])
 
   useEffect(() => {
     return () => {
@@ -583,12 +553,6 @@ export default function ResearchChat() {
     }
   }, [])
 
-  const handleOpenSweepCreator = useCallback(() => {
-    handleTabChange('chat')
-    setEditingSweepConfig(null)
-    setShowSweepForm(true)
-  }, [handleTabChange])
-
   const handleInsertChatReference = useCallback((text: string) => {
     handleTabChange('chat')
     setChatDraftInsert({
@@ -704,14 +668,6 @@ export default function ResearchChat() {
             onDesktopSidebarToggle={() => setDesktopSidebarHidden(false)}
             eventCount={events.filter(e => e.status === 'new').length}
             onAlertClick={handleNavigateToEvents}
-            onCreateSweepClick={handleOpenSweepCreator}
-            onOpenContextualClick={() => router.push('/contextual')}
-            showArtifacts={showArtifacts}
-            onToggleArtifacts={() => setShowArtifacts(prev => !prev)}
-            collapseChats={collapseChats}
-            onToggleCollapseChats={() => setCollapseChats(prev => !prev)}
-            collapseArtifactsInChat={collapseArtifactsInChat}
-            onToggleCollapseArtifactsInChat={() => setCollapseArtifactsInChat(prev => !prev)}
             sessionTitle={currentSession?.title || 'New Chat'}
             currentSessionId={currentSessionId}
             sessions={sessions}

--- a/components/floating-nav.tsx
+++ b/components/floating-nav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Menu, Bell, Settings, PlugZap, Eye, Edit3, Plus, ChevronDown, Type, Code, BarChart3, Sparkles, PanelLeftOpen, Orbit, Pause, Play, Square, Target } from 'lucide-react'
+import { Menu, Bell, Eye, Edit3, Plus, ChevronDown, Type, Code, BarChart3, Sparkles, PanelLeftOpen, Pause, Play, Square, Target } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -9,8 +9,6 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
   DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuLabel,
 } from '@/components/ui/dropdown-menu'
 import {
   Select,
@@ -21,8 +19,6 @@ import {
 } from '@/components/ui/select'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { Progress } from '@/components/ui/progress'
-import { Switch } from '@/components/ui/switch'
-import { Label } from '@/components/ui/label'
 import { useApiConfig } from '@/lib/api-config'
 import type { WildLoopPhase } from '@/lib/types'
 import type { RunStats } from '@/hooks/use-wild-loop'
@@ -67,14 +63,6 @@ interface FloatingNavProps {
   // Chat-specific props
   eventCount?: number
   onAlertClick?: () => void
-  onCreateSweepClick?: () => void
-  onOpenContextualClick?: () => void
-  showArtifacts?: boolean
-  onToggleArtifacts?: () => void
-  collapseChats?: boolean
-  onToggleCollapseChats?: () => void
-  collapseArtifactsInChat?: boolean
-  onToggleCollapseArtifactsInChat?: () => void
   // Session selector props (for chat tab)
   sessionTitle?: string
   currentSessionId?: string | null
@@ -96,14 +84,6 @@ export function FloatingNav({
   onDesktopSidebarToggle,
   eventCount = 0,
   onAlertClick,
-  onCreateSweepClick,
-  onOpenContextualClick,
-  showArtifacts = false,
-  onToggleArtifacts,
-  collapseChats = false,
-  onToggleCollapseChats,
-  collapseArtifactsInChat = false,
-  onToggleCollapseArtifactsInChat,
   sessionTitle = 'New Chat',
   currentSessionId,
   sessions = [],
@@ -230,91 +210,6 @@ export function FloatingNav({
             )}
             <span className="sr-only">View alerts ({eventCount})</span>
           </Button>
-
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onCreateSweepClick}
-            className="h-8 w-8"
-            title="Create sweep"
-          >
-            <PlugZap className="h-4 w-4" />
-            <span className="sr-only">Create sweep</span>
-          </Button>
-
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onOpenContextualClick}
-            className="h-8 w-8"
-            title="Open contextual chat"
-          >
-            <Orbit className="h-4 w-4" />
-            <span className="sr-only">Open contextual chat</span>
-          </Button>
-
-          {/* Settings Dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-              >
-                <Settings className="h-4 w-4" />
-                <span className="sr-only">Chat settings</span>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
-              <DropdownMenuLabel>Chat Settings</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                className="flex items-center justify-between cursor-pointer"
-                onSelect={(e) => {
-                  e.preventDefault()
-                  onToggleArtifacts?.()
-                }}
-              >
-                <Label htmlFor="show-artifacts" className="cursor-pointer">Show artifacts</Label>
-                <Switch
-                  id="show-artifacts"
-                  checked={showArtifacts}
-                  onCheckedChange={onToggleArtifacts}
-                  onClick={(e) => e.stopPropagation()}
-                />
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="flex items-center justify-between cursor-pointer"
-                onSelect={(e) => {
-                  e.preventDefault()
-                  onToggleCollapseChats?.()
-                }}
-              >
-                <Label htmlFor="collapse-chats" className="cursor-pointer">Collapse all chats</Label>
-                <Switch
-                  id="collapse-chats"
-                  checked={collapseChats}
-                  onCheckedChange={onToggleCollapseChats}
-                  onClick={(e) => e.stopPropagation()}
-                />
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="flex items-center justify-between cursor-pointer"
-                onSelect={(e) => {
-                  e.preventDefault()
-                  onToggleCollapseArtifactsInChat?.()
-                }}
-              >
-                <Label htmlFor="collapse-artifacts" className="cursor-pointer">Collapse artifacts in chat</Label>
-                <Switch
-                  id="collapse-artifacts"
-                  checked={collapseArtifactsInChat}
-                  onCheckedChange={onToggleCollapseArtifactsInChat}
-                  onClick={(e) => e.stopPropagation()}
-                />
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
         </div>
       )}
 

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -362,6 +362,30 @@ export function SettingsDialog({
           value: settings.appearance.showChatContextPanel !== false,
         },
         {
+          id: 'showChatArtifacts',
+          label: 'Show Artifacts',
+          description: 'Show or hide artifacts panel in chat views',
+          icon: LayoutGrid,
+          type: 'toggle' as const,
+          value: settings.appearance.showChatArtifacts === true,
+        },
+        {
+          id: 'chatCollapseAllChats',
+          label: 'Collapse All Chats',
+          description: 'Render chat history in collapsed mode by default',
+          icon: EyeOff,
+          type: 'toggle' as const,
+          value: settings.appearance.chatCollapseAllChats === true,
+        },
+        {
+          id: 'chatCollapseArtifactsInChat',
+          label: 'Collapse Artifacts In Chat',
+          description: 'Render artifacts collapsed inside chat messages',
+          icon: LayoutGrid,
+          type: 'toggle' as const,
+          value: settings.appearance.chatCollapseArtifactsInChat === true,
+        },
+        {
           id: 'appearanceAdvanced',
           label: 'Advanced Appearance',
           description: 'Set exact numeric sizes',
@@ -918,6 +942,9 @@ export function SettingsDialog({
                 if (item.id === 'webNotifications') handleWebNotificationsToggle(checked)
                 if (item.id === 'showStarterCards') updateAppearanceSettings({ showStarterCards: checked })
                 if (item.id === 'showChatContextPanel') updateAppearanceSettings({ showChatContextPanel: checked })
+                if (item.id === 'showChatArtifacts') updateAppearanceSettings({ showChatArtifacts: checked })
+                if (item.id === 'chatCollapseAllChats') updateAppearanceSettings({ chatCollapseAllChats: checked })
+                if (item.id === 'chatCollapseArtifactsInChat') updateAppearanceSettings({ chatCollapseArtifactsInChat: checked })
                 if (item.id === 'showWildLoopState') {
                   onSettingsChange({
                     ...settings,

--- a/components/settings-page-content.tsx
+++ b/components/settings-page-content.tsx
@@ -346,6 +346,30 @@ export function SettingsPageContent({
           value: settings.appearance.showChatContextPanel !== false,
         },
         {
+          id: 'showChatArtifacts',
+          label: 'Show Artifacts',
+          description: 'Show or hide artifacts panel in chat views',
+          icon: LayoutGrid,
+          type: 'toggle' as const,
+          value: settings.appearance.showChatArtifacts === true,
+        },
+        {
+          id: 'chatCollapseAllChats',
+          label: 'Collapse All Chats',
+          description: 'Render chat history in collapsed mode by default',
+          icon: EyeOff,
+          type: 'toggle' as const,
+          value: settings.appearance.chatCollapseAllChats === true,
+        },
+        {
+          id: 'chatCollapseArtifactsInChat',
+          label: 'Collapse Artifacts In Chat',
+          description: 'Render artifacts collapsed inside chat messages',
+          icon: LayoutGrid,
+          type: 'toggle' as const,
+          value: settings.appearance.chatCollapseArtifactsInChat === true,
+        },
+        {
           id: 'mobileEnterToNewline',
           label: 'Mobile Enter Key Insert New Line',
           description: 'On mobile, Enter inserts newline instead of sending (send button to send)',
@@ -885,6 +909,9 @@ export function SettingsPageContent({
                 if (item.id === 'showRunItemMetadata') updateAppearanceSettings({ showRunItemMetadata: checked })
                 if (item.id === 'showStarterCards') updateAppearanceSettings({ showStarterCards: checked })
                 if (item.id === 'showChatContextPanel') updateAppearanceSettings({ showChatContextPanel: checked })
+                if (item.id === 'showChatArtifacts') updateAppearanceSettings({ showChatArtifacts: checked })
+                if (item.id === 'chatCollapseAllChats') updateAppearanceSettings({ chatCollapseAllChats: checked })
+                if (item.id === 'chatCollapseArtifactsInChat') updateAppearanceSettings({ chatCollapseArtifactsInChat: checked })
                 if (item.id === 'mobileEnterToNewline') updateAppearanceSettings({ mobileEnterToNewline: checked })
                 if (item.id === 'showWildLoopState') {
                   onSettingsChange({

--- a/lib/app-settings.tsx
+++ b/lib/app-settings.tsx
@@ -31,6 +31,10 @@ const STORAGE_KEY_APPEARANCE_CUSTOM_PRIMARY_COLOR =
   "research-agent-appearance-custom-primary-color";
 const STORAGE_KEY_APPEARANCE_CUSTOM_ACCENT_COLOR =
   "research-agent-appearance-custom-accent-color";
+const LEGACY_STORAGE_KEY_CHAT_SHOW_ARTIFACTS = "chatShowArtifacts";
+const LEGACY_STORAGE_KEY_CHAT_COLLAPSE_CHATS = "chatCollapseChats";
+const LEGACY_STORAGE_KEY_CHAT_COLLAPSE_ARTIFACTS =
+  "chatCollapseArtifactsInChat";
 
 export const defaultAppSettings: AppSettings = {
   appearance: {
@@ -53,6 +57,9 @@ export const defaultAppSettings: AppSettings = {
     showStarterCards: true,
     starterCardFlavor: "novice",
     showChatContextPanel: true,
+    showChatArtifacts: false,
+    chatCollapseAllChats: false,
+    chatCollapseArtifactsInChat: false,
     showSidebarNewChatButton: true,
     mobileEnterToNewline: false,
   },
@@ -317,6 +324,15 @@ function readStoredSettings(): AppSettings {
     const storedCustomAccentColor = sanitizeHexColor(
       localStorage.getItem(STORAGE_KEY_APPEARANCE_CUSTOM_ACCENT_COLOR),
     );
+    const legacyShowArtifacts = localStorage.getItem(
+      LEGACY_STORAGE_KEY_CHAT_SHOW_ARTIFACTS,
+    );
+    const legacyCollapseChats = localStorage.getItem(
+      LEGACY_STORAGE_KEY_CHAT_COLLAPSE_CHATS,
+    );
+    const legacyCollapseArtifacts = localStorage.getItem(
+      LEGACY_STORAGE_KEY_CHAT_COLLAPSE_ARTIFACTS,
+    );
 
     const resolvedTheme = isValidTheme(storedTheme)
       ? storedTheme
@@ -392,6 +408,21 @@ function readStoredSettings(): AppSettings {
         showChatContextPanel:
           parsed?.appearance?.showChatContextPanel ??
           defaultAppSettings.appearance.showChatContextPanel,
+        showChatArtifacts:
+          parsed?.appearance?.showChatArtifacts ??
+          (legacyShowArtifacts != null
+            ? legacyShowArtifacts === "true"
+            : defaultAppSettings.appearance.showChatArtifacts),
+        chatCollapseAllChats:
+          parsed?.appearance?.chatCollapseAllChats ??
+          (legacyCollapseChats != null
+            ? legacyCollapseChats === "true"
+            : defaultAppSettings.appearance.chatCollapseAllChats),
+        chatCollapseArtifactsInChat:
+          parsed?.appearance?.chatCollapseArtifactsInChat ??
+          (legacyCollapseArtifacts != null
+            ? legacyCollapseArtifacts === "true"
+            : defaultAppSettings.appearance.chatCollapseArtifactsInChat),
         showSidebarNewChatButton:
           parsed?.appearance?.showSidebarNewChatButton ??
           defaultAppSettings.appearance.showSidebarNewChatButton,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -104,6 +104,9 @@ export interface AppSettings {
     showStarterCards?: boolean;
     starterCardFlavor?: "novice" | "expert";
     showChatContextPanel?: boolean;
+    showChatArtifacts?: boolean;
+    chatCollapseAllChats?: boolean;
+    chatCollapseArtifactsInChat?: boolean;
     showSidebarNewChatButton?: boolean;
     starterCardTemplates?: Record<string, string>;
     mobileEnterToNewline?: boolean;


### PR DESCRIPTION
Summary
- remove sweep creation and contextual navigation buttons from the chat top-right
- surface chat appearance controls (artifacts visibility, collapse behavior) in the settings screens instead of a dropdown, keeping values in app settings
- drop dropdown menu dependencies and wire contextual/chat pages to the new appearance flags

Testing
- Not run (not requested)