### PR TITLE
feat: move dictation mic button to action bar

### DIFF
--- a/components/chat-input-simple.tsx
+++ b/components/chat-input-simple.tsx
@@ -1,7 +1,7 @@
-'use client'
+"use client";
 
-import React from 'react'
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
+import React from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import {
   Send,
   Paperclip,
@@ -25,86 +25,105 @@ import {
   Check,
   Sparkles,
   Wand2,
-} from 'lucide-react'
-import { Button } from '@/components/ui/button'
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from '@/components/ui/popover'
-import type { ExperimentRun, Artifact, InsightChart, ChatMessage, Sweep } from '@/lib/types'
-import type { Alert as ApiAlert } from '@/lib/api-client'
-import type { ChatModelOption, SessionModelSelection } from '@/lib/api-client'
-import type { PromptSkill } from '@/lib/api'
+} from "@/components/ui/popover";
+import type {
+  ExperimentRun,
+  Artifact,
+  InsightChart,
+  ChatMessage,
+  Sweep,
+} from "@/lib/types";
+import type { Alert as ApiAlert } from "@/lib/api-client";
+import type { ChatModelOption, SessionModelSelection } from "@/lib/api-client";
+import type { PromptSkill } from "@/lib/api";
 import {
   REFERENCE_TYPE_COLOR_MAP,
   type ReferenceTokenType,
-} from '@/lib/reference-token-colors'
-import { useAppSettings } from '@/lib/app-settings'
-import { useIsMobile } from '@/components/ui/use-mobile'
+} from "@/lib/reference-token-colors";
+import { useAppSettings } from "@/lib/app-settings";
+import { useIsMobile } from "@/components/ui/use-mobile";
 
 // Re-export types matching the original chat-input.tsx so imports stay compatible.
-export type ChatMode = 'agent' | 'wild' | 'sweep' | 'plan'
-export type MentionType = ReferenceTokenType
+export type ChatMode = "agent" | "wild" | "sweep" | "plan";
+export type MentionType = ReferenceTokenType;
 
 export interface MentionItem {
-  id: string
-  type: MentionType
-  label: string
-  sublabel?: string
-  color?: string
-  icon?: React.ReactNode
+  id: string;
+  type: MentionType;
+  label: string;
+  sublabel?: string;
+  color?: string;
+  icon?: React.ReactNode;
 }
 
 interface ChatInputProps {
-  onSend: (message: string, attachments?: File[], mode?: ChatMode) => void
-  onStop?: () => void
-  disabled?: boolean
-  mode: ChatMode
-  onModeChange: (mode: ChatMode) => void
-  runs?: ExperimentRun[]
-  sweeps?: Sweep[]
-  alerts?: ApiAlert[]
-  artifacts?: Artifact[]
-  charts?: InsightChart[]
-  messages?: ChatMessage[]
-  isStreaming?: boolean
-  onQueue?: (message: string) => void
-  queueCount?: number
-  queue?: string[]
-  onRemoveFromQueue?: (index: number) => void
-  insertDraft?: { id: number; text: string } | null
-  insertReplyExcerpt?: { id: number; text: string; fileName?: string } | null
-  conversationKey?: string
-  layout?: 'docked' | 'centered'
-  skills?: PromptSkill[]
-  isWildLoopActive?: boolean
-  onSteer?: (message: string, priority: number) => void
-  onOpenReplyExcerpt?: (excerpt: { fileName: string; text: string }) => void
-  contextTokenCount?: number
-  modelOptions?: ChatModelOption[]
-  selectedModel?: SessionModelSelection | null
-  isModelUpdating?: boolean
-  onModelChange?: (model: SessionModelSelection) => Promise<void> | void
+  onSend: (message: string, attachments?: File[], mode?: ChatMode) => void;
+  onStop?: () => void;
+  disabled?: boolean;
+  mode: ChatMode;
+  onModeChange: (mode: ChatMode) => void;
+  runs?: ExperimentRun[];
+  sweeps?: Sweep[];
+  alerts?: ApiAlert[];
+  artifacts?: Artifact[];
+  charts?: InsightChart[];
+  messages?: ChatMessage[];
+  isStreaming?: boolean;
+  onQueue?: (message: string) => void;
+  queueCount?: number;
+  queue?: string[];
+  onRemoveFromQueue?: (index: number) => void;
+  insertDraft?: { id: number; text: string } | null;
+  insertReplyExcerpt?: { id: number; text: string; fileName?: string } | null;
+  conversationKey?: string;
+  layout?: "docked" | "centered";
+  skills?: PromptSkill[];
+  isWildLoopActive?: boolean;
+  onSteer?: (message: string, priority: number) => void;
+  onOpenReplyExcerpt?: (excerpt: { fileName: string; text: string }) => void;
+  contextTokenCount?: number;
+  modelOptions?: ChatModelOption[];
+  selectedModel?: SessionModelSelection | null;
+  isModelUpdating?: boolean;
+  onModelChange?: (model: SessionModelSelection) => Promise<void> | void;
 }
 
 // ---------------------------------------------------------------------------
 // Resize helpers
 // ---------------------------------------------------------------------------
-const INITIAL_HEIGHT_PX = 48
-const MAX_HEIGHT_PX = 200
+const INITIAL_HEIGHT_PX = 48;
+const MAX_HEIGHT_PX = 200;
 
 function autoResize(textarea: HTMLTextAreaElement) {
-  textarea.style.height = 'auto'
-  const next = Math.min(Math.max(textarea.scrollHeight, INITIAL_HEIGHT_PX), MAX_HEIGHT_PX)
-  textarea.style.height = `${next}px`
+  textarea.style.height = "auto";
+  const next = Math.min(
+    Math.max(textarea.scrollHeight, INITIAL_HEIGHT_PX),
+    MAX_HEIGHT_PX,
+  );
+  textarea.style.height = `${next}px`;
 }
 
 // ---------------------------------------------------------------------------
 // Regex to detect @type:id reference tokens
 // ---------------------------------------------------------------------------
-const REFERENCE_REGEX = /(?<!\S)@(?:run|sweep|artifact|alert|chart|chat|skill):[A-Za-z0-9:._-]+/g
-const MENTION_FILTER_OPTIONS: Array<MentionType | 'all'> = ['all', 'run', 'sweep', 'artifact', 'alert', 'chart', 'chat', 'skill']
+const REFERENCE_REGEX =
+  /(?<!\S)@(?:run|sweep|artifact|alert|chart|chat|skill):[A-Za-z0-9:._-]+/g;
+const MENTION_FILTER_OPTIONS: Array<MentionType | "all"> = [
+  "all",
+  "run",
+  "sweep",
+  "artifact",
+  "alert",
+  "chart",
+  "chat",
+  "skill",
+];
 
 // ---------------------------------------------------------------------------
 // Component
@@ -128,8 +147,8 @@ export function ChatInput({
   onRemoveFromQueue,
   insertDraft = null,
   insertReplyExcerpt = null,
-  conversationKey = 'default',
-  layout = 'docked',
+  conversationKey = "default",
+  layout = "docked",
   skills = [],
   isWildLoopActive = false,
   onSteer,
@@ -139,543 +158,656 @@ export function ChatInput({
   isModelUpdating = false,
   onModelChange,
 }: ChatInputProps) {
-  const { settings } = useAppSettings()
-  const isMobile = useIsMobile()
+  const { settings } = useAppSettings();
+  const isMobile = useIsMobile();
 
   // ---- core state ----
-  const [message, setMessage] = useState('')
-  const [attachments, setAttachments] = useState<File[]>([])
-  const [replyExcerpt, setReplyExcerpt] = useState<{ text: string; fileName: string } | null>(null)
-  const [isAttachOpen, setIsAttachOpen] = useState(false)
-  const [isModeOpen, setIsModeOpen] = useState(false)
-  const [isModelOpen, setIsModelOpen] = useState(false)
-  const [isQueueExpanded, setIsQueueExpanded] = useState(true)
-  const [isRecording, setIsRecording] = useState(false)
-  const [dictationSupported, setDictationSupported] = useState(false)
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const highlightRef = useRef<HTMLDivElement>(null)
-  const recognitionRef = useRef<any>(null)
+  const [message, setMessage] = useState("");
+  const [attachments, setAttachments] = useState<File[]>([]);
+  const [replyExcerpt, setReplyExcerpt] = useState<{
+    text: string;
+    fileName: string;
+  } | null>(null);
+  const [isAttachOpen, setIsAttachOpen] = useState(false);
+  const [isModeOpen, setIsModeOpen] = useState(false);
+  const [isModelOpen, setIsModelOpen] = useState(false);
+  const [isQueueExpanded, setIsQueueExpanded] = useState(true);
+  const [isRecording, setIsRecording] = useState(false);
+  const [dictationSupported, setDictationSupported] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const highlightRef = useRef<HTMLDivElement>(null);
+  const recognitionRef = useRef<any>(null);
 
   // ---- @mention autocomplete state ----
-  const [isMentionOpen, setIsMentionOpen] = useState(false)
-  const [mentionQuery, setMentionQuery] = useState('')
-  const [mentionStartIndex, setMentionStartIndex] = useState<number | null>(null)
-  const [selectedMentionIndex, setSelectedMentionIndex] = useState(0)
-  const [mentionFilter, setMentionFilter] = useState<MentionType | 'all'>('all')
+  const [isMentionOpen, setIsMentionOpen] = useState(false);
+  const [mentionQuery, setMentionQuery] = useState("");
+  const [mentionStartIndex, setMentionStartIndex] = useState<number | null>(
+    null,
+  );
+  const [selectedMentionIndex, setSelectedMentionIndex] = useState(0);
+  const [mentionFilter, setMentionFilter] = useState<MentionType | "all">(
+    "all",
+  );
 
   // ---- sweep mode redirect ----
   useEffect(() => {
-    if (mode === 'sweep') onModeChange('agent')
-  }, [mode, onModeChange])
+    if (mode === "sweep") onModeChange("agent");
+  }, [mode, onModeChange]);
 
   // ---- auto resize ----
   useEffect(() => {
-    if (textareaRef.current) autoResize(textareaRef.current)
-  }, [message])
+    if (textareaRef.current) autoResize(textareaRef.current);
+  }, [message]);
 
   // ---- insert draft ----
   useEffect(() => {
-    if (!insertDraft?.text) return
+    if (!insertDraft?.text) return;
     setMessage((prev) => {
-      if (!prev) return insertDraft.text
-      const sep = prev.endsWith(' ') ? '' : ' '
-      return `${prev}${sep}${insertDraft.text}`
-    })
-    setTimeout(() => textareaRef.current?.focus(), 0)
-  }, [insertDraft?.id, insertDraft?.text])
+      if (!prev) return insertDraft.text;
+      const sep = prev.endsWith(" ") ? "" : " ";
+      return `${prev}${sep}${insertDraft.text}`;
+    });
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  }, [insertDraft?.id, insertDraft?.text]);
 
   // ---- insert reply excerpt ----
   useEffect(() => {
-    if (!insertReplyExcerpt?.text) return
+    if (!insertReplyExcerpt?.text) return;
     setReplyExcerpt({
       text: insertReplyExcerpt.text,
-      fileName: insertReplyExcerpt.fileName || 'excerpt.txt',
-    })
-    setTimeout(() => textareaRef.current?.focus(), 0)
-  }, [insertReplyExcerpt?.id, insertReplyExcerpt?.text, insertReplyExcerpt?.fileName])
+      fileName: insertReplyExcerpt.fileName || "excerpt.txt",
+    });
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  }, [
+    insertReplyExcerpt?.id,
+    insertReplyExcerpt?.text,
+    insertReplyExcerpt?.fileName,
+  ]);
 
   // ---- clear excerpt on conversation change ----
