### PR TITLE
feat: add Modal GLM-5 and NVIDIA Kimi K2.5 providers

### DIFF
--- a/server/opencode.json
+++ b/server/opencode.json
@@ -127,6 +127,40 @@
           }
         }
       }
+    },
+    "modal-glm5": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Modal GLM-5",
+      "options": {
+        "baseURL": "https://api.us-west-2.modal.direct/v1",
+        "apiKey": "{env:MODAL_GLM5_API_KEY}"
+      },
+      "models": {
+        "zai-org/GLM-5-FP8": {
+          "name": "GLM-5 FP8",
+          "limit": {
+            "context": 131072,
+            "output": 8192
+          }
+        }
+      }
+    },
+    "nvidia-kimi": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "NVIDIA Kimi K2.5",
+      "options": {
+        "baseURL": "https://integrate.api.nvidia.com/v1",
+        "apiKey": "{env:NVIDIA_API}"
+      },
+      "models": {
+        "moonshotai/kimi-k2.5": {
+          "name": "Kimi K2.5",
+          "limit": {
+            "context": 131072,
+            "output": 16384
+          }
+        }
+      }
     }
   },
   "command": {


### PR DESCRIPTION
## Summary

- Added **Modal GLM-5** (`zai-org/GLM-5-FP8`) provider via `api.us-west-2.modal.direct`
- Added **NVIDIA Kimi K2.5** (`moonshotai/kimi-k2.5`) provider via `integrate.api.nvidia.com`
- Both use the `@ai-sdk/openai-compatible` adapter in opencode
- API keys: `MODAL_GLM5_API_KEY` and `NVIDIA_API` env vars

## Secrets Added
- [x] `NVIDIA_API` → GitHub Actions
- [x] `NVIDIA_API` → Modal `research-agent-preview-secrets`
- [x] `MODAL_GLM5_API_KEY` → Pending (key not yet available)

## Testing
Config-only change to `server/opencode.json`. No code logic changes.