### PR TITLE
ci: add frontend build + backend test checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # -------------------------------------------------------------------
+  # Frontend — verify Next.js build succeeds
+  # -------------------------------------------------------------------
+  frontend-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        run: pnpm run build
+
+  # -------------------------------------------------------------------
+  # Backend — verify Python tests pass
+  # -------------------------------------------------------------------
+  backend-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -r server/requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: pytest tests/ -v


### PR DESCRIPTION
## Summary

Adds a new CI workflow (`.github/workflows/ci.yml`) that runs on every PR and push to `main`.

### Jobs

| Job | What it checks |
|-----|----------------|
| **frontend-build** | `pnpm install --frozen-lockfile` + `pnpm run build` (Next.js) |
| **backend-tests** | `pip install` server deps + `pytest tests/ -v` |

Both jobs run in parallel on `ubuntu-latest` with a 10-minute timeout.

### Concurrency

In-progress runs for the same PR are automatically cancelled when a new commit is pushed.

### Testing

The workflow itself is the test — this PR's CI run validates that both jobs pass.