-  useEffect(() => { setReplyExcerpt(null) }, [conversationKey])
+  useEffect(() => {
+    setReplyExcerpt(null);
+  }, [conversationKey]);
 
   // ---- dictation setup ----
   useEffect(() => {
-    if (typeof window === 'undefined') return
+    if (typeof window === "undefined") return;
 
-    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    const SpeechRecognition =
+      (window as any).SpeechRecognition ||
+      (window as any).webkitSpeechRecognition;
     if (!SpeechRecognition) {
-      setDictationSupported(false)
-      recognitionRef.current = null
-      return
+      setDictationSupported(false);
+      recognitionRef.current = null;
+      return;
     }
 
-    setDictationSupported(true)
-    const recognition = new SpeechRecognition()
-    recognition.continuous = true
-    recognition.interimResults = true
-    recognition.lang = 'en-US'
+    setDictationSupported(true);
+    const recognition = new SpeechRecognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = "en-US";
 
     recognition.onresult = (event: any) => {
-      const chunks: string[] = []
+      const chunks: string[] = [];
       for (let i = event.resultIndex; i < event.results.length; i += 1) {
-        const piece = event.results[i]?.[0]?.transcript
-        if (piece) chunks.push(piece)
+        const piece = event.results[i]?.[0]?.transcript;
+        if (piece) chunks.push(piece);
       }
 
-      const normalized = chunks.join(' ').trim()
-      if (!normalized) return
-      setMessage((prev) => (prev.trim().length > 0 ? `${prev} ${normalized}` : normalized))
+      const normalized = chunks.join(" ").trim();
+      if (!normalized) return;
+      setMessage((prev) =>
+        prev.trim().length > 0 ? `${prev} ${normalized}` : normalized,
+      );
       setTimeout(() => {
-        if (!textareaRef.current) return
-        textareaRef.current.focus()
-        autoResize(textareaRef.current)
-      }, 0)
-    }
+        if (!textareaRef.current) return;
+        textareaRef.current.focus();
+        autoResize(textareaRef.current);
+      }, 0);
+    };
 
-    recognition.onend = () => setIsRecording(false)
+    recognition.onend = () => setIsRecording(false);
     recognition.onerror = (error: any) => {
-      console.error('Dictation error:', error)
-      setIsRecording(false)
-    }
-    recognitionRef.current = recognition
+      console.error("Dictation error:", error);
+      setIsRecording(false);
+    };
+    recognitionRef.current = recognition;
 
     return () => {
       try {
-        recognition.stop()
+        recognition.stop();
       } catch {
         // Ignore stop errors during teardown.
       }
-      recognitionRef.current = null
-    }
-  }, [])
+      recognitionRef.current = null;
+    };
+  }, []);
 
   // =========================================================================
   // Mention items – built from runs / sweeps / alerts / artifacts / charts
   // =========================================================================
   const mentionItems = useMemo<MentionItem[]>(() => {
-    const items: MentionItem[] = []
-    const runById = new Map(runs.map((r) => [r.id, r]))
-    const alertIds = new Set<string>()
+    const items: MentionItem[] = [];
+    const runById = new Map(runs.map((r) => [r.id, r]));
+    const alertIds = new Set<string>();
 
     sweeps.forEach((sweep) => {
       items.push({
         id: `sweep:${sweep.id}`,
-        type: 'sweep',
+        type: "sweep",
         label: sweep.config.name || `Sweep ${sweep.id}`,
         sublabel: `${sweep.status} · ${sweep.progress.running} running · ${sweep.progress.completed} done`,
-        color: '#a855f7',
+        color: "#a855f7",
         icon: <Sparkles className="h-3 w-3" />,
-      })
-    })
+      });
+    });
 
     runs.forEach((run) => {
       items.push({
         id: `run:${run.id}`,
-        type: 'run',
+        type: "run",
         label: run.alias || run.name,
         sublabel: run.config?.model || run.status,
         color: run.color,
         icon: <Play className="h-3 w-3" />,
-      })
-      ;(run.alerts || []).forEach((alert, idx) => {
-        const alertId = `alert:${run.id}:${idx}`
-        if (alertIds.has(alertId)) return
-        alertIds.add(alertId)
+      });
+      (run.alerts || []).forEach((alert, idx) => {
+        const alertId = `alert:${run.id}:${idx}`;
+        if (alertIds.has(alertId)) return;
+        alertIds.add(alertId);
         items.push({
           id: alertId,
-          type: 'alert',
-          label: alert.message.slice(0, 40) + (alert.message.length > 40 ? '...' : ''),
+          type: "alert",
+          label:
+            alert.message.slice(0, 40) +
+            (alert.message.length > 40 ? "..." : ""),
           sublabel: `${run.alias || run.name} - ${alert.type}`,
-          color: alert.type === 'error' ? '#f87171' : alert.type === 'warning' ? '#facc15' : '#60a5fa',
+          color:
+            alert.type === "error"
+              ? "#f87171"
+              : alert.type === "warning"
+                ? "#facc15"
+                : "#60a5fa",
           icon: <AlertTriangle className="h-3 w-3" />,
-        })
-      })
+        });
+      });
       run.artifacts?.forEach((artifact) => {
         items.push({
           id: `artifact:${artifact.id}`,
-          type: 'artifact',
+          type: "artifact",
           label: artifact.name,
           sublabel: `${run.alias || run.name} - ${artifact.type}`,
           icon: <Archive className="h-3 w-3" />,
-        })
-      })
-    })
+        });
+      });
+    });
 
     artifacts.forEach((artifact) => {
       if (!items.find((i) => i.id === `artifact:${artifact.id}`)) {
         items.push({
           id: `artifact:${artifact.id}`,
-          type: 'artifact',
+          type: "artifact",
           label: artifact.name,
           sublabel: artifact.type,
           icon: <Archive className="h-3 w-3" />,
-        })
+        });
       }
-    })
+    });
 
     charts.forEach((chart) => {
       items.push({
         id: `chart:${chart.id}`,
-        type: 'chart',
+        type: "chart",
         label: chart.title,
         sublabel: chart.type,
         icon: <BarChart3 className="h-3 w-3" />,
-      })
-    })
+      });
+    });
 
     skills.forEach((skill) => {
       items.push({
         id: `skill:${skill.id}`,
-        type: 'skill',
+        type: "skill",
         label: skill.name,
         sublabel: skill.description || skill.id,
-        color: '#8b5cf6',
+        color: "#8b5cf6",
         icon: <Wand2 className="h-3 w-3" />,
-      })
-    })
+      });
+    });
 
     messages
