### PR TITLE
feat: add thinking display mode toggle (collapsible/inline)

### DIFF
--- a/components/chat-message.tsx
+++ b/components/chat-message.tsx
@@ -120,8 +120,8 @@ export function ChatMessage({
   previousUserContent,
 }: ChatMessageProps) {
   const { settings } = useAppSettings()
-  const thinkingInline = settings.appearance.thinkingDisplayMode === 'inline'
-  const [isThinkingOpen, setIsThinkingOpen] = useState(false)
+  const thinkingMode = settings.appearance.thinkingDisplayMode || 'inline'
+  const [isThinkingOpen, setIsThinkingOpen] = useState(thinkingMode === 'expand')
   const [isChartOpen, setIsChartOpen] = useState(true)
   const [isUserMessageExpanded, setIsUserMessageExpanded] = useState(false)
   const [selectionReplyUi, setSelectionReplyUi] = useState<{
@@ -623,13 +623,13 @@ export function ChatMessage({
         ) : (
           // Legacy: single thinking block
           message.thinking && (
-            thinkingInline ? (
+            thinkingMode === 'inline' ? (
               <div className="space-y-1">
                 <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                   <Brain className="h-3 w-3" />
                   <span>Thought</span>
                 </div>
-                <div className="px-1 py-1 text-xs leading-relaxed text-muted-foreground">
+                <div className="px-1 py-1 leading-relaxed text-muted-foreground" style={{ fontSize: 'var(--app-thinking-tool-font-size, 14px)' }}>
                   {message.thinking.split('\n').map((line, i) => (
                     <p key={i} className={line.trim() === '' ? 'h-2' : ''}>
                       {line}
@@ -649,7 +649,7 @@ export function ChatMessage({
                   <span>Thinking process</span>
                 </CollapsibleTrigger>
                 <CollapsibleContent className="mt-2">
-                  <div className="w-full rounded-lg border border-border/50 bg-secondary/30 p-3 text-xs leading-relaxed text-muted-foreground">
+                  <div className="w-full rounded-lg border border-border/50 bg-secondary/30 p-3 leading-relaxed text-muted-foreground" style={{ fontSize: 'var(--app-thinking-tool-font-size, 14px)' }}>
                     {message.thinking.split('\n').map((line, i) => (
                       <p key={i} className={line.trim() === '' ? 'h-2' : ''}>
                         {line}
@@ -773,18 +773,23 @@ function SavedPartRenderer({
   renderMarkdown: (content: string) => React.ReactNode
 }) {
   const { settings } = useAppSettings()
-  const thinkingInline = settings.appearance.thinkingDisplayMode === 'inline'
-  const [isOpen, setIsOpen] = useState(false) // Default collapsed per user preference
+  const thinkingMode = settings.appearance.thinkingDisplayMode || 'inline'
+  const toolMode = settings.appearance.toolDisplayMode || 'expand'
+  const [isOpen, setIsOpen] = useState(() => {
+    if (part.type === 'thinking') return thinkingMode === 'expand'
+    if (part.type === 'tool') return toolMode === 'expand'
+    return false
+  })
 
   if (part.type === 'thinking') {
-    if (thinkingInline) {
+    if (thinkingMode === 'inline') {
       return (
         <div className="space-y-1">
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <Brain className="h-3 w-3" />
             <span>Thought</span>
           </div>
-          <div className="px-1 py-1 text-xs leading-relaxed text-muted-foreground">
+          <div className="px-1 py-1 leading-relaxed text-muted-foreground" style={{ fontSize: 'var(--app-thinking-tool-font-size, 14px)' }}>
             {part.content.split('\n').map((line, i) => (
               <p key={i} className={line.trim() === '' ? 'h-2' : ''}>
                 {line}
@@ -812,7 +817,7 @@ function SavedPartRenderer({
           )}
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-2">
-          <div className="w-full rounded-lg border border-border/50 bg-secondary/30 p-3 text-xs leading-relaxed text-muted-foreground max-h-[var(--app-streaming-tool-box-height,7.5rem)] overflow-y-auto">
+          <div className="w-full rounded-lg border border-border/50 bg-secondary/30 p-3 leading-relaxed text-muted-foreground max-h-[var(--app-streaming-tool-box-height,7.5rem)] overflow-y-auto" style={{ fontSize: 'var(--app-thinking-tool-font-size, 14px)' }}>
             {part.content.split('\n').map((line, i) => (
               <p key={i} className={line.trim() === '' ? 'h-2' : ''}>
                 {line}
@@ -851,6 +856,50 @@ function SavedPartRenderer({
       }
     }
 
+    const toolContent = (part.toolInput || part.toolOutput || part.content) ? (
+      <div className="w-full rounded-lg border border-border/50 bg-secondary/30 p-3 leading-relaxed text-muted-foreground space-y-2 max-h-[var(--app-streaming-tool-box-height,7.5rem)] overflow-y-auto" style={{ fontSize: 'var(--app-thinking-tool-font-size, 14px)' }}>
+        {part.toolInput && (
+          <div>
+            <span className="font-medium text-foreground/70">Input:</span>
+            <pre className="mt-1 whitespace-pre-wrap break-all overflow-hidden">{part.toolInput}</pre>
+          </div>
+        )}
+        {part.toolOutput && (
+          <div>
+            <span className="font-medium text-foreground/70">Output:</span>
+            <pre className="mt-1 whitespace-pre-wrap break-all overflow-hidden">{part.toolOutput}</pre>
+          </div>
+        )}
+        {part.content && !part.toolInput && !part.toolOutput && (
+          <pre className="whitespace-pre-wrap break-all overflow-hidden">{part.content}</pre>
+        )}
+        {(part.toolStartedAt || part.toolEndedAt) && (
+          <div className="text-muted-foreground/80">
+            {part.toolStartedAt && <div>Start: {formatToolTimestamp(part.toolStartedAt)}</div>}
+            {part.toolEndedAt && <div>End: {formatToolTimestamp(part.toolEndedAt)}</div>}
+          </div>
+        )}
+      </div>
+    ) : null
+
+    if (toolMode === 'inline') {
+      return (
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            {getStatusIcon()}
+            <Wrench className="h-3 w-3" />
+            <span>{part.toolName || 'Tool'}</span>
+            <span className="text-muted-foreground/60">•</span>
+            <span className={part.toolState === 'completed' ? 'text-green-500' : part.toolState === 'error' ? 'text-red-500' : ''}>
+              {getStatusText()}
+            </span>
+            {durationLabel && <span className="text-muted-foreground/70">({durationLabel})</span>}
+          </div>
+          {toolContent}
+        </div>
+      )
+    }
+
     return (
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <CollapsibleTrigger className="flex w-full items-center justify-start gap-2 rounded-lg bg-secondary/50 px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground">
@@ -870,31 +919,7 @@ function SavedPartRenderer({
           )}
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-2">
-          {(part.toolInput || part.toolOutput || part.content) && (
-            <div className="w-full rounded-lg border border-border/50 bg-secondary/30 p-3 text-xs leading-relaxed text-muted-foreground space-y-2 max-h-[var(--app-streaming-tool-box-height,7.5rem)] overflow-y-auto">
-              {part.toolInput && (
-                <div>
-                  <span className="font-medium text-foreground/70">Input:</span>
-                  <pre className="mt-1 whitespace-pre-wrap break-all overflow-hidden">{part.toolInput}</pre>
-                </div>
-              )}
-              {part.toolOutput && (
-                <div>
-                  <span className="font-medium text-foreground/70">Output:</span>
-                  <pre className="mt-1 whitespace-pre-wrap break-all overflow-hidden">{part.toolOutput}</pre>
-                </div>
-              )}
-              {part.content && !part.toolInput && !part.toolOutput && (
-                <pre className="whitespace-pre-wrap break-all overflow-hidden">{part.content}</pre>
-              )}
-              {(part.toolStartedAt || part.toolEndedAt) && (
-                <div className="text-muted-foreground/80">
-                  {part.toolStartedAt && <div>Start: {formatToolTimestamp(part.toolStartedAt)}</div>}
-                  {part.toolEndedAt && <div>End: {formatToolTimestamp(part.toolEndedAt)}</div>}
-                </div>
-              )}
-            </div>
-          )}
+          {toolContent}
         </CollapsibleContent>
       </Collapsible>
     )

--- a/components/connected-chat-view.tsx
+++ b/components/connected-chat-view.tsx
@@ -110,7 +110,7 @@ export function ConnectedChatView({
     const [excerptPreview, setExcerptPreview] = useState<{ fileName: string; text: string } | null>(null)
     const [isExcerptPreviewOpen, setIsExcerptPreviewOpen] = useState(false)
     const { settings, setSettings } = useAppSettings()
-    const showStarterCards = settings.appearance.showStarterCards !== false
+    const showStarterCards = settings.appearance.starterCardFlavor !== 'none'
     const showChatContextPanel = settings.appearance.showChatContextPanel !== false
     const starterCardFlavor = settings.appearance.starterCardFlavor || 'novice'
     const customTemplates = settings.appearance.starterCardTemplates ?? {}

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -341,16 +341,8 @@ export function SettingsDialog({
           label: 'Starter Cards',
           description: 'Show contextual prompt cards on new chats',
           icon: LayoutGrid,
-          type: 'toggle' as const,
-          value: settings.appearance.showStarterCards !== false,
-        },
-        {
-          id: 'starterCardFlavor',
-          label: 'Starter Card Flavor',
-          description: 'Choose between expert context cards and novice quick-start prompts',
-          icon: LayoutGrid,
           type: 'select' as const,
-          options: ['expert', 'novice'],
+          options: ['none', 'novice', 'expert'],
           value: settings.appearance.starterCardFlavor || 'novice',
         },
         {
@@ -909,7 +901,8 @@ export function SettingsDialog({
                       if (item.id === 'theme') handleThemeChange(option as 'dark' | 'light' | 'system')
                       if (item.id === 'fontSize') handleFontSizeChange(option as 'small' | 'medium' | 'large')
                       if (item.id === 'buttonSize') handleButtonSizeChange(option as 'compact' | 'default' | 'large')
-                      if (item.id === 'starterCardFlavor') updateAppearanceSettings({ starterCardFlavor: option as 'expert' | 'novice' })
+                      if (item.id === 'starterCardFlavor') updateAppearanceSettings({ starterCardFlavor: option as 'none' | 'novice' | 'expert' })
+                      if (item.id === 'showStarterCards') updateAppearanceSettings({ starterCardFlavor: option as 'none' | 'novice' | 'expert' })
                     }}
                     className={`flex-1 rounded-lg px-3 py-2 text-xs font-medium capitalize whitespace-nowrap transition-colors ${item.value === option
                       ? 'bg-accent text-accent-foreground'
@@ -940,7 +933,6 @@ export function SettingsDialog({
               onCheckedChange={(checked) => {
                 if (item.id === 'alertsEnabled') handleAlertsToggle(checked)
                 if (item.id === 'webNotifications') handleWebNotificationsToggle(checked)
-                if (item.id === 'showStarterCards') updateAppearanceSettings({ showStarterCards: checked })
                 if (item.id === 'showChatContextPanel') updateAppearanceSettings({ showChatContextPanel: checked })
                 if (item.id === 'showChatArtifacts') updateAppearanceSettings({ showChatArtifacts: checked })
                 if (item.id === 'chatCollapseAllChats') updateAppearanceSettings({ chatCollapseAllChats: checked })

--- a/components/settings-page-content.tsx
+++ b/components/settings-page-content.tsx
@@ -26,6 +26,7 @@ import {
   X,
   Bug,
   FileText,
+  Wrench,
 } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
@@ -111,6 +112,9 @@ export function SettingsPageContent({
   )
   const [wildLoopHistoryBoxHeightInput, setWildLoopHistoryBoxHeightInput] = useState<string>(
     settings.appearance.wildLoopHistoryBoxHeightPx?.toString() ?? ''
+  )
+  const [thinkingToolFontSizeInput, setThinkingToolFontSizeInput] = useState<string>(
+    settings.appearance.thinkingToolFontSizePx?.toString() ?? ''
   )
 
   React.useEffect(() => {
@@ -326,16 +330,8 @@ export function SettingsPageContent({
           label: 'Starter Cards',
           description: 'Show contextual prompt cards on new chats',
           icon: LayoutGrid,
-          type: 'toggle' as const,
-          value: settings.appearance.showStarterCards !== false,
-        },
-        {
-          id: 'starterCardFlavor',
-          label: 'Starter Card Flavor',
-          description: 'Choose between expert context cards and novice quick-start prompts',
-          icon: LayoutGrid,
           type: 'select' as const,
-          options: ['expert', 'novice'],
+          options: ['none', 'novice', 'expert'],
           value: settings.appearance.starterCardFlavor || 'novice',
         },
         {
@@ -381,11 +377,27 @@ export function SettingsPageContent({
         {
           id: 'thinkingDisplayMode',
           label: 'Thinking Display',
-          description: 'Show thinking as collapsible box or inline text',
+          description: 'How thinking content is rendered',
           icon: Brain,
           type: 'select' as const,
-          options: ['collapsible', 'inline'],
-          value: settings.appearance.thinkingDisplayMode || 'collapsible',
+          options: ['collapse', 'expand', 'inline'],
+          value: settings.appearance.thinkingDisplayMode || 'inline',
+        },
+        {
+          id: 'toolDisplayMode',
+          label: 'Tool Display',
+          description: 'How tool call content is rendered',
+          icon: Wrench,
+          type: 'select' as const,
+          options: ['collapse', 'expand', 'inline'],
+          value: settings.appearance.toolDisplayMode || 'expand',
+        },
+        {
+          id: 'thinkingToolFontSize',
+          label: 'Thinking / Tool Font Size',
+          description: 'Font size in px for thinking and tool content (10–24)',
+          icon: Type,
+          type: 'custom' as const,
         },
         {
           id: 'appearanceAdvanced',
@@ -887,7 +899,9 @@ export function SettingsPageContent({
                       if (item.id === 'fontSize') handleFontSizeChange(option as 'small' | 'medium' | 'large')
                       if (item.id === 'buttonSize') handleButtonSizeChange(option as 'compact' | 'default' | 'large')
                       if (item.id === 'starterCardFlavor') updateAppearanceSettings({ starterCardFlavor: option as 'expert' | 'novice' })
-                      if (item.id === 'thinkingDisplayMode') updateAppearanceSettings({ thinkingDisplayMode: option as 'collapsible' | 'inline' })
+                      if (item.id === 'showStarterCards') updateAppearanceSettings({ starterCardFlavor: option as 'none' | 'novice' | 'expert' })
+                      if (item.id === 'thinkingDisplayMode') updateAppearanceSettings({ thinkingDisplayMode: option as 'collapse' | 'expand' | 'inline' })
+                      if (item.id === 'toolDisplayMode') updateAppearanceSettings({ toolDisplayMode: option as 'collapse' | 'expand' | 'inline' })
                     }}
                     className={`flex-1 rounded-lg px-3 py-2 text-xs font-medium capitalize whitespace-nowrap transition-colors ${item.value === option
                       ? 'bg-accent text-accent-foreground'
@@ -918,7 +932,6 @@ export function SettingsPageContent({
                 if (item.id === 'alertsEnabled') handleAlertsToggle(checked)
                 if (item.id === 'webNotifications') handleWebNotificationsToggle(checked)
                 if (item.id === 'showRunItemMetadata') updateAppearanceSettings({ showRunItemMetadata: checked })
-                if (item.id === 'showStarterCards') updateAppearanceSettings({ showStarterCards: checked })
                 if (item.id === 'showChatContextPanel') updateAppearanceSettings({ showChatContextPanel: checked })
                 if (item.id === 'showChatArtifacts') updateAppearanceSettings({ showChatArtifacts: checked })
                 if (item.id === 'chatCollapseAllChats') updateAppearanceSettings({ chatCollapseAllChats: checked })
@@ -947,21 +960,58 @@ export function SettingsPageContent({
           </div>
         )
       case 'custom':
-        if (item.id === 'appearanceAdvanced') {
+        if (item.id === 'thinkingToolFontSize') {
           return (
             <div className="rounded-lg bg-secondary/50 p-4">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-background">
-                  <Square className="h-5 w-5 text-muted-foreground" />
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div className="flex items-center gap-3 md:min-w-0 md:flex-1">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-background">
+                    <Type className="h-5 w-5 text-muted-foreground" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-foreground md:truncate">{item.label}</p>
+                    <p className="text-xs text-muted-foreground md:truncate">{item.description}</p>
+                  </div>
                 </div>
-                <div>
-                  <p className="text-sm font-medium text-foreground">Advanced Appearance</p>
-                  <p className="text-xs text-muted-foreground">Numeric control for fonts and buttons</p>
-                </div>
+                <Input
+                  id="thinking-tool-font-size"
+                  type="number"
+                  min={10}
+                  max={24}
+                  value={thinkingToolFontSizeInput}
+                  onChange={(e) => {
+                    setThinkingToolFontSizeInput(e.target.value)
+                    const v = Number(e.target.value)
+                    if (Number.isFinite(v) && v >= 10 && v <= 24) {
+                      updateAppearanceSettings({ thinkingToolFontSizePx: v })
+                    }
+                  }}
+                  onBlur={(e) => {
+                    const v = Number(e.target.value)
+                    if (Number.isFinite(v) && v >= 10 && v <= 24) {
+                      updateAppearanceSettings({ thinkingToolFontSizePx: v })
+                    } else {
+                      setThinkingToolFontSizeInput(settings.appearance.thinkingToolFontSizePx?.toString() ?? '14')
+                    }
+                  }}
+                  placeholder="14"
+                  className="h-8 w-24 text-xs"
+                />
+              </div>
+            </div>
+          )
+        }
+
+        if (item.id === 'appearanceAdvanced') {
+          return (
+            <div className="space-y-3">
+              <div className="flex items-center gap-3 px-1">
+                <Square className="h-4 w-4 text-muted-foreground" />
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Advanced</p>
               </div>
 
-              <div className="mt-4 space-y-3 border-t border-border pt-4">
-                  <div className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-background/60 px-3 py-2">
+              <div className="rounded-lg bg-secondary/50 p-4">
+                  <div className="flex items-center justify-between gap-3 rounded-md px-1 py-1">
                     <div>
                       <Label htmlFor="sidebar-new-chat-toggle" className="text-xs">Sidebar New Chat Button</Label>
                       <p className="text-[11px] text-muted-foreground">Show or hide the New Chat button in the desktop sidebar</p>
@@ -972,8 +1022,10 @@ export function SettingsPageContent({
                       onCheckedChange={(checked) => updateAppearanceSettings({ showSidebarNewChatButton: checked })}
                     />
                   </div>
+              </div>
 
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
                       <Label htmlFor="custom-font-size" className="text-xs">Font Size (px) <span className="font-normal text-muted-foreground">1–1000</span></Label>
                       <p className="text-[11px] text-muted-foreground">Overrides small/medium/large when set</p>
@@ -990,8 +1042,10 @@ export function SettingsPageContent({
                       className="h-8 w-24 text-xs"
                     />
                   </div>
+                  </div>
 
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
                       <Label htmlFor="custom-button-scale" className="text-xs">Button Scale (%) <span className="font-normal text-muted-foreground">1–1000</span></Label>
                       <p className="text-[11px] text-muted-foreground">Scales global button sizes</p>
@@ -1008,8 +1062,10 @@ export function SettingsPageContent({
                       className="h-8 w-24 text-xs"
                     />
                   </div>
+                  </div>
 
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
                       <Label htmlFor="chat-toolbar-button-size" className="text-xs">Chat Bottom Buttons (px) <span className="font-normal text-muted-foreground">1–1000</span></Label>
                       <p className="text-[11px] text-muted-foreground">Mode/add/mention/command controls</p>
@@ -1026,8 +1082,10 @@ export function SettingsPageContent({
                       className="h-8 w-24 text-xs"
                     />
                   </div>
+                  </div>
 
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
                       <Label htmlFor="chat-input-initial-height" className="text-xs">Chat Input Initial Height (px) <span className="font-normal text-muted-foreground">40–120</span></Label>
                       <p className="text-[11px] text-muted-foreground">Default one-line composer height before expansion</p>
@@ -1044,8 +1102,10 @@ export function SettingsPageContent({
                       className="h-8 w-24 text-xs"
                     />
                   </div>
+                  </div>
 
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
                       <Label htmlFor="tool-box-height" className="text-xs">Tool / Thinking Box Height (rem) <span className="font-normal text-muted-foreground">1–1000</span></Label>
                       <p className="text-[11px] text-muted-foreground">Max height of tool/thinking boxes during streaming</p>
@@ -1063,8 +1123,10 @@ export function SettingsPageContent({
                       className="h-8 w-24 text-xs"
                     />
                   </div>
+                  </div>
 
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
                       <Label htmlFor="custom-primary-color" className="text-xs">Primary Color</Label>
                       <p className="text-[11px] text-muted-foreground">Hex color for --primary (example: #f59e0b)</p>
@@ -1078,8 +1140,27 @@ export function SettingsPageContent({
                       className="h-8 w-28 text-xs font-mono"
                     />
                   </div>
+                  </div>
 
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                    <div>
+                      <Label htmlFor="custom-accent-color" className="text-xs">Accent Color</Label>
+                      <p className="text-[11px] text-muted-foreground">Hex color for --accent (example: #fb923c)</p>
+                    </div>
+                    <Input
+                      id="custom-accent-color"
+                      value={accentColorInput}
+                      onChange={(e) => handleAccentColorChange(e.target.value)}
+                      onBlur={(e) => handleAccentColorBlur(e.target.value)}
+                      placeholder="#fb923c"
+                      className="h-8 w-28 text-xs font-mono"
+                    />
+                  </div>
+                  </div>
+
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
                       <Label htmlFor="wild-loop-tasks-font-size" className="text-xs">Wild Loop Tasks Font (px) <span className="font-normal text-muted-foreground">12–28</span></Label>
                       <p className="text-[11px] text-muted-foreground">tasks.md text size in the Wild Loop Debug panel</p>
@@ -1096,8 +1177,10 @@ export function SettingsPageContent({
                       className="h-8 w-24 text-xs"
                     />
                   </div>
+                  </div>
 
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
                       <Label htmlFor="wild-loop-tasks-box-height" className="text-xs">Wild Loop Tasks Box Height (px) <span className="font-normal text-muted-foreground">160–1200</span></Label>
                       <p className="text-[11px] text-muted-foreground">Max height of the tasks.md scroll area in the Wild Loop Debug panel</p>
@@ -1114,23 +1197,10 @@ export function SettingsPageContent({
                       className="h-8 w-24 text-xs"
                     />
                   </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="custom-accent-color" className="text-xs">Accent Color</Label>
-                      <p className="text-[11px] text-muted-foreground">Hex color for --accent (example: #fb923c)</p>
-                    </div>
-                    <Input
-                      id="custom-accent-color"
-                      value={accentColorInput}
-                      onChange={(e) => handleAccentColorChange(e.target.value)}
-                      onBlur={(e) => handleAccentColorBlur(e.target.value)}
-                      placeholder="#fb923c"
-                      className="h-8 w-28 text-xs font-mono"
-                    />
                   </div>
 
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
                       <Label htmlFor="wild-loop-history-font-size" className="text-xs">Wild Loop History Font (px) <span className="font-normal text-muted-foreground">12–28</span></Label>
                       <p className="text-[11px] text-muted-foreground">iteration history text size in the Wild Loop Debug panel</p>
@@ -1147,8 +1217,10 @@ export function SettingsPageContent({
                       className="h-8 w-24 text-xs"
                     />
                   </div>
+                  </div>
 
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div className="rounded-lg bg-secondary/50 p-4">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <div>
                       <Label htmlFor="wild-loop-history-box-height" className="text-xs">Wild Loop History Box Height (px) <span className="font-normal text-muted-foreground">120–1000</span></Label>
                       <p className="text-[11px] text-muted-foreground">Max height of iteration history list in the Wild Loop Debug panel</p>
@@ -1164,6 +1236,7 @@ export function SettingsPageContent({
                       placeholder="300"
                       className="h-8 w-24 text-xs"
                     />
+                  </div>
                   </div>
 
                   <div className="flex justify-end">
@@ -1183,13 +1256,13 @@ export function SettingsPageContent({
                           wildLoopHistoryFontSizePx: null,
                           wildLoopTasksBoxHeightPx: null,
                           wildLoopHistoryBoxHeightPx: null,
+                          thinkingToolFontSizePx: null,
                         })
                       }
                     >
                       Reset Advanced
                     </Button>
                   </div>
-                </div>
             </div>
           )
         }

--- a/components/streaming-message.tsx
+++ b/components/streaming-message.tsx
@@ -17,7 +17,7 @@ interface StreamingMessageProps {
  */
 export function StreamingMessage({ streamingState }: StreamingMessageProps) {
     const { settings } = useAppSettings()
-    const thinkingInline = settings.appearance.thinkingDisplayMode === 'inline'
+    const thinkingMode = settings.appearance.thinkingDisplayMode || 'inline'
     const { isStreaming, parts, thinkingContent, textContent, toolCalls } = streamingState
 
     if (!isStreaming) {
@@ -39,13 +39,13 @@ export function StreamingMessage({ streamingState }: StreamingMessageProps) {
                     // Legacy fallback: grouped thinking, tools, text
                     <>
                         {thinkingContent && (
-                            thinkingInline ? (
+                            thinkingMode === 'inline' ? (
                                 <div className="space-y-1">
                                     <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                                         <Brain className="h-3 w-3 animate-pulse" />
                                         <span>Thinking...</span>
                                     </div>
-                                    <div className="px-1 py-1 text-xs leading-relaxed text-muted-foreground">
+                                    <div className="px-1 py-1 leading-relaxed text-muted-foreground" style={{ fontSize: 'var(--app-thinking-tool-font-size, 14px)' }}>
                                         {thinkingContent.split('\n').map((line, i) => (
                                             <p key={i} className={line.trim() === '' ? 'h-2' : ''}>
                                                 {line}
@@ -131,8 +131,8 @@ function StreamingPartRenderer({ part }: { part: StreamingPart }) {
  */
 function StreamingThinkingPart({ part }: { part: StreamingPart }) {
     const { settings } = useAppSettings()
-    const thinkingInline = settings.appearance.thinkingDisplayMode === 'inline'
-    const [isOpen, setIsOpen] = useState(true)
+    const thinkingMode = settings.appearance.thinkingDisplayMode || 'inline'
+    const [isOpen, setIsOpen] = useState(thinkingMode !== 'collapse')
     const [isDone, setIsDone] = useState(false)
     const prevContentRef = useRef(part.content)
     const length_to_show = 150
@@ -144,20 +144,20 @@ function StreamingThinkingPart({ part }: { part: StreamingPart }) {
         const timer = setTimeout(() => {
             if (prevContentRef.current === part.content && part.content.length > 0) {
                 setIsDone(true)
-                setIsOpen(false)
+                if (thinkingMode !== 'inline') setIsOpen(false)
             }
         }, 400)
         return () => clearTimeout(timer)
-    }, [part.content, isDone])
+    }, [part.content, isDone, thinkingMode])
 
-    if (thinkingInline) {
+    if (thinkingMode === 'inline') {
         return (
             <div className="space-y-1">
                 <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                     <Brain className={`h-3 w-3 ${!isDone ? 'animate-pulse' : ''}`} />
                     <span>{isDone ? 'Thought' : 'Thinking...'}</span>
                 </div>
-                <div className="px-1 py-1 text-xs leading-relaxed text-muted-foreground">
+                <div className="px-1 py-1 leading-relaxed text-muted-foreground" style={{ fontSize: 'var(--app-thinking-tool-font-size, 14px)' }}>
                     {part.content.split('\n').map((line, i) => (
                         <p key={i} className={line.trim() === '' ? 'h-2' : ''}>
                             {line}
@@ -182,7 +182,7 @@ function StreamingThinkingPart({ part }: { part: StreamingPart }) {
                 )}
             </CollapsibleTrigger>
             <CollapsibleContent className="mt-2">
-                <div className="w-full rounded-lg border border-border/50 bg-secondary/30 p-3 text-xs leading-relaxed text-muted-foreground max-h-[var(--app-streaming-tool-box-height,7.5rem)] overflow-y-auto">
+                <div className="w-full rounded-lg border border-border/50 bg-secondary/30 p-3 leading-relaxed text-muted-foreground max-h-[var(--app-streaming-tool-box-height,7.5rem)] overflow-y-auto" style={{ fontSize: 'var(--app-thinking-tool-font-size, 14px)' }}>
                     {part.content.split('\n').map((line, i) => (
                         <p key={i} className={line.trim() === '' ? 'h-2' : ''}>
                             {line}
@@ -196,19 +196,69 @@ function StreamingThinkingPart({ part }: { part: StreamingPart }) {
 }
 
 function StreamingToolPart({ part }: { part: StreamingPart }) {
-    const [isOpen, setIsOpen] = useState(true)
+    const { settings } = useAppSettings()
+    const toolMode = settings.appearance.toolDisplayMode || 'expand'
+    const [isOpen, setIsOpen] = useState(toolMode !== 'collapse')
     const state = part.toolState || 'pending'
     const durationLabel = formatDuration(part.toolDurationMs, part.toolStartedAt, part.toolEndedAt)
     const length_to_show = 150
 
-    // Auto-collapse when tool finishes (completed or error)
+    // Auto-collapse when tool finishes (completed or error) — only if in collapse/expand mode
     useEffect(() => {
+        if (toolMode === 'inline') return
         if (state === 'completed' || state === 'error') {
             // Small delay so user can briefly see the final state
             const timer = setTimeout(() => setIsOpen(false), 300)
             return () => clearTimeout(timer)
         }
-    }, [state])
+    }, [state, toolMode])
+
+    const toolContentBlock = (
+        <div className="w-full rounded-lg border border-border/50 bg-secondary/30 p-3 leading-relaxed text-muted-foreground space-y-2 max-h-[var(--app-streaming-tool-box-height,7.5rem)] overflow-y-auto" style={{ fontSize: 'var(--app-thinking-tool-font-size, 14px)' }}>
+            {part.toolDescription && (
+                <div>
+                    <span className="font-medium text-foreground/70">Description:</span>{' '}
+                    <span>{part.toolDescription}</span>
+                </div>
+            )}
+            {part.toolInput && (
+                <div>
+                    <span className="font-medium text-foreground/70">Input:</span>
+                    <pre className="mt-1 whitespace-pre-wrap break-all overflow-hidden">{part.toolInput}</pre>
+                </div>
+            )}
+            {part.toolOutput && (
+                <div>
+                    <span className="font-medium text-foreground/70">Output:</span>
+                    <pre className="mt-1 whitespace-pre-wrap break-all overflow-hidden">{part.toolOutput}</pre>
+                </div>
+            )}
+            {(part.toolStartedAt || part.toolEndedAt) && (
+                <div className="text-muted-foreground/80">
+                    {part.toolStartedAt && <div>Start: {formatTimestamp(part.toolStartedAt)}</div>}
+                    {part.toolEndedAt && <div>End: {formatTimestamp(part.toolEndedAt)}</div>}
+                </div>
+            )}
+        </div>
+    )
+
+    if (toolMode === 'inline') {
+        return (
+            <div className="space-y-1">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <ToolStateIcon state={state} />
+                    <Wrench className="h-3 w-3" />
+                    <span>{part.toolName || 'Tool'}</span>
+                    <span className="text-muted-foreground/60">•</span>
+                    <span className={state === 'completed' ? 'text-green-500' : state === 'error' ? 'text-red-500' : ''}>
+                        {getToolStateLabel(state)}
+                    </span>
+                    {durationLabel && <span className="text-muted-foreground/70">({durationLabel})</span>}
+                </div>
+                {toolContentBlock}
+            </div>
+        )
+    }
 
     return (
         <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -229,32 +279,7 @@ function StreamingToolPart({ part }: { part: StreamingPart }) {
                 )}
             </CollapsibleTrigger>
             <CollapsibleContent className="mt-2">
-                <div className="w-full rounded-lg border border-border/50 bg-secondary/30 p-3 text-xs leading-relaxed text-muted-foreground space-y-2 max-h-[var(--app-streaming-tool-box-height,7.5rem)] overflow-y-auto">
-                    {part.toolDescription && (
-                        <div>
-                            <span className="font-medium text-foreground/70">Description:</span>{' '}
-                            <span>{part.toolDescription}</span>
-                        </div>
-                    )}
-                    {part.toolInput && (
-                        <div>
-                            <span className="font-medium text-foreground/70">Input:</span>
-                            <pre className="mt-1 whitespace-pre-wrap break-all overflow-hidden">{part.toolInput}</pre>
-                        </div>
-                    )}
-                    {part.toolOutput && (
-                        <div>
-                            <span className="font-medium text-foreground/70">Output:</span>
-                            <pre className="mt-1 whitespace-pre-wrap break-all overflow-hidden">{part.toolOutput}</pre>
-                        </div>
-                    )}
-                    {(part.toolStartedAt || part.toolEndedAt) && (
-                        <div className="text-muted-foreground/80">
-                            {part.toolStartedAt && <div>Start: {formatTimestamp(part.toolStartedAt)}</div>}
-                            {part.toolEndedAt && <div>End: {formatTimestamp(part.toolEndedAt)}</div>}
-                        </div>
-                    )}
-                </div>
+                {toolContentBlock}
             </CollapsibleContent>
         </Collapsible>
     )

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -101,8 +101,8 @@ export interface AppSettings {
     wildLoopHistoryFontSizePx?: number | null;
     wildLoopTasksBoxHeightPx?: number | null;
     wildLoopHistoryBoxHeightPx?: number | null;
-    showStarterCards?: boolean;
-    starterCardFlavor?: "novice" | "expert";
+    showStarterCards?: boolean; // DEPRECATED: use starterCardFlavor 'none' instead
+    starterCardFlavor?: "none" | "novice" | "expert";
     showChatContextPanel?: boolean;
     showChatArtifacts?: boolean;
     chatCollapseAllChats?: boolean;
@@ -110,7 +110,9 @@ export interface AppSettings {
     showSidebarNewChatButton?: boolean;
     starterCardTemplates?: Record<string, string>;
     mobileEnterToNewline?: boolean;
-    thinkingDisplayMode?: 'collapsible' | 'inline';
+    thinkingDisplayMode?: 'collapse' | 'expand' | 'inline';
+    toolDisplayMode?: 'collapse' | 'expand' | 'inline';
+    thinkingToolFontSizePx?: number | null;
   };
   integrations: {
     slack?: {


### PR DESCRIPTION
## Summary

Adds a new **Thinking Display** setting under Appearance that lets users choose how thinking content is rendered:

- **Collapsible** (default): existing behavior — thinking content is wrapped in a collapsible box
- **Inline**: thinking content renders as plain text paragraphs with a Brain icon label

## Changes

| File | Change |
|------|--------|
| `lib/types.ts` | Add `thinkingDisplayMode` to `AppSettings.appearance` |
| `lib/app-settings.tsx` | Add default value (`'collapsible'`) and localStorage persistence |
| `components/settings-page-content.tsx` | Add `select` dropdown in Appearance section |
| `components/chat-message.tsx` | Conditional rendering in `SavedPartRenderer` and legacy thinking block |
| `components/streaming-message.tsx` | Conditional rendering in `StreamingThinkingPart` and legacy fallback |

## Verification

- ✅ `npm run build` passes cleanly
- Manual testing needed for UI toggle behavior