### PR TITLE
feat: add export session to markdown button in chat view

### DIFF
--- a/components/connected-chat-view.tsx
+++ b/components/connected-chat-view.tsx
@@ -7,7 +7,8 @@ import { ChatInput, type ChatMode } from './chat-input-simple'
 import { StreamingMessage } from './streaming-message'
 import { EventQueuePanel } from './event-queue-panel'
 import { WildTerminationDialog } from './wild-termination-dialog'
-import { AlertCircle, Loader2, PanelRightOpen, RefreshCw, WifiOff } from 'lucide-react'
+import { AlertCircle, Download, Loader2, PanelRightOpen, RefreshCw, WifiOff } from 'lucide-react'
+import { exportSessionToMarkdown, downloadMarkdown } from '@/lib/export-session-markdown'
 import { ChatStarterCards } from '@/components/chat-starter-cards'
 import { WildModeSetupPanel } from '@/components/wild-mode-setup-panel'
 import { WildLoopDebugPanel } from '@/components/wild-loop-debug-panel'
@@ -677,6 +678,25 @@ export function ConnectedChatView({
                             </div>
                         ) : (
                             <>
+                                {/* Export button toolbar */}
+                                <div className="shrink-0 flex items-center justify-end px-3 py-1.5 border-b border-border/40">
+                                    <button
+                                        type="button"
+                                        id="export-session-markdown"
+                                        onClick={() => {
+                                            const title = currentSession?.title?.trim() || 'Untitled Session'
+                                            const markdown = exportSessionToMarkdown(displayMessages, title)
+                                            const safeTitle = title.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 60)
+                                            downloadMarkdown(markdown, `${safeTitle}.md`)
+                                        }}
+                                        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                                        title="Export session as Markdown"
+                                    >
+                                        <Download className="h-3.5 w-3.5" />
+                                        Export
+                                    </button>
+                                </div>
+
                                 {/* Scrollable Chat Area */}
                                 <div className="flex-1 min-h-0 overflow-hidden">
                                     <ScrollArea className="h-full" ref={scrollRef}>

--- a/lib/export-session-markdown.ts
+++ b/lib/export-session-markdown.ts
@@ -1,0 +1,106 @@
+import type { ChatMessage } from '@/lib/types'
+
+/**
+ * Convert a list of chat messages into a shareable Markdown string.
+ */
+export function exportSessionToMarkdown(
+  messages: ChatMessage[],
+  sessionTitle?: string
+): string {
+  const title = sessionTitle?.trim() || 'Untitled Session'
+  const exportDate = new Date().toLocaleString()
+
+  const lines: string[] = [
+    `# ${title}`,
+    '',
+    `> Exported on ${exportDate}`,
+    '',
+    '---',
+    '',
+  ]
+
+  for (const message of messages) {
+    const roleLabel = message.role === 'user' ? '🧑 **You**' : '🤖 **Assistant**'
+    const time = message.timestamp.toLocaleString()
+
+    lines.push(`## ${roleLabel}`)
+    lines.push(`*${time}*`)
+    lines.push('')
+
+    // Render parts if available (structured messages)
+    if (message.parts && message.parts.length > 0) {
+      for (const part of message.parts) {
+        if (part.type === 'thinking' && part.content) {
+          lines.push('<details>')
+          lines.push('<summary>💭 Thinking</summary>')
+          lines.push('')
+          lines.push(part.content)
+          lines.push('')
+          lines.push('</details>')
+          lines.push('')
+        } else if (part.type === 'tool') {
+          const toolLabel = part.toolName || 'Tool'
+          const status = part.toolState || 'unknown'
+          lines.push('<details>')
+          lines.push(`<summary>🔧 ${toolLabel} (${status})</summary>`)
+          lines.push('')
+          if (part.toolInput) {
+            lines.push('**Input:**')
+            lines.push('```')
+            lines.push(part.toolInput)
+            lines.push('```')
+            lines.push('')
+          }
+          if (part.toolOutput) {
+            lines.push('**Output:**')
+            lines.push('```')
+            lines.push(part.toolOutput)
+            lines.push('```')
+            lines.push('')
+          }
+          lines.push('</details>')
+          lines.push('')
+        } else if (part.type === 'text' && part.content) {
+          lines.push(part.content)
+          lines.push('')
+        }
+      }
+    } else {
+      // Legacy: render thinking + content directly
+      if (message.thinking) {
+        lines.push('<details>')
+        lines.push('<summary>💭 Thinking</summary>')
+        lines.push('')
+        lines.push(message.thinking)
+        lines.push('')
+        lines.push('</details>')
+        lines.push('')
+      }
+
+      if (message.content) {
+        lines.push(message.content)
+        lines.push('')
+      }
+    }
+
+    lines.push('---')
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Trigger a browser download of the given text content as a .md file.
+ */
+export function downloadMarkdown(content: string, filename: string): void {
+  const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary

Adds a **Download / Export** button in the chat view toolbar that converts the current session's messages into a shareable Markdown file and triggers a browser download.

## Changes

### New: `lib/export-session-markdown.ts`
- `exportSessionToMarkdown(messages, title?)` — converts `ChatMessage[]` to Markdown with:
  - Session title and export timestamp header
  - Role-labeled messages with timestamps
  - Thinking blocks in collapsible `<details>` sections
  - Tool calls with input/output in collapsible `<details>` sections
  - Falls back to legacy thinking/content format for older messages
- `downloadMarkdown(content, filename)` — triggers a browser file download via Blob URL

### Modified: `components/connected-chat-view.tsx`
- Added an Export button in a slim toolbar above the scrollable chat area
- Button only appears when a conversation is active (`hasConversation` is true)
- Uses the session title for the filename (sanitized to filesystem-safe characters)
- Styled to match existing UI patterns (lucide icon, border, hover effects)

## Testing
- `npm run build` passes with no errors
- Button renders in the chat area header when messages exist
- Clicking triggers download of a properly formatted `.md` file