-      .filter((m) => m.role === 'user' && m.content.trim())
+      .filter((m) => m.role === "user" && m.content.trim())
       .slice(-10)
       .forEach((msg) => {
         items.push({
           id: `chat:${msg.id}`,
-          type: 'chat',
-          label: msg.content.slice(0, 40) + (msg.content.length > 40 ? '...' : ''),
-          sublabel: new Date(msg.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+          type: "chat",
+          label:
+            msg.content.slice(0, 40) + (msg.content.length > 40 ? "..." : ""),
+          sublabel: new Date(msg.timestamp).toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          }),
           icon: <MessageSquare className="h-3 w-3" />,
-        })
-      })
+        });
+      });
 
     alerts.forEach((alert) => {
-      const alertId = `alert:${alert.id}`
-      if (alertIds.has(alertId)) return
-      alertIds.add(alertId)
-      const run = runById.get(alert.run_id)
-      const severity = alert.severity === 'critical' ? 'error' : alert.severity === 'warning' ? 'warning' : 'info'
+      const alertId = `alert:${alert.id}`;
+      if (alertIds.has(alertId)) return;
+      alertIds.add(alertId);
+      const run = runById.get(alert.run_id);
+      const severity =
+        alert.severity === "critical"
+          ? "error"
+          : alert.severity === "warning"
+            ? "warning"
+            : "info";
       items.push({
         id: alertId,
-        type: 'alert',
-        label: alert.message.slice(0, 40) + (alert.message.length > 40 ? '...' : ''),
+        type: "alert",
+        label:
+          alert.message.slice(0, 40) + (alert.message.length > 40 ? "..." : ""),
         sublabel: `${run?.alias || run?.name || alert.run_id} - ${severity}`,
-        color: severity === 'error' ? '#f87171' : severity === 'warning' ? '#facc15' : '#60a5fa',
+        color:
+          severity === "error"
+            ? "#f87171"
+            : severity === "warning"
+              ? "#facc15"
+              : "#60a5fa",
         icon: <AlertTriangle className="h-3 w-3" />,
-      })
-    })
+      });
+    });
 
-    return items
-  }, [runs, sweeps, artifacts, charts, skills, messages, alerts])
+    return items;
+  }, [runs, sweeps, artifacts, charts, skills, messages, alerts]);
 
   const filteredMentionItems = useMemo(() => {
-    let items = mentionItems
-    if (mentionFilter !== 'all') items = items.filter((i) => i.type === mentionFilter)
+    let items = mentionItems;
+    if (mentionFilter !== "all")
+      items = items.filter((i) => i.type === mentionFilter);
     if (mentionQuery) {
-      const q = mentionQuery.toLowerCase()
-      items = items.filter((i) => i.label.toLowerCase().includes(q) || i.sublabel?.toLowerCase().includes(q))
+      const q = mentionQuery.toLowerCase();
+      items = items.filter(
+        (i) =>
+          i.label.toLowerCase().includes(q) ||
+          i.sublabel?.toLowerCase().includes(q),
+      );
     }
-    return items.slice(0, 8)
-  }, [mentionItems, mentionQuery, mentionFilter])
+    return items.slice(0, 8);
+  }, [mentionItems, mentionQuery, mentionFilter]);
 
-  useEffect(() => { setSelectedMentionIndex(0) }, [filteredMentionItems])
+  useEffect(() => {
+    setSelectedMentionIndex(0);
+  }, [filteredMentionItems]);
 
   // =========================================================================
   // Highlighted message overlay – text color only, no background
   // =========================================================================
   const highlightedMessage = useMemo(() => {
-    if (!message) return null
-    const parts: React.ReactNode[] = []
-    const regex = new RegExp(REFERENCE_REGEX.source, 'g')
-    let cursor = 0
-    let match: RegExpExecArray | null
-    let key = 0
+    if (!message) return null;
+    const parts: React.ReactNode[] = [];
+    const regex = new RegExp(REFERENCE_REGEX.source, "g");
+    let cursor = 0;
+    let match: RegExpExecArray | null;
+    let key = 0;
 
     while ((match = regex.exec(message)) !== null) {
-      const token = match[0]
-      const start = match.index
-      const end = start + token.length
+      const token = match[0];
+      const start = match.index;
+      const end = start + token.length;
 
       if (start > cursor) {
-        parts.push(<span key={`t-${key++}`}>{message.slice(cursor, start)}</span>)
+        parts.push(
+          <span key={`t-${key++}`}>{message.slice(cursor, start)}</span>,
+        );
       }
 
       // Extract the type part from @type:id
-      const maybeType = token.slice(1).split(':')[0] as MentionType
-      const color = maybeType in REFERENCE_TYPE_COLOR_MAP
-        ? REFERENCE_TYPE_COLOR_MAP[maybeType]
-        : undefined
+      const maybeType = token.slice(1).split(":")[0] as MentionType;
+      const color =
+        maybeType in REFERENCE_TYPE_COLOR_MAP
+          ? REFERENCE_TYPE_COLOR_MAP[maybeType]
+          : undefined;
 
       parts.push(
         <span key={`m-${key++}`} style={color ? { color } : undefined}>
           {token}
         </span>,
-      )
-      cursor = end
+      );
+      cursor = end;
     }
 
     if (cursor < message.length) {
-      parts.push(<span key={`t-${key++}`}>{message.slice(cursor)}</span>)
+      parts.push(<span key={`t-${key++}`}>{message.slice(cursor)}</span>);
     }
-    return parts
-  }, [message])
+    return parts;
+  }, [message]);
 
   // =========================================================================
   // Build outgoing message (with optional quote block)
   // =========================================================================
   const buildOutgoingMessage = useCallback(() => {
-    if (!replyExcerpt) return message
-    const quoteBlock = replyExcerpt.text.split('\n').map((l) => `> ${l}`).join('\n')
-    return message.trim() ? `${quoteBlock}\n\n${message}` : quoteBlock
-  }, [message, replyExcerpt])
+    if (!replyExcerpt) return message;
+    const quoteBlock = replyExcerpt.text
+      .split("\n")
+      .map((l) => `> ${l}`)
+      .join("\n");
+    return message.trim() ? `${quoteBlock}\n\n${message}` : quoteBlock;
+  }, [message, replyExcerpt]);
 
   // =========================================================================
   // Insert mention from dropdown
   // =========================================================================
   const insertMention = useCallback(
     (item: MentionItem) => {
-      if (mentionStartIndex === null) return
-      const before = message.slice(0, mentionStartIndex)
-      const after = message.slice(textareaRef.current?.selectionStart || message.length)
-      const token = `@${item.id} `
-      setMessage(before + token + after)
-      setIsMentionOpen(false)
-      setMentionStartIndex(null)
-      setMentionQuery('')
-      setMentionFilter('all')
+      if (mentionStartIndex === null) return;
+      const before = message.slice(0, mentionStartIndex);
+      const after = message.slice(
+        textareaRef.current?.selectionStart || message.length,
+      );
+      const token = `@${item.id} `;
+      setMessage(before + token + after);
+      setIsMentionOpen(false);
+      setMentionStartIndex(null);
+      setMentionQuery("");
+      setMentionFilter("all");
       setTimeout(() => {
         if (textareaRef.current) {
-          const pos = before.length + token.length
-          textareaRef.current.focus()
-          textareaRef.current.setSelectionRange(pos, pos)
+          const pos = before.length + token.length;
+          textareaRef.current.focus();
+          textareaRef.current.setSelectionRange(pos, pos);
         }
-      }, 0)
+      }, 0);
     },
     [mentionStartIndex, message],
-  )
+  );
 
