### PR TITLE
feat: full-stack pause/resume/steer for wild loop V2

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -697,7 +697,7 @@ export default function ResearchChat() {
             sessions={sessions}
             onSessionChange={handleSessionChange}
             contextTokenCount={contextTokenCount}
-            wildLoop={wildLoop.isActive ? {
+            wildLoop={(wildLoop.isActive || wildLoop.isPaused) ? {
               isActive: wildLoop.isActive,
               isPaused: wildLoop.isPaused,
               phase: wildLoop.phase,
@@ -709,6 +709,7 @@ export default function ResearchChat() {
               onPause: wildLoop.pause,
               onResume: wildLoop.resume,
               onStop: wildLoop.stop,
+              onSteer: wildLoop.steer,
             } : null}
             reportIsPreviewMode={reportToolbar?.isPreviewMode ?? true}
             onReportPreviewModeChange={reportToolbar?.setPreviewMode}

--- a/components/floating-nav.tsx
+++ b/components/floating-nav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Menu, Bell, Download, Eye, Edit3, Plus, ChevronDown, Type, Code, BarChart3, Sparkles, PanelLeftOpen, Pause, Play, Square, Target } from 'lucide-react'
+import { Menu, Bell, Download, Eye, Edit3, Plus, ChevronDown, Type, Code, BarChart3, Sparkles, PanelLeftOpen, Pause, Play, Square, Target, Send } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -53,6 +53,7 @@ interface WildLoopNavProps {
   onPause: () => void
   onResume: () => void
   onStop: () => void
+  onSteer?: (context: string) => void
 }
 
 interface FloatingNavProps {
@@ -312,8 +313,10 @@ function WildLoopNavDropdown({
   onPause,
   onResume,
   onStop,
+  onSteer,
 }: WildLoopNavProps) {
   const [elapsed, setElapsed] = useState('0:00')
+  const [steerText, setSteerText] = useState('')
 
   useEffect(() => {
     if (!startedAt) return
@@ -433,6 +436,37 @@ function WildLoopNavDropdown({
             Stop
           </Button>
         </div>
+        {/* Steer Input */}
+        {onSteer && (
+          <div className="border-t border-border/40 px-4 py-2.5">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault()
+                if (steerText.trim()) {
+                  onSteer(steerText.trim())
+                  setSteerText('')
+                }
+              }}
+              className="flex items-center gap-2"
+            >
+              <input
+                type="text"
+                value={steerText}
+                onChange={(e) => setSteerText(e.target.value)}
+                placeholder="Steer the agent…"
+                className="flex-1 rounded-md border border-border/60 bg-secondary/40 px-2.5 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/60 focus:border-violet-500/50 focus:outline-none focus:ring-1 focus:ring-violet-500/30"
+              />
+              <Button
+                type="submit"
+                size="sm"
+                disabled={!steerText.trim()}
+                className="h-7 w-7 p-0 bg-violet-600 hover:bg-violet-700 disabled:opacity-40"
+              >
+                <Send className="h-3 w-3" />
+              </Button>
+            </form>
+          </div>
+        )}
       </PopoverContent>
     </Popover>
   )

--- a/hooks/use-favicon.ts
+++ b/hooks/use-favicon.ts
@@ -1,0 +1,72 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+/**
+ * Dynamically change the browser tab favicon to indicate connection state.
+ *
+ * When `isRetrying` is true, a small orange warning badge is drawn on top of
+ * the existing favicon. When false, the original favicon is restored.
+ */
+export function useFavicon(isRetrying: boolean) {
+    const originalHrefRef = useRef<string | null>(null)
+
+    useEffect(() => {
+        if (typeof document === 'undefined') return
+
+        const link = document.querySelector<HTMLLinkElement>(
+            'link[rel="icon"][type="image/svg+xml"], link[rel="icon"]'
+        )
+        if (!link) return
+
+        // Capture the original href on first call
+        if (originalHrefRef.current === null) {
+            originalHrefRef.current = link.href
+        }
+
+        if (!isRetrying) {
+            // Restore original
+            if (originalHrefRef.current) {
+                link.href = originalHrefRef.current
+            }
+            return
+        }
+
+        // Draw a badge on the favicon
+        const img = new Image()
+        img.crossOrigin = 'anonymous'
+        img.onload = () => {
+            const size = 32
+            const canvas = document.createElement('canvas')
+            canvas.width = size
+            canvas.height = size
+            const ctx = canvas.getContext('2d')
+            if (!ctx) return
+
+            // Draw original icon
+            ctx.drawImage(img, 0, 0, size, size)
+
+            // Draw orange dot badge (bottom-right)
+            const badgeRadius = 7
+            const cx = size - badgeRadius - 1
+            const cy = size - badgeRadius - 1
+            ctx.beginPath()
+            ctx.arc(cx, cy, badgeRadius, 0, Math.PI * 2)
+            ctx.fillStyle = '#f59e0b' // amber-500
+            ctx.fill()
+            ctx.strokeStyle = '#78350f' // amber-900
+            ctx.lineWidth = 1.5
+            ctx.stroke()
+
+            // Draw a small "!" in the badge
+            ctx.fillStyle = '#fff'
+            ctx.font = 'bold 9px sans-serif'
+            ctx.textAlign = 'center'
+            ctx.textBaseline = 'middle'
+            ctx.fillText('!', cx, cy)
+
+            link.href = canvas.toDataURL('image/png')
+        }
+        img.src = originalHrefRef.current || link.href
+    }, [isRetrying])
+}

--- a/hooks/use-wild-loop.ts
+++ b/hooks/use-wild-loop.ts
@@ -209,8 +209,8 @@ export function useWildLoop(): UseWildLoopResult {
 
   // ---- Derive return values from V2 backend state ----
 
-  const isActive = status?.active ?? false
   const isPaused = status?.status === 'paused'
+  const isActive = (status?.active ?? false) || isPaused
   const v2Status = status?.status ?? null
   const iteration = status?.iteration ?? 0
   const maxIterations = status?.max_iterations ?? 25

--- a/server/wild_loop_v2.py
+++ b/server/wild_loop_v2.py
@@ -307,7 +307,7 @@ class WildV2Engine:
             return {"active": False}
 
         d = self._session.to_dict()
-        d["active"] = self._session.status == "running"
+        d["active"] = self._session.status in ("running", "paused")
 
         # System health is served via /wild/v2/system-health endpoint
 


### PR DESCRIPTION
## Summary

End-to-end wiring of pause, resume, and steer for Wild Loop V2. The engine changes from PR #210 are included plus full-stack frontend integration.

## Issues Fixed

| # | Bug | Fix |
|---|-----|-----|
| 1 | Paused loops reported `active: false`, hiding all UI | `get_status()` returns `active: true` for paused sessions |
| 2 | FloatingNav controls disappeared when paused | `page.tsx` passes `wildLoop` when active **or** paused |
| 3 | Steer went to event queue, not the engine | `onSteer` now calls `wildLoop.steer()` directly |
| 4 | Chat steer button hidden when paused | `isWildLoopActive` includes paused state |

## Changes

### Backend
- `server/wild_loop_v2.py`: `get_status()` `active` field includes paused
- Engine changes from #210: asyncio.Event suspension, `_interruptible_sleep()`, `_check_pause()`

### Frontend
- `hooks/use-wild-loop.ts`: `isActive` derivation includes paused
- `app/page.tsx`: pass wildLoop to nav when paused + add `onSteer`
- `components/connected-chat-view.tsx`: steer calls engine, `isWildLoopActive` includes paused
- `components/floating-nav.tsx`: `onSteer` prop + compact steer input in popover
- `hooks/use-favicon.ts`: new file (was untracked/missing)

## Verification
- ✅ `next build` passes cleanly
- ✅ 42/42 pytest tests pass (including 3 new async tests)