### PR TITLE
fix: simplify user messages and move collapse toggle to nav bar

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -710,6 +710,11 @@ export default function ResearchChat() {
               onResume: wildLoop.resume,
               onStop: wildLoop.stop,
             } : null}
+            collapseChats={collapseChats}
+            onCollapseChatsChange={(collapsed) => setSettings({
+              ...settings,
+              appearance: { ...settings.appearance, chatCollapseAllChats: collapsed },
+            })}
             reportIsPreviewMode={reportToolbar?.isPreviewMode ?? true}
             onReportPreviewModeChange={reportToolbar?.setPreviewMode}
             onReportAddCell={reportToolbar?.addCell}

--- a/components/chat-message.tsx
+++ b/components/chat-message.tsx
@@ -120,7 +120,7 @@ export function ChatMessage({
 }: ChatMessageProps) {
   const [isThinkingOpen, setIsThinkingOpen] = useState(false)
   const [isChartOpen, setIsChartOpen] = useState(true)
-  const [isUserMessageExpanded, setIsUserMessageExpanded] = useState(false)
+
   const [selectionReplyUi, setSelectionReplyUi] = useState<{
     text: string
     x: number
@@ -557,14 +557,10 @@ export function ChatMessage({
     const hasExcerptCard = Boolean(parsedUserReply.excerpt)
     const userBody = hasExcerptCard ? parsedUserReply.body : message.content
     const excerptLineCount = parsedUserReply.excerpt ? parsedUserReply.excerpt.split('\n').length : 0
-    const collapsedPreviewSource = (userBody || parsedUserReply.excerpt || message.content)
-      .replace(/\s+/g, ' ')
-      .trim()
-    const collapsedPreview = collapsedPreviewSource || 'User message'
 
     return (
       <div className="px-0.5 py-2 min-w-0 overflow-hidden">
-        {isUserMessageExpanded && hasExcerptCard && parsedUserReply.excerpt && (
+        {hasExcerptCard && parsedUserReply.excerpt && (
           <div className="mb-2 flex justify-start">
             <div className="w-[220px] rounded-2xl border border-border/80 bg-card/80 p-3 shadow-sm">
               <p className="text-sm font-medium leading-tight text-foreground break-words">
@@ -580,25 +576,9 @@ export function ChatMessage({
           </div>
         )}
         <div className="border-l-4 border-primary px-3 py-1">
-          <button
-            type="button"
-            onClick={() => setIsUserMessageExpanded((prev) => !prev)}
-            className="flex w-full items-start gap-1.5 text-left"
-          >
-            {isUserMessageExpanded ? (
-              <ChevronDown className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            ) : (
-              <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            )}
-            <span className={`${isUserMessageExpanded ? 'whitespace-pre-wrap break-words' : 'truncate'} flex-1 text-base leading-relaxed text-foreground`}>
-              {collapsedPreview}
-            </span>
-          </button>
-          {isUserMessageExpanded && (
-            <div className="mt-1.5 space-y-1 text-base leading-relaxed text-foreground break-words">
-              {renderMarkdown(userBody)}
-            </div>
-          )}
+          <div className="text-base leading-relaxed text-foreground whitespace-pre-wrap break-words space-y-1">
+            {renderMarkdown(userBody)}
+          </div>
         </div>
       </div>
     )

--- a/components/floating-nav.tsx
+++ b/components/floating-nav.tsx
@@ -64,6 +64,8 @@ interface FloatingNavProps {
   eventCount?: number
   onAlertClick?: () => void
   onExportSession?: () => void
+  collapseChats?: boolean
+  onCollapseChatsChange?: (collapsed: boolean) => void
   // Session selector props (for chat tab)
   sessionTitle?: string
   currentSessionId?: string | null
@@ -86,6 +88,8 @@ export function FloatingNav({
   eventCount = 0,
   onAlertClick,
   onExportSession,
+  collapseChats = false,
+  onCollapseChatsChange,
   sessionTitle = 'New Chat',
   currentSessionId,
   sessions = [],
@@ -194,6 +198,19 @@ export function FloatingNav({
       {/* Right side buttons - only show in chat */}
       {isChat && (
         <div className="flex items-center gap-1 shrink-0">
+          {/* Collapse All Chats Button */}
+          {onCollapseChatsChange && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => onCollapseChatsChange(!collapseChats)}
+              className={`h-8 w-8 ${collapseChats ? 'bg-secondary text-secondary-foreground' : ''}`}
+              title={collapseChats ? 'Expand all chats' : 'Collapse all chats'}
+            >
+              <PanelLeftOpen className="h-4 w-4" />
+              <span className="sr-only">{collapseChats ? 'Expand all chats' : 'Collapse all chats'}</span>
+            </Button>
+          )}
           {/* Export Button */}
           {onExportSession && (
             <Button

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -370,14 +370,6 @@ export function SettingsDialog({
           value: settings.appearance.showChatArtifacts === true,
         },
         {
-          id: 'chatCollapseAllChats',
-          label: 'Collapse All Chats',
-          description: 'Render chat history in collapsed mode by default',
-          icon: EyeOff,
-          type: 'toggle' as const,
-          value: settings.appearance.chatCollapseAllChats === true,
-        },
-        {
           id: 'chatCollapseArtifactsInChat',
           label: 'Collapse Artifacts In Chat',
           description: 'Render artifacts collapsed inside chat messages',
@@ -943,7 +935,6 @@ export function SettingsDialog({
                 if (item.id === 'showStarterCards') updateAppearanceSettings({ showStarterCards: checked })
                 if (item.id === 'showChatContextPanel') updateAppearanceSettings({ showChatContextPanel: checked })
                 if (item.id === 'showChatArtifacts') updateAppearanceSettings({ showChatArtifacts: checked })
-                if (item.id === 'chatCollapseAllChats') updateAppearanceSettings({ chatCollapseAllChats: checked })
                 if (item.id === 'chatCollapseArtifactsInChat') updateAppearanceSettings({ chatCollapseArtifactsInChat: checked })
                 if (item.id === 'showWildLoopState') {
                   onSettingsChange({

--- a/components/settings-page-content.tsx
+++ b/components/settings-page-content.tsx
@@ -354,14 +354,6 @@ export function SettingsPageContent({
           value: settings.appearance.showChatArtifacts === true,
         },
         {
-          id: 'chatCollapseAllChats',
-          label: 'Collapse All Chats',
-          description: 'Render chat history in collapsed mode by default',
-          icon: EyeOff,
-          type: 'toggle' as const,
-          value: settings.appearance.chatCollapseAllChats === true,
-        },
-        {
           id: 'chatCollapseArtifactsInChat',
           label: 'Collapse Artifacts In Chat',
           description: 'Render artifacts collapsed inside chat messages',
@@ -910,7 +902,6 @@ export function SettingsPageContent({
                 if (item.id === 'showStarterCards') updateAppearanceSettings({ showStarterCards: checked })
                 if (item.id === 'showChatContextPanel') updateAppearanceSettings({ showChatContextPanel: checked })
                 if (item.id === 'showChatArtifacts') updateAppearanceSettings({ showChatArtifacts: checked })
-                if (item.id === 'chatCollapseAllChats') updateAppearanceSettings({ chatCollapseAllChats: checked })
                 if (item.id === 'chatCollapseArtifactsInChat') updateAppearanceSettings({ chatCollapseArtifactsInChat: checked })
                 if (item.id === 'mobileEnterToNewline') updateAppearanceSettings({ mobileEnterToNewline: checked })
                 if (item.id === 'showWildLoopState') {


### PR DESCRIPTION
## Summary

Simplifies the chat interface by:

1. **Removing collapsible user messages** — user messages are now always fully displayed with markdown rendering and the vertical bar indicator. The `isUserMessageExpanded` state and chevron toggle have been removed.

2. **Adding a collapse all chats button to the floating nav bar** — a new `PanelLeftOpen` icon button in the chat nav bar replicates the old "Collapse All Chats" setting. The button visually highlights when collapse mode is active.

3. **Removing "Collapse All Chats" from Settings > Appearance** — the toggle has been removed from both `settings-dialog.tsx` and `settings-page-content.tsx`. The underlying `chatCollapseAllChats` setting is preserved for the nav bar button.

## Files Changed

| File | Change |
|------|--------|
| `components/chat-message.tsx` | Removed collapsible user message logic |
| `components/floating-nav.tsx` | Added collapse all chats button with props |
| `app/page.tsx` | Wired `collapseChats` + `onCollapseChatsChange` to FloatingNav |
| `components/settings-dialog.tsx` | Removed toggle + handler |
| `components/settings-page-content.tsx` | Removed toggle + handler |