-  const handleMentionNavigationKey = useCallback((e: { key: string; preventDefault: () => void }) => {
-    if (!isMentionOpen) return false
+  const handleMentionNavigationKey = useCallback(
+    (e: { key: string; preventDefault: () => void }) => {
+      if (!isMentionOpen) return false;
 
-    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-      e.preventDefault()
-      const currentFilterIndex = MENTION_FILTER_OPTIONS.indexOf(mentionFilter)
-      const offset = e.key === 'ArrowRight' ? 1 : -1
-      const nextFilterIndex = (currentFilterIndex + offset + MENTION_FILTER_OPTIONS.length) % MENTION_FILTER_OPTIONS.length
-      setMentionFilter(MENTION_FILTER_OPTIONS[nextFilterIndex])
-      setSelectedMentionIndex(0)
-      return true
-    }
+      if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+        e.preventDefault();
+        const currentFilterIndex =
+          MENTION_FILTER_OPTIONS.indexOf(mentionFilter);
+        const offset = e.key === "ArrowRight" ? 1 : -1;
+        const nextFilterIndex =
+          (currentFilterIndex + offset + MENTION_FILTER_OPTIONS.length) %
+          MENTION_FILTER_OPTIONS.length;
+        setMentionFilter(MENTION_FILTER_OPTIONS[nextFilterIndex]);
+        setSelectedMentionIndex(0);
+        return true;
+      }
 
-    if (filteredMentionItems.length > 0 && e.key === 'ArrowDown') {
-      e.preventDefault()
-      setSelectedMentionIndex((p) => (p < filteredMentionItems.length - 1 ? p + 1 : 0))
-      return true
-    }
+      if (filteredMentionItems.length > 0 && e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedMentionIndex((p) =>
+          p < filteredMentionItems.length - 1 ? p + 1 : 0,
+        );
+        return true;
+      }
 
-    if (filteredMentionItems.length > 0 && e.key === 'ArrowUp') {
-      e.preventDefault()
-      setSelectedMentionIndex((p) => (p > 0 ? p - 1 : filteredMentionItems.length - 1))
-      return true
-    }
+      if (filteredMentionItems.length > 0 && e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedMentionIndex((p) =>
+          p > 0 ? p - 1 : filteredMentionItems.length - 1,
+        );
+        return true;
+      }
 
-    if (filteredMentionItems.length > 0 && (e.key === 'Enter' || e.key === 'Tab')) {
-      e.preventDefault()
-      insertMention(filteredMentionItems[selectedMentionIndex])
-      return true
-    }
+      if (
+        filteredMentionItems.length > 0 &&
+        (e.key === "Enter" || e.key === "Tab")
+      ) {
+        e.preventDefault();
+        insertMention(filteredMentionItems[selectedMentionIndex]);
+        return true;
+      }
 
-    if (e.key === 'Escape') {
-      e.preventDefault()
-      setIsMentionOpen(false)
-      setMentionStartIndex(null)
-      setMentionQuery('')
-      return true
-    }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setIsMentionOpen(false);
+        setMentionStartIndex(null);
+        setMentionQuery("");
+        return true;
+      }
 
-    return false
-  }, [filteredMentionItems, insertMention, isMentionOpen, mentionFilter, selectedMentionIndex])
+      return false;
+    },
+    [
+      filteredMentionItems,
+      insertMention,
+      isMentionOpen,
+      mentionFilter,
+      selectedMentionIndex,
+    ],
+  );
 
   useEffect(() => {
-    if (!isMentionOpen) return
+    if (!isMentionOpen) return;
 
     const onWindowKeyDown = (event: KeyboardEvent) => {
-      if (document.activeElement === textareaRef.current) return
-      const handled = handleMentionNavigationKey(event)
+      if (document.activeElement === textareaRef.current) return;
+      const handled = handleMentionNavigationKey(event);
       if (handled) {
-        event.stopPropagation()
+        event.stopPropagation();
       }
-    }
+    };
 
-    window.addEventListener('keydown', onWindowKeyDown, true)
+    window.addEventListener("keydown", onWindowKeyDown, true);
     return () => {
-      window.removeEventListener('keydown', onWindowKeyDown, true)
-    }
-  }, [handleMentionNavigationKey, isMentionOpen])
+      window.removeEventListener("keydown", onWindowKeyDown, true);
+    };
+  }, [handleMentionNavigationKey, isMentionOpen]);
 
   // =========================================================================
   // Submit
   // =========================================================================
   const handleSubmit = () => {
-    const outgoing = buildOutgoingMessage()
-    const canSubmit = Boolean(message.trim() || replyExcerpt || attachments.length > 0)
-    if (!canSubmit) return
+    const outgoing = buildOutgoingMessage();
+    const canSubmit = Boolean(
+      message.trim() || replyExcerpt || attachments.length > 0,
+    );
+    if (!canSubmit) return;
 
     if (isStreaming && onQueue && (message.trim() || replyExcerpt)) {
-      onQueue(outgoing.trim())
+      onQueue(outgoing.trim());
     } else if (isWildLoopActive && onSteer && message.trim()) {
-      onSteer(message.trim(), 15)
+      onSteer(message.trim(), 15);
     } else {
-      onSend(outgoing, attachments, mode)
+      onSend(outgoing, attachments, mode);
     }
 
-    setMessage('')
-    setAttachments([])
-    setReplyExcerpt(null)
-    setIsMentionOpen(false)
-    setMentionStartIndex(null)
-    setMentionQuery('')
+    setMessage("");
+    setAttachments([]);
+    setReplyExcerpt(null);
+    setIsMentionOpen(false);
+    setMentionStartIndex(null);
+    setMentionQuery("");
     setTimeout(() => {
-      if (textareaRef.current) textareaRef.current.style.height = `${INITIAL_HEIGHT_PX}px`
-    }, 0)
-  }
+      if (textareaRef.current)
+        textareaRef.current.style.height = `${INITIAL_HEIGHT_PX}px`;
+    }, 0);
+  };
 
   // =========================================================================
   // Keyboard
   // =========================================================================
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (handleMentionNavigationKey(e)) {
-      return
+      return;
     }
 
     // Enter / Shift+Enter
-    const reverseEnter = isMobile && (settings.appearance.mobileEnterToNewline ?? false)
+    const reverseEnter =
+      isMobile && (settings.appearance.mobileEnterToNewline ?? false);
     if (reverseEnter) {
-      if (e.key === 'Enter' && e.shiftKey) { e.preventDefault(); handleSubmit() }
+      if (e.key === "Enter" && e.shiftKey) {
+        e.preventDefault();
+        handleSubmit();
+      }
     } else {
-      if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSubmit() }
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSubmit();
+      }
     }
-  }
+  };
 
   // =========================================================================
   // Text change – detect @mention trigger
   // =========================================================================
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const value = e.target.value
-    const cursorPos = e.target.selectionStart
-    setMessage(value)
-    autoResize(e.target)
+    const value = e.target.value;
+    const cursorPos = e.target.selectionStart;
+    setMessage(value);
+    autoResize(e.target);
 
     // Sync scroll for highlight overlay
-    if (highlightRef.current) highlightRef.current.scrollTop = e.target.scrollTop
+    if (highlightRef.current)
+      highlightRef.current.scrollTop = e.target.scrollTop;
 
     // Detect @mention trigger
-    const before = value.slice(0, cursorPos)
-    const atIdx = before.lastIndexOf('@')
+    const before = value.slice(0, cursorPos);
+    const atIdx = before.lastIndexOf("@");
     if (atIdx !== -1) {
-      const afterAt = before.slice(atIdx + 1)
-      if (!afterAt.includes(' ')) {
-        setMentionStartIndex(atIdx)
-        setIsMentionOpen(true)
+      const afterAt = before.slice(atIdx + 1);
+      if (!afterAt.includes(" ")) {
+        setMentionStartIndex(atIdx);
+        setIsMentionOpen(true);
         // Auto-detect filter prefix
-        if (afterAt.startsWith('run:')) { setMentionFilter('run'); setMentionQuery(afterAt.slice(4)) }
-        else if (afterAt.startsWith('sweep:')) { setMentionFilter('sweep'); setMentionQuery(afterAt.slice(6)) }
-        else if (afterAt.startsWith('alert:')) { setMentionFilter('alert'); setMentionQuery(afterAt.slice(6)) }
-        else if (afterAt.startsWith('artifact:')) { setMentionFilter('artifact'); setMentionQuery(afterAt.slice(9)) }
-        else if (afterAt.startsWith('chart:')) { setMentionFilter('chart'); setMentionQuery(afterAt.slice(6)) }
-        else if (afterAt.startsWith('chat:')) { setMentionFilter('chat'); setMentionQuery(afterAt.slice(5)) }
-        else if (afterAt.startsWith('skill:')) { setMentionFilter('skill'); setMentionQuery(afterAt.slice(6)) }
-        else { setMentionFilter('all'); setMentionQuery(afterAt) }
-        return
+        if (afterAt.startsWith("run:")) {
+          setMentionFilter("run");
+          setMentionQuery(afterAt.slice(4));
+        } else if (afterAt.startsWith("sweep:")) {
+          setMentionFilter("sweep");
+          setMentionQuery(afterAt.slice(6));
+        } else if (afterAt.startsWith("alert:")) {
+          setMentionFilter("alert");
+          setMentionQuery(afterAt.slice(6));
+        } else if (afterAt.startsWith("artifact:")) {
+          setMentionFilter("artifact");
+          setMentionQuery(afterAt.slice(9));
+        } else if (afterAt.startsWith("chart:")) {
+          setMentionFilter("chart");
+          setMentionQuery(afterAt.slice(6));
+        } else if (afterAt.startsWith("chat:")) {
+          setMentionFilter("chat");
+          setMentionQuery(afterAt.slice(5));
+        } else if (afterAt.startsWith("skill:")) {
+          setMentionFilter("skill");
+          setMentionQuery(afterAt.slice(6));
+        } else {
+          setMentionFilter("all");
+          setMentionQuery(afterAt);
+        }
+        return;
       }
     }
-    setIsMentionOpen(false)
-    setMentionStartIndex(null)
-    setMentionQuery('')
-    setMentionFilter('all')
-  }
+    setIsMentionOpen(false);
+    setMentionStartIndex(null);
+    setMentionQuery("");
+    setMentionFilter("all");
+  };
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
-      setAttachments((prev) => [...prev, ...Array.from(e.target.files as FileList)])
+      setAttachments((prev) => [
+        ...prev,
+        ...Array.from(e.target.files as FileList),
+      ]);
     }
-    e.target.value = ''
-    setIsAttachOpen(false)
-  }
+    e.target.value = "";
+    setIsAttachOpen(false);
+  };
 
   const removeAttachment = (index: number) => {
-    setAttachments((prev) => prev.filter((_, i) => i !== index))
-  }
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+  };
 
   const openFilePicker = (accept?: string) => {
-    if (!fileInputRef.current) return
-    fileInputRef.current.accept = accept || ''
-    fileInputRef.current.click()
-    setIsAttachOpen(false)
-  }
+    if (!fileInputRef.current) return;
+    fileInputRef.current.accept = accept || "";
+    fileInputRef.current.click();
+    setIsAttachOpen(false);
+  };
 
   const toggleRecording = () => {
-    if (!dictationSupported || !recognitionRef.current) return
+    if (!dictationSupported || !recognitionRef.current) return;
 
     if (isRecording) {
-      recognitionRef.current.stop()
-      setIsRecording(false)
-      return
+      recognitionRef.current.stop();
+      setIsRecording(false);
+      return;
     }
 
     try {
-      recognitionRef.current.start()
-      setIsRecording(true)
+      recognitionRef.current.start();
+      setIsRecording(true);
     } catch {
-      setIsRecording(false)
+      setIsRecording(false);
     }
-  }
+  };
 
