### PR TITLE
feat(settings): add developer toggles for Memory, Report, Terminal, Contextual panels

### DIFF
--- a/components/desktop-sidebar.tsx
+++ b/components/desktop-sidebar.tsx
@@ -370,6 +370,10 @@ export function DesktopSidebar({
                 {PRIMARY_NAV_ITEMS
                   .filter((item) => {
                     if (item.tab === 'plans') return settings.developer?.showPlanPanel
+                    if (item.tab === 'memory') return settings.developer?.showMemoryPanel
+                    if (item.tab === 'report') return settings.developer?.showReportPanel
+                    if (item.tab === 'terminal') return settings.developer?.showTerminalPanel
+                    if (item.tab === 'contextual') return settings.developer?.showContextualPanel
 
                     const configItem = settings.leftPanel?.items.find((i) => i.id === item.tab)
                     if (configItem) return configItem.visible

--- a/components/settings-page-content.tsx
+++ b/components/settings-page-content.tsx
@@ -10,8 +10,10 @@ import {
   Eye,
   EyeOff,
   LayoutGrid,
+  Lightbulb,
   Monitor,
   Moon,
+  Orbit,
   RotateCcw,
   Server,
   Clock,
@@ -19,6 +21,7 @@ import {
   Sparkles,
   Square,
   Sun,
+  Terminal,
   Type,
   Wifi,
   WifiOff,
@@ -32,6 +35,7 @@ import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Separator } from '@/components/ui/separator'
+import { Badge } from '@/components/ui/badge'
 import { createSetupShareLink, useApiConfig } from '@/lib/api-config'
 import type { AppSettings } from '@/lib/types'
 
@@ -435,6 +439,42 @@ export function SettingsPageContent({
           icon: Eye,
           type: 'toggle' as const,
           value: settings.developer?.showSidebarRunsSweepsPreview !== false,
+        },
+        {
+          id: 'showMemoryPanel',
+          label: 'Memory Panel',
+          description: 'Show the Memory tab in the sidebar',
+          icon: Lightbulb,
+          type: 'toggle' as const,
+          value: settings.developer?.showMemoryPanel === true,
+          beta: true,
+        },
+        {
+          id: 'showReportPanel',
+          label: 'Report Panel',
+          description: 'Show the Report tab in the sidebar',
+          icon: FileText,
+          type: 'toggle' as const,
+          value: settings.developer?.showReportPanel === true,
+          beta: true,
+        },
+        {
+          id: 'showTerminalPanel',
+          label: 'Terminal Panel',
+          description: 'Show the Terminal tab in the sidebar',
+          icon: Terminal,
+          type: 'toggle' as const,
+          value: settings.developer?.showTerminalPanel === true,
+          beta: true,
+        },
+        {
+          id: 'showContextualPanel',
+          label: 'Contextual Panel',
+          description: 'Show the Contextual tab in the sidebar',
+          icon: Orbit,
+          type: 'toggle' as const,
+          value: settings.developer?.showContextualPanel === true,
+          beta: true,
         },
       ],
     },
@@ -897,7 +937,12 @@ export function SettingsPageContent({
                 <Icon className="h-5 w-5 text-muted-foreground" />
               </div>
               <div>
-                <p className="text-sm font-medium text-foreground">{item.label}</p>
+                <p className="text-sm font-medium text-foreground">
+                  {item.label}
+                  {'beta' in item && (item as Record<string, unknown>).beta === true && (
+                    <Badge variant="secondary" className="ml-2 text-[10px] px-1.5 py-0">beta</Badge>
+                  )}
+                </p>
                 <p className="text-xs text-muted-foreground">{item.description}</p>
               </div>
             </div>
@@ -923,6 +968,30 @@ export function SettingsPageContent({
                   onSettingsChange({
                     ...settings,
                     developer: { ...settings.developer, showPlanPanel: checked },
+                  })
+                }
+                if (item.id === 'showMemoryPanel') {
+                  onSettingsChange({
+                    ...settings,
+                    developer: { ...settings.developer, showMemoryPanel: checked },
+                  })
+                }
+                if (item.id === 'showReportPanel') {
+                  onSettingsChange({
+                    ...settings,
+                    developer: { ...settings.developer, showReportPanel: checked },
+                  })
+                }
+                if (item.id === 'showTerminalPanel') {
+                  onSettingsChange({
+                    ...settings,
+                    developer: { ...settings.developer, showTerminalPanel: checked },
+                  })
+                }
+                if (item.id === 'showContextualPanel') {
+                  onSettingsChange({
+                    ...settings,
+                    developer: { ...settings.developer, showContextualPanel: checked },
                   })
                 }
                 if (item.id === 'showSidebarRunsSweepsPreview') {

--- a/lib/app-settings.tsx
+++ b/lib/app-settings.tsx
@@ -83,6 +83,10 @@ export const defaultAppSettings: AppSettings = {
     showPlanPanel: false,
     showSidebarRunsSweepsPreview: true,
     debugRefreshIntervalSeconds: 2,
+    showMemoryPanel: false,
+    showReportPanel: false,
+    showTerminalPanel: false,
+    showContextualPanel: false,
   },
 };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -132,6 +132,10 @@ export interface AppSettings {
     showSidebarRunsSweepsPreview?: boolean;
     debugRefreshIntervalSeconds?: number;
     wildLoopDebugPanelWidthPx?: number;
+    showMemoryPanel?: boolean;
+    showReportPanel?: boolean;
+    showTerminalPanel?: boolean;
+    showContextualPanel?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary

Adds 4 new toggles to **Settings > Developer** to control sidebar visibility of Memory, Report, Terminal, and Contextual tabs. All default to **false** (hidden) and display a **beta** badge.

## Changes

| File | Change |
|------|--------|
| `lib/types.ts` | Added `showMemoryPanel`, `showReportPanel`, `showTerminalPanel`, `showContextualPanel` to `developer` interface |
| `lib/app-settings.tsx` | Set defaults to `false` in `defaultAppSettings` |
| `components/settings-page-content.tsx` | Added 4 toggle items with beta badges + change handlers |
| `components/desktop-sidebar.tsx` | Gated sidebar tabs behind their respective developer toggles |

## Testing

- `tsc --noEmit` passes with 0 errors
- Manual: open Settings > Developer, verify 4 new toggles with beta badges, toggle on/off to show/hide tabs