### PR TITLE
fix(ci): deploy preview even when PR has merge conflicts

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_PAT }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

The `preview-deploy.yml` workflow uses `actions/checkout@v4` which defaults to checking out `refs/pull/N/merge` — a GitHub-synthesized merge ref. When a PR has merge conflicts with the base branch, this ref doesn't exist, so checkout fails and the deploy is skipped entirely.

**Fix:** Add `ref: ${{ github.event.pull_request.head.sha }}` to check out the PR's head commit directly, ensuring the preview is always deployed regardless of merge status.

## Changes

- `.github/workflows/preview-deploy.yml`: Added `ref:` to checkout step in `deploy-preview` job