-  const openMentionFromToolbar = (type: MentionType | 'all') => {
-    const textarea = textareaRef.current
-    const cursorPos = textarea?.selectionStart ?? message.length
-    const before = message.slice(0, cursorPos)
-    const after = message.slice(cursorPos)
-    const nextMessage = `${before}@${after}`
+  const openMentionFromToolbar = (type: MentionType | "all") => {
+    const textarea = textareaRef.current;
+    const cursorPos = textarea?.selectionStart ?? message.length;
+    const before = message.slice(0, cursorPos);
+    const after = message.slice(cursorPos);
+    const nextMessage = `${before}@${after}`;
 
-    setMessage(nextMessage)
-    setMentionStartIndex(cursorPos)
-    setMentionQuery('')
-    setMentionFilter(type)
-    setIsMentionOpen(true)
+    setMessage(nextMessage);
+    setMentionStartIndex(cursorPos);
+    setMentionQuery("");
+    setMentionFilter(type);
+    setIsMentionOpen(true);
 
     setTimeout(() => {
-      if (!textareaRef.current) return
-      const nextCursorPos = cursorPos + 1
-      textareaRef.current.focus()
-      textareaRef.current.setSelectionRange(nextCursorPos, nextCursorPos)
-      autoResize(textareaRef.current)
-    }, 0)
-  }
+      if (!textareaRef.current) return;
+      const nextCursorPos = cursorPos + 1;
+      textareaRef.current.focus();
+      textareaRef.current.setSelectionRange(nextCursorPos, nextCursorPos);
+      autoResize(textareaRef.current);
+    }, 0);
+  };
 
   // =========================================================================
   // Model selector helpers
   // =========================================================================
-  const defaultModelOption = modelOptions.find((o) => o.is_default) || modelOptions[0] || null
-  const effectiveSelectedModel = selectedModel || (
-    defaultModelOption
-      ? { provider_id: defaultModelOption.provider_id, model_id: defaultModelOption.model_id }
-      : null
-  )
+  const defaultModelOption =
+    modelOptions.find((o) => o.is_default) || modelOptions[0] || null;
+  const effectiveSelectedModel =
+    selectedModel ||
+    (defaultModelOption
+      ? {
+          provider_id: defaultModelOption.provider_id,
+          model_id: defaultModelOption.model_id,
+        }
+      : null);
   const modelOptionsByProvider = useMemo(() => {
-    const groups = new Map<string, ChatModelOption[]>()
+    const groups = new Map<string, ChatModelOption[]>();
     modelOptions.forEach((o) => {
-      const existing = groups.get(o.provider_id) || []
-      existing.push(o)
-      groups.set(o.provider_id, existing)
-    })
+      const existing = groups.get(o.provider_id) || [];
+      existing.push(o);
+      groups.set(o.provider_id, existing);
+    });
     return Array.from(groups.entries())
       .sort((a, b) => a[0].localeCompare(b[0]))
-      .map(([pid, opts]) => ({ providerId: pid, options: opts.slice().sort((a, b) => a.model_id.localeCompare(b.model_id)) }))
-  }, [modelOptions])
+      .map(([pid, opts]) => ({
+        providerId: pid,
+        options: opts
+          .slice()
+          .sort((a, b) => a.model_id.localeCompare(b.model_id)),
+      }));
+  }, [modelOptions]);
 
   // =========================================================================
   // Mention type color map for filter pills
   // =========================================================================
-  const mentionTypeColorMap = REFERENCE_TYPE_COLOR_MAP
+  const mentionTypeColorMap = REFERENCE_TYPE_COLOR_MAP;
 
   // =========================================================================
   // Render
@@ -683,9 +815,9 @@ export function ChatInput({
   return (
     <div
       className={
-        layout === 'centered'
-          ? 'rounded-2xl border border-border bg-background px-4 pb-4 pt-3 shadow-[0_8px_20px_rgba(15,23,42,0.07)]'
-          : 'border-t border-border bg-background px-4 pb-4 pt-3'
+        layout === "centered"
+          ? "rounded-2xl border border-border bg-background px-4 pb-4 pt-3 shadow-[0_8px_20px_rgba(15,23,42,0.07)]"
+          : "border-t border-border bg-background px-4 pb-4 pt-3"
       }
     >
       {/* Reply excerpt / attachments */}
@@ -696,22 +828,44 @@ export function ChatInput({
               role="button"
               tabIndex={0}
               onClick={() => onOpenReplyExcerpt?.(replyExcerpt)}
-              onKeyDown={(ev) => { if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); onOpenReplyExcerpt?.(replyExcerpt) } }}
+              onKeyDown={(ev) => {
+                if (ev.key === "Enter" || ev.key === " ") {
+                  ev.preventDefault();
+                  onOpenReplyExcerpt?.(replyExcerpt);
+                }
+              }}
               className="group relative w-[220px] rounded-2xl border border-border/80 bg-card/80 p-3 text-left shadow-sm transition-all hover:border-primary/50 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
               title="Open excerpt preview"
             >
-              <button type="button" onClick={(ev) => { ev.stopPropagation(); setReplyExcerpt(null) }} className="absolute right-2 top-2 z-10 text-muted-foreground hover:text-foreground" aria-label="Remove quoted excerpt">
+              <button
+                type="button"
+                onClick={(ev) => {
+                  ev.stopPropagation();
+                  setReplyExcerpt(null);
+                }}
+                className="absolute right-2 top-2 z-10 text-muted-foreground hover:text-foreground"
+                aria-label="Remove quoted excerpt"
+              >
                 <X className="h-3.5 w-3.5" />
               </button>
-              <p className="pr-5 text-sm font-medium leading-tight text-foreground break-words group-hover:text-primary">{replyExcerpt.fileName}</p>
-              <p className="mt-2 text-xs text-muted-foreground">{replyExcerpt.text.split('\n').length} lines</p>
-              <span className="mt-2 inline-flex rounded-md border border-border px-2 py-0.5 text-xs font-medium text-muted-foreground">TXT</span>
+              <p className="pr-5 text-sm font-medium leading-tight text-foreground break-words group-hover:text-primary">
+                {replyExcerpt.fileName}
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {replyExcerpt.text.split("\n").length} lines
+              </p>
+              <span className="mt-2 inline-flex rounded-md border border-border px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                TXT
+              </span>
             </div>
           )}
           {attachments.map((file, index) => {
-            const isFigure = file.type.startsWith('image/')
+            const isFigure = file.type.startsWith("image/");
             return (
-              <div key={`${file.name}-${index}`} className="flex items-center gap-1.5 rounded-md bg-secondary px-2 py-1 text-xs">
+              <div
+                key={`${file.name}-${index}`}
+                className="flex items-center gap-1.5 rounded-md bg-secondary px-2 py-1 text-xs"
+              >
                 {isFigure ? (
                   <ImageIcon className="h-3 w-3 text-muted-foreground" />
                 ) : (
@@ -719,13 +873,20 @@ export function ChatInput({
                 )}
                 <span className="max-w-[120px] truncate">{file.name}</span>
                 {isFigure && (
-                  <span className="rounded border border-border px-1 py-0 text-[9px] font-semibold text-muted-foreground">FIG</span>
+                  <span className="rounded border border-border px-1 py-0 text-[9px] font-semibold text-muted-foreground">
+                    FIG
+                  </span>
                 )}
-                <button type="button" onClick={() => removeAttachment(index)} className="text-muted-foreground hover:text-foreground" aria-label={`Remove ${file.name}`}>
+                <button
+                  type="button"
+                  onClick={() => removeAttachment(index)}
+                  className="text-muted-foreground hover:text-foreground"
+                  aria-label={`Remove ${file.name}`}
+                >
                   <X className="h-3 w-3" />
                 </button>
               </div>
-            )
+            );
           })}
         </div>
       )}
@@ -733,21 +894,41 @@ export function ChatInput({
       {/* Queue drawer */}
       {queue.length > 0 && (
         <div className="mb-2 rounded-lg border border-amber-500/30 bg-amber-500/5 overflow-hidden">
-          <button type="button" onClick={() => setIsQueueExpanded(!isQueueExpanded)} className="w-full flex items-center justify-between px-3 py-1.5 hover:bg-amber-500/10 transition-colors">
+          <button
+            type="button"
+            onClick={() => setIsQueueExpanded(!isQueueExpanded)}
+            className="w-full flex items-center justify-between px-3 py-1.5 hover:bg-amber-500/10 transition-colors"
+          >
             <div className="flex items-center gap-2">
               <ListPlus className="h-3.5 w-3.5 text-amber-500" />
-              <span className="text-xs font-medium text-amber-600 dark:text-amber-400">{queue.length} message{queue.length > 1 ? 's' : ''} queued</span>
+              <span className="text-xs font-medium text-amber-600 dark:text-amber-400">
+                {queue.length} message{queue.length > 1 ? "s" : ""} queued
+              </span>
             </div>
-            <ChevronDown className={`h-3.5 w-3.5 text-amber-500 transition-transform ${isQueueExpanded ? 'rotate-180' : ''}`} />
+            <ChevronDown
+              className={`h-3.5 w-3.5 text-amber-500 transition-transform ${isQueueExpanded ? "rotate-180" : ""}`}
+            />
           </button>
           {isQueueExpanded && (
             <div className="border-t border-amber-500/20 max-h-32 overflow-y-auto">
               {queue.map((queuedMsg, index) => (
-                <div key={index} className="flex items-start gap-2 px-3 py-2 hover:bg-amber-500/5 group">
-                  <span className="text-[10px] text-amber-500/70 font-medium mt-0.5 shrink-0">#{index + 1}</span>
-                  <p className="flex-1 text-xs text-foreground/80 line-clamp-2">{queuedMsg}</p>
+                <div
+                  key={index}
+                  className="flex items-start gap-2 px-3 py-2 hover:bg-amber-500/5 group"
+                >
+                  <span className="text-[10px] text-amber-500/70 font-medium mt-0.5 shrink-0">
+                    #{index + 1}
+                  </span>
+                  <p className="flex-1 text-xs text-foreground/80 line-clamp-2">
+                    {queuedMsg}
+                  </p>
                   {onRemoveFromQueue && (
-                    <button type="button" onClick={() => onRemoveFromQueue(index)} className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity shrink-0" title="Remove from queue">
+                    <button
+                      type="button"
+                      onClick={() => onRemoveFromQueue(index)}
+                      className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity shrink-0"
+                      title="Remove from queue"
+                    >
                       <Trash2 className="h-3 w-3" />
                     </button>
                   )}
@@ -772,25 +953,38 @@ export function ChatInput({
                     onClick={() => insertMention(item)}
                     onMouseEnter={() => setSelectedMentionIndex(index)}
                     className={`w-full flex items-center gap-2 px-3 py-1.5 text-left transition-colors ${
-                      index === selectedMentionIndex ? 'bg-secondary' : 'hover:bg-secondary/50'
+                      index === selectedMentionIndex
+                        ? "bg-secondary"
+                        : "hover:bg-secondary/50"
                     }`}
                   >
                     <span
                       className="flex items-center justify-center h-5 w-5 rounded shrink-0"
                       style={{
-                        backgroundColor: item.color ? `${item.color}20` : 'var(--secondary)',
-                        color: item.color || 'var(--muted-foreground)',
+                        backgroundColor: item.color
+                          ? `${item.color}20`
+                          : "var(--secondary)",
+                        color: item.color || "var(--muted-foreground)",
                       }}
                     >
                       {item.icon}
                     </span>
                     <div className="flex-1 min-w-0">
-                      <p className="text-xs font-medium text-foreground truncate">{item.label}</p>
-                      {item.sublabel && <p className="text-[10px] text-muted-foreground truncate">{item.sublabel}</p>}
+                      <p className="text-xs font-medium text-foreground truncate">
+                        {item.label}
+                      </p>
+                      {item.sublabel && (
+                        <p className="text-[10px] text-muted-foreground truncate">
+                          {item.sublabel}
+                        </p>
+                      )}
                     </div>
                     <span
                       className="shrink-0 rounded border px-1.5 py-0.5 text-[9px] uppercase"
-                      style={{ color: mentionTypeColorMap[item.type], borderColor: `${mentionTypeColorMap[item.type]}66` }}
+                      style={{
+                        color: mentionTypeColorMap[item.type],
+                        borderColor: `${mentionTypeColorMap[item.type]}66`,
+                      }}
                     >
                       @{item.type}
                     </span>
@@ -798,14 +992,20 @@ export function ChatInput({
                 ))
               ) : (
                 <div className="px-3 py-3 text-xs text-muted-foreground">
-                  {mentionQuery ? `No results for "${mentionQuery}"` : mentionFilter === 'all' ? 'No items available.' : `No ${mentionFilter} items available.`}
+                  {mentionQuery
+                    ? `No results for "${mentionQuery}"`
+                    : mentionFilter === "all"
+                      ? "No items available."
+                      : `No ${mentionFilter} items available.`}
                 </div>
               )}
             </div>
 
             {/* Filter row */}
             <div className="flex items-center gap-1 px-2 py-1.5 border-t border-border bg-secondary/30">
-              <span className="text-[10px] text-muted-foreground mr-1">Filter:</span>
+              <span className="text-[10px] text-muted-foreground mr-1">
+                Filter:
+              </span>
               <div className="flex-1 min-w-0 overflow-x-auto">
                 <div className="flex min-w-max items-center gap-1 pr-1">
                   {MENTION_FILTER_OPTIONS.map((type) => (
@@ -814,17 +1014,30 @@ export function ChatInput({
                       type="button"
                       onClick={() => setMentionFilter(type)}
                       className={`shrink-0 max-w-[88px] rounded border px-2 py-0.5 text-[10px] transition-colors ${
-                        mentionFilter === type ? 'border-transparent' : 'border-transparent text-muted-foreground hover:bg-secondary'
+                        mentionFilter === type
+                          ? "border-transparent"
+                          : "border-transparent text-muted-foreground hover:bg-secondary"
                       }`}
                       style={
                         mentionFilter === type
-                          ? type === 'all'
-                            ? { backgroundColor: 'hsl(var(--secondary))', color: 'hsl(var(--foreground))', borderColor: 'hsl(var(--border))' }
-                            : { color: mentionTypeColorMap[type], borderColor: `${mentionTypeColorMap[type]}66` }
+                          ? type === "all"
+                            ? {
+                                backgroundColor: "hsl(var(--secondary))",
+                                color: "hsl(var(--foreground))",
+                                borderColor: "hsl(var(--border))",
+                              }
+                            : {
+                                color: mentionTypeColorMap[type],
+                                borderColor: `${mentionTypeColorMap[type]}66`,
+                              }
                           : undefined
                       }
                     >
-                      <span className="block truncate">{type === 'all' ? 'All' : type.charAt(0).toUpperCase() + type.slice(1)}</span>
+                      <span className="block truncate">
+                        {type === "all"
+                          ? "All"
+                          : type.charAt(0).toUpperCase() + type.slice(1)}
+                      </span>
                     </button>
                   ))}
                 </div>
@@ -833,10 +1046,22 @@ export function ChatInput({
 
             <div className="px-2 py-1 border-t border-border bg-secondary/20">
               <p className="text-[10px] text-muted-foreground">
-                <kbd className="px-1 py-0.5 bg-secondary rounded text-[9px]">↑↓</kbd> results
-                <kbd className="ml-2 px-1 py-0.5 bg-secondary rounded text-[9px]">←→</kbd> filter
-                <kbd className="ml-2 px-1 py-0.5 bg-secondary rounded text-[9px]">Enter</kbd> select
-                <kbd className="ml-2 px-1 py-0.5 bg-secondary rounded text-[9px]">Esc</kbd> close
+                <kbd className="px-1 py-0.5 bg-secondary rounded text-[9px]">
+                  ↑↓
+                </kbd>{" "}
+                results
+                <kbd className="ml-2 px-1 py-0.5 bg-secondary rounded text-[9px]">
+                  ←→
+                </kbd>{" "}
+                filter
+                <kbd className="ml-2 px-1 py-0.5 bg-secondary rounded text-[9px]">
+                  Enter
+                </kbd>{" "}
+                select
+                <kbd className="ml-2 px-1 py-0.5 bg-secondary rounded text-[9px]">
+                  Esc
+                </kbd>{" "}
+                close
               </p>
             </div>
           </div>
@@ -850,8 +1075,12 @@ export function ChatInput({
             aria-hidden
             className="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-4 py-3 text-base leading-6 text-foreground"
           >
-            {message ? highlightedMessage : (
-              <span className="text-muted-foreground">Ask me about your research</span>
+            {message ? (
+              highlightedMessage
+            ) : (
+              <span className="text-muted-foreground">
+                Ask me about your research
+              </span>
             )}
           </div>
 
@@ -861,29 +1090,20 @@ export function ChatInput({
             onChange={handleChange}
             onKeyDown={handleKeyDown}
             onScroll={(e) => {
-              if (highlightRef.current) highlightRef.current.scrollTop = e.currentTarget.scrollTop
+              if (highlightRef.current)
+                highlightRef.current.scrollTop = e.currentTarget.scrollTop;
             }}
             placeholder="Ask me about your research"
             disabled={disabled}
             rows={1}
-            className="relative z-10 w-full resize-none bg-transparent px-4 py-3 pr-12 text-base leading-6 text-transparent caret-foreground placeholder:text-transparent focus:outline-none disabled:opacity-50"
+            className="relative z-10 w-full resize-none bg-transparent px-4 py-3 text-base leading-6 text-transparent caret-foreground placeholder:text-transparent focus:outline-none disabled:opacity-50"
             style={{
               minHeight: `${INITIAL_HEIGHT_PX}px`,
               maxHeight: `${MAX_HEIGHT_PX}px`,
-              caretColor: 'var(--foreground)',
-              color: 'transparent',
+              caretColor: "var(--foreground)",
+              color: "transparent",
             }}
           />
-          <Button
-            variant="ghost"
-            size="icon"
-            className={`chat-toolbar-icon absolute bottom-2 right-2 z-20 ${isRecording ? 'bg-destructive/10 text-destructive' : ''}`}
-            onClick={toggleRecording}
-            disabled={!dictationSupported}
-            title={dictationSupported ? (isRecording ? 'Stop dictation' : 'Start dictation') : 'Dictation not supported'}
-          >
-            {isRecording ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
-          </Button>
         </div>
       </div>
 
@@ -893,17 +1113,30 @@ export function ChatInput({
           {/* Attachments */}
           <Popover open={isAttachOpen} onOpenChange={setIsAttachOpen}>
             <PopoverTrigger asChild>
-              <Button variant="ghost" size="icon" className="chat-toolbar-icon" title="Attach">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="chat-toolbar-icon"
+                title="Attach"
+              >
                 <Paperclip className="h-4 w-4" />
               </Button>
             </PopoverTrigger>
             <PopoverContent side="top" align="start" className="w-44 p-1.5">
               <div className="flex flex-col gap-0.5">
-                <button type="button" onClick={() => openFilePicker('image/*')} className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors hover:bg-secondary">
+                <button
+                  type="button"
+                  onClick={() => openFilePicker("image/*")}
+                  className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors hover:bg-secondary"
+                >
                   <ImageIcon className="h-3.5 w-3.5" />
                   <span>Attach figure</span>
                 </button>
-                <button type="button" onClick={() => openFilePicker()} className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors hover:bg-secondary">
+                <button
+                  type="button"
+                  onClick={() => openFilePicker()}
+                  className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors hover:bg-secondary"
+                >
                   <FileText className="h-3.5 w-3.5" />
                   <span>Attach file</span>
                 </button>
@@ -912,7 +1145,13 @@ export function ChatInput({
           </Popover>
 
           {/* @ menu trigger */}
-          <Button variant="ghost" size="icon" className="chat-toolbar-icon" onClick={() => openMentionFromToolbar('all')} title="Open @ menu">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="chat-toolbar-icon"
+            onClick={() => openMentionFromToolbar("all")}
+            title="Open @ menu"
+          >
             <AtSign className="h-4 w-4" />
           </Button>
 
@@ -922,32 +1161,86 @@ export function ChatInput({
               <button
                 type="button"
                 className={`chat-toolbar-pill flex items-center gap-1 rounded-lg px-2.5 py-1 text-[11px] font-semibold transition-colors ${
-                  mode === 'agent'
-                    ? 'border border-border/60 bg-secondary text-foreground shadow-sm hover:bg-secondary/80'
-                    : mode === 'wild'
-                    ? 'border border-violet-500/35 bg-violet-500/15 text-violet-700 dark:border-violet-400/50 dark:bg-violet-500/24 dark:text-violet-300'
-                    : mode === 'plan'
-                    ? 'border border-orange-500/35 bg-orange-500/15 text-orange-700 dark:border-orange-400/50 dark:bg-orange-500/24 dark:text-orange-300'
-                    : 'border border-blue-500/35 bg-blue-500/14 text-blue-700 dark:border-blue-400/50 dark:bg-blue-500/24 dark:text-blue-300'
+                  mode === "agent"
+                    ? "border border-border/60 bg-secondary text-foreground shadow-sm hover:bg-secondary/80"
+                    : mode === "wild"
+                      ? "border border-violet-500/35 bg-violet-500/15 text-violet-700 dark:border-violet-400/50 dark:bg-violet-500/24 dark:text-violet-300"
+                      : mode === "plan"
+                        ? "border border-orange-500/35 bg-orange-500/15 text-orange-700 dark:border-orange-400/50 dark:bg-orange-500/24 dark:text-orange-300"
+                        : "border border-blue-500/35 bg-blue-500/14 text-blue-700 dark:border-blue-400/50 dark:bg-blue-500/24 dark:text-blue-300"
                 }`}
               >
-                {mode === 'agent' ? <MessageSquare className="h-3 w-3" /> : mode === 'wild' ? <Zap className="h-3 w-3" /> : <ClipboardList className="h-3 w-3" />}
-                {mode === 'wild' ? 'Wild' : mode === 'plan' ? 'Plan' : 'Agent'}
+                {mode === "agent" ? (
+                  <MessageSquare className="h-3 w-3" />
+                ) : mode === "wild" ? (
+                  <Zap className="h-3 w-3" />
+                ) : (
+                  <ClipboardList className="h-3 w-3" />
+                )}
+                {mode === "wild" ? "Wild" : mode === "plan" ? "Plan" : "Agent"}
               </button>
             </PopoverTrigger>
             <PopoverContent side="top" align="start" className="w-56 p-1.5">
               <div className="flex flex-col gap-0.5">
-                <button type="button" onClick={() => { onModeChange('agent'); setIsModeOpen(false) }} className={`flex items-start gap-2 rounded-md px-2 py-2 text-left transition-colors ${mode === 'agent' ? 'bg-secondary border border-border/60' : 'hover:bg-secondary'}`}>
-                  <MessageSquare className={`h-4 w-4 mt-0.5 shrink-0 ${mode === 'agent' ? 'text-foreground' : 'text-muted-foreground'}`} />
-                  <div><p className="text-xs font-medium text-foreground">Agent Mode</p><p className="text-[10px] text-muted-foreground">Normal chat — ask and discuss</p></div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onModeChange("agent");
+                    setIsModeOpen(false);
+                  }}
+                  className={`flex items-start gap-2 rounded-md px-2 py-2 text-left transition-colors ${mode === "agent" ? "bg-secondary border border-border/60" : "hover:bg-secondary"}`}
+                >
+                  <MessageSquare
+                    className={`h-4 w-4 mt-0.5 shrink-0 ${mode === "agent" ? "text-foreground" : "text-muted-foreground"}`}
+                  />
+                  <div>
+                    <p className="text-xs font-medium text-foreground">
+                      Agent Mode
+                    </p>
+                    <p className="text-[10px] text-muted-foreground">
+                      Normal chat — ask and discuss
+                    </p>
+                  </div>
                 </button>
-                <button type="button" onClick={() => { onModeChange('plan'); setIsModeOpen(false) }} className={`flex items-start gap-2 rounded-md px-2 py-2 text-left transition-colors ${mode === 'plan' ? 'bg-orange-500/10 border border-orange-500/35 dark:bg-orange-500/18 dark:border-orange-400/45' : 'hover:bg-secondary'}`}>
-                  <ClipboardList className={`h-4 w-4 mt-0.5 shrink-0 ${mode === 'plan' ? 'text-orange-600 dark:text-orange-300' : 'text-muted-foreground'}`} />
-                  <div><p className="text-xs font-medium text-foreground">Plan Mode</p><p className="text-[10px] text-muted-foreground">Think first — propose a plan before acting</p></div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onModeChange("plan");
+                    setIsModeOpen(false);
+                  }}
+                  className={`flex items-start gap-2 rounded-md px-2 py-2 text-left transition-colors ${mode === "plan" ? "bg-orange-500/10 border border-orange-500/35 dark:bg-orange-500/18 dark:border-orange-400/45" : "hover:bg-secondary"}`}
+                >
+                  <ClipboardList
+                    className={`h-4 w-4 mt-0.5 shrink-0 ${mode === "plan" ? "text-orange-600 dark:text-orange-300" : "text-muted-foreground"}`}
+                  />
+                  <div>
+                    <p className="text-xs font-medium text-foreground">
+                      Plan Mode
+                    </p>
+                    <p className="text-[10px] text-muted-foreground">
+                      Think first — propose a plan before acting
+                    </p>
+                  </div>
                 </button>
-                <button type="button" onClick={() => { onModeChange('wild'); setIsModeOpen(false) }} className={`flex items-start gap-2 rounded-md px-2 py-2 text-left transition-colors ${mode === 'wild' ? 'bg-violet-500/10 border border-violet-500/35 dark:bg-violet-500/18 dark:border-violet-400/45' : 'hover:bg-secondary'}`}>
-                  <Zap className={`h-4 w-4 mt-0.5 shrink-0 ${mode === 'wild' ? 'text-violet-600 dark:text-violet-300' : 'text-muted-foreground'}`} />
-                  <div><p className="text-xs font-medium text-foreground">Wild Mode</p><p className="text-[10px] text-muted-foreground">Autonomous loop — agent runs experiments</p></div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onModeChange("wild");
+                    setIsModeOpen(false);
+                  }}
+                  className={`flex items-start gap-2 rounded-md px-2 py-2 text-left transition-colors ${mode === "wild" ? "bg-violet-500/10 border border-violet-500/35 dark:bg-violet-500/18 dark:border-violet-400/45" : "hover:bg-secondary"}`}
+                >
+                  <Zap
+                    className={`h-4 w-4 mt-0.5 shrink-0 ${mode === "wild" ? "text-violet-600 dark:text-violet-300" : "text-muted-foreground"}`}
+                  />
+                  <div>
+                    <p className="text-xs font-medium text-foreground">
+                      Wild Mode
+                    </p>
+                    <p className="text-[10px] text-muted-foreground">
+                      Autonomous loop — agent runs experiments
+                    </p>
+                  </div>
                 </button>
               </div>
             </PopoverContent>
@@ -957,27 +1250,69 @@ export function ChatInput({
           {onModelChange && modelOptions.length > 0 && (
             <Popover open={isModelOpen} onOpenChange={setIsModelOpen}>
               <PopoverTrigger asChild>
-                <button type="button" disabled={isModelUpdating} className="chat-toolbar-pill flex max-w-[190px] min-w-9 items-center gap-1 rounded-lg border border-border/60 bg-secondary px-2 py-1 text-[11px] font-medium text-foreground shadow-sm transition-colors hover:bg-secondary/80 disabled:cursor-not-allowed disabled:opacity-60" title="Select model">
+                <button
+                  type="button"
+                  disabled={isModelUpdating}
+                  className="chat-toolbar-pill flex max-w-[190px] min-w-9 items-center gap-1 rounded-lg border border-border/60 bg-secondary px-2 py-1 text-[11px] font-medium text-foreground shadow-sm transition-colors hover:bg-secondary/80 disabled:cursor-not-allowed disabled:opacity-60"
+                  title="Select model"
+                >
                   <Cpu className="h-3 w-3 shrink-0 text-muted-foreground" />
-                  <span className="min-w-0 flex-1 truncate">{effectiveSelectedModel?.model_id || 'Model'}</span>
+                  <span className="min-w-0 flex-1 truncate">
+                    {effectiveSelectedModel?.model_id || "Model"}
+                  </span>
                   <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
                 </button>
               </PopoverTrigger>
               <PopoverContent side="top" align="start" className="w-72 p-1.5">
-                <p className="px-2 pb-1 text-[10px] uppercase tracking-wide text-muted-foreground">Provider &gt; Model ID</p>
+                <p className="px-2 pb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Provider &gt; Model ID
+                </p>
                 <div className="flex max-h-72 flex-col gap-1 overflow-y-auto">
                   {modelOptionsByProvider.map((group) => (
-                    <div key={group.providerId} className="rounded-md border border-border/50 bg-background/60 p-1">
-                      <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{group.providerId}</p>
+                    <div
+                      key={group.providerId}
+                      className="rounded-md border border-border/50 bg-background/60 p-1"
+                    >
+                      <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        {group.providerId}
+                      </p>
                       <div className="flex flex-col gap-0.5">
                         {group.options.map((option) => {
-                          const isSelected = Boolean(effectiveSelectedModel && option.provider_id === effectiveSelectedModel.provider_id && option.model_id === effectiveSelectedModel.model_id)
+                          const isSelected = Boolean(
+                            effectiveSelectedModel &&
+                            option.provider_id ===
+                              effectiveSelectedModel.provider_id &&
+                            option.model_id === effectiveSelectedModel.model_id,
+                          );
                           return (
-                            <button key={`${option.provider_id}:${option.model_id}`} type="button" disabled={isModelUpdating} onClick={() => { void (async () => { try { await onModelChange({ provider_id: option.provider_id, model_id: option.model_id }) } finally { setIsModelOpen(false) } })() }} className={`flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-colors ${isSelected ? 'border border-border/70 bg-secondary' : 'border border-transparent hover:bg-secondary/70'}`}>
-                              <div className="h-4 w-4 shrink-0 text-primary">{isSelected ? <Check className="h-4 w-4" /> : null}</div>
-                              <p className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">{option.model_id}</p>
+                            <button
+                              key={`${option.provider_id}:${option.model_id}`}
+                              type="button"
+                              disabled={isModelUpdating}
+                              onClick={() => {
+                                void (async () => {
+                                  try {
+                                    await onModelChange({
+                                      provider_id: option.provider_id,
+                                      model_id: option.model_id,
+                                    });
+                                  } finally {
+                                    setIsModelOpen(false);
+                                  }
+                                })();
+                              }}
+                              className={`flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-colors ${isSelected ? "border border-border/70 bg-secondary" : "border border-transparent hover:bg-secondary/70"}`}
+                            >
+                              <div className="h-4 w-4 shrink-0 text-primary">
+                                {isSelected ? (
+                                  <Check className="h-4 w-4" />
+                                ) : null}
+                              </div>
+                              <p className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+                                {option.model_id}
+                              </p>
                             </button>
-                          )
+                          );
                         })}
                       </div>
                     </div>
@@ -990,21 +1325,56 @@ export function ChatInput({
 
         {/* Stop + Send */}
         <div className="ml-auto flex min-w-0 items-center gap-1.5">
+          {/* Dictation mic button */}
+          <div className="relative flex items-center">
+            <Button
+              variant="ghost"
+              size="icon"
+              className={`chat-toolbar-icon ${isRecording ? "bg-destructive/10 text-destructive" : ""}`}
+              onClick={toggleRecording}
+              disabled={!dictationSupported}
+              title={
+                dictationSupported
+                  ? isRecording
+                    ? "Stop dictation"
+                    : "Start dictation"
+                  : "Dictation not supported"
+              }
+            >
+              {isRecording ? (
+                <MicOff className="h-4 w-4" />
+              ) : (
+                <Mic className="h-4 w-4" />
+              )}
+            </Button>
+            {isRecording && (
+              <span className="absolute -top-1 -right-1 flex items-center gap-0.5 text-[9px] text-destructive animate-pulse">
+                <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
+              </span>
+            )}
+          </div>
           {isStreaming && onStop && (
-            <Button onClick={onStop} variant="outline" size="sm" className="h-9 px-3 text-xs border-destructive/40 text-destructive hover:bg-destructive/10">
+            <Button
+              onClick={onStop}
+              variant="outline"
+              size="sm"
+              className="h-9 px-3 text-xs border-destructive/40 text-destructive hover:bg-destructive/10"
+            >
               Stop
             </Button>
           )}
           <Button
             onClick={handleSubmit}
-            disabled={!message.trim() && !replyExcerpt && attachments.length === 0}
+            disabled={
+              !message.trim() && !replyExcerpt && attachments.length === 0
+            }
             size="icon"
             className={`chat-toolbar-icon ml-auto shrink-0 rounded-lg disabled:opacity-30 relative ${
               isStreaming && onQueue
-                ? 'bg-amber-500 text-white hover:bg-amber-600'
+                ? "bg-amber-500 text-white hover:bg-amber-600"
                 : isWildLoopActive && onSteer
-                  ? 'bg-orange-500 text-white hover:bg-orange-600'
-                  : 'bg-primary text-primary-foreground hover:bg-primary/90'
+                  ? "bg-orange-500 text-white hover:bg-orange-600"
+                  : "bg-primary text-primary-foreground hover:bg-primary/90"
             }`}
             title="Send message"
           >
@@ -1012,17 +1382,31 @@ export function ChatInput({
               <>
                 <ListPlus />
                 {queueCount > 0 && (
-                  <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-foreground text-[9px] font-medium text-background">{queueCount}</span>
+                  <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-foreground text-[9px] font-medium text-background">
+                    {queueCount}
+                  </span>
                 )}
               </>
             ) : (
               <Send />
             )}
-            <span className="sr-only">{isStreaming && onQueue ? 'Queue message' : isWildLoopActive && onSteer ? 'Steer agent' : 'Send message'}</span>
+            <span className="sr-only">
+              {isStreaming && onQueue
+                ? "Queue message"
+                : isWildLoopActive && onSteer
+                  ? "Steer agent"
+                  : "Send message"}
+            </span>
           </Button>
         </div>
       </div>
-      <input ref={fileInputRef} type="file" className="hidden" multiple onChange={handleFileSelect} />
+      <input
+        ref={fileInputRef}
+        type="file"
+        className="hidden"
+        multiple
+        onChange={handleFileSelect}
+      />
     </div>
-  )
+  );
 }

--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -1312,7 +1312,7 @@ export function ChatInput({
             placeholder="Ask me about your research"
             disabled={disabled}
             rows={1}
-            className="relative z-10 w-full resize-none bg-transparent px-4 py-3 pr-12 text-base leading-6 text-transparent caret-foreground placeholder:text-transparent focus:outline-none disabled:opacity-50"
+            className="relative z-10 w-full resize-none bg-transparent px-4 py-3 text-base leading-6 text-transparent caret-foreground placeholder:text-transparent focus:outline-none disabled:opacity-50"
             style={{
               minHeight: `var(--app-chat-input-initial-height, ${DEFAULT_CHAT_INPUT_INITIAL_HEIGHT_PX}px)`,
               maxHeight: `${MAX_CHAT_INPUT_HEIGHT_PX}px`,
@@ -1320,26 +1320,6 @@ export function ChatInput({
               color: 'transparent',
             }}
           />
-          <Button
-            variant="ghost"
-            size="icon"
-            className={`chat-toolbar-icon absolute bottom-2 right-2 z-20 ${isRecording ? 'text-destructive bg-destructive/10' : ''}`}
-            onClick={toggleRecording}
-            disabled={!dictationSupported}
-            title={dictationSupported ? (isRecording ? 'Stop dictation' : 'Start dictation') : 'Dictation not supported'}
-          >
-            {isRecording ? (
-              <MicOff className="h-4 w-4" />
-            ) : (
-              <Mic className="h-4 w-4" />
-            )}
-          </Button>
-          {isRecording && (
-            <span className="absolute bottom-4 right-12 z-20 flex items-center gap-1 text-[10px] text-destructive animate-pulse">
-              <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
-              Rec
-            </span>
-          )}
         </div>
       </div>
 
@@ -1565,6 +1545,24 @@ export function ChatInput({
 
         {/* Stop + Send/Queue buttons */}
         <div className="ml-auto flex min-w-0 items-center gap-1.5">
+          {/* Dictation mic button */}
+          <div className="relative flex items-center">
+            <Button
+              variant="ghost"
+              size="icon"
+              className={`chat-toolbar-icon ${isRecording ? 'bg-destructive/10 text-destructive' : ''}`}
+              onClick={toggleRecording}
+              disabled={!dictationSupported}
+              title={dictationSupported ? (isRecording ? 'Stop dictation' : 'Start dictation') : 'Dictation not supported'}
+            >
+              {isRecording ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+            </Button>
+            {isRecording && (
+              <span className="absolute -top-1 -right-1 flex items-center gap-0.5 text-[9px] text-destructive animate-pulse">
+                <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
+              </span>
+            )}
+          </div>
           {/* Context token count - circular indicator */}
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

Moves the dictation (Mic/MicOff) button from its absolute-positioned overlay inside the textarea container to the bottom action bar, next to the Stop and Send buttons.

## Changes

- **chat-input-simple.tsx** (active component): Removed Mic button from textarea overlay, added it to the send-button row with a recording indicator dot
- **chat-input.tsx** (backup component): Same structural changes for consistency
- Removed unnecessary `pr-12` right padding from textarea (no longer needed without the overlay button)

## Verification

- `npm run build` passes cleanly