### PR TITLE
fix: replace hardcoded dark backgrounds in log/terminal sections with theme-aware colors

### DIFF
--- a/components/log-viewer.tsx
+++ b/components/log-viewer.tsx
@@ -211,7 +211,7 @@ export function LogViewer({ runId, isFullPage = false, onExpand, showHeader = tr
             {/* Log content */}
             <div
                 ref={scrollRef}
-                className={`${containerHeight} overflow-auto font-mono text-[11px] bg-black/50`}
+                className={`${containerHeight} overflow-auto font-mono text-[11px] bg-muted/50`}
                 onScroll={handleScroll}
             >
                 {/* Load more indicator */}
@@ -235,7 +235,7 @@ export function LogViewer({ runId, isFullPage = false, onExpand, showHeader = tr
                 ) : logs ? (
                     <pre
                         ref={logContainerRef}
-                        className="p-3 whitespace-pre-wrap break-all text-gray-300 leading-relaxed"
+                        className="p-3 whitespace-pre-wrap break-all text-foreground leading-relaxed"
                     >
                         {logs}
                     </pre>

--- a/components/run-detail-view.tsx
+++ b/components/run-detail-view.tsx
@@ -692,67 +692,67 @@ export function RunDetailView({ run, alerts = [], onSweepSelect, onUpdateRun, al
             <div id={`run-alerts-${run.id}`}>
               <Collapsible open={alertsOpen} onOpenChange={setAlertsOpen}>
                 <div className={`rounded-lg border bg-card overflow-hidden ${runAlerts.length > 0 ? 'border-border' : 'border-border border-dashed'}`}>
-                <CollapsibleTrigger asChild>
-                  <button type="button" className="flex w-full items-center justify-between p-3">
-                    <div className="flex items-center gap-2">
-                      <AlertTriangle className="h-4 w-4 text-warning" />
-                      <span className={`text-xs font-medium ${runAlerts.length > 0 ? 'text-foreground' : 'text-muted-foreground'}`}>
-                        Alerts {runAlerts.length > 0 && `(${runAlerts.length})`}
-                      </span>
-                    </div>
-                    {alertsOpen ? (
-                      <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                    ) : (
-                      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-                    )}
-                  </button>
-                </CollapsibleTrigger>
-                <CollapsibleContent>
-                  <div className="border-t border-border px-3 pb-3">
-                    {runAlerts.length > 0 ? (
-                      <div className="mt-2 space-y-2">
-                        {runAlerts.map((alert) => {
-                          const severity = alert.severity === 'critical' ? 'error' : alert.severity === 'warning' ? 'warning' : 'info'
-                          const badgeClass =
-                            severity === 'error'
-                              ? 'border-destructive/50 bg-destructive/10 text-destructive'
-                              : severity === 'warning'
-                              ? 'border-warning/50 bg-warning/10 text-warning'
-                              : 'border-blue-400/50 bg-blue-400/10 text-blue-400'
-                          return (
-                            <div key={alert.id} className="rounded border border-border bg-secondary/40 p-2">
-                              <div className="flex items-start gap-2">
-                                <AlertTriangle className={`h-3.5 w-3.5 mt-0.5 ${severity === 'error' ? 'text-destructive' : severity === 'warning' ? 'text-warning' : 'text-blue-400'}`} />
-                                <div className="flex-1 min-w-0">
-                                  <div className="flex items-center gap-2">
-                                    <Badge variant="outline" className={`text-[9px] h-4 ${badgeClass}`}>
-                                      {alert.severity}
-                                    </Badge>
-                                    <span className="text-[10px] text-muted-foreground">
-                                      {formatAlertTime(alert.timestamp)}
-                                    </span>
-                                  </div>
-                                  <p className="text-xs text-foreground mt-1 leading-relaxed">
-                                    {alert.message}
-                                  </p>
-                                  {alert.response && (
-                                    <p className="text-[10px] text-muted-foreground mt-1">
-                                      Response: {alert.response}
+                  <CollapsibleTrigger asChild>
+                    <button type="button" className="flex w-full items-center justify-between p-3">
+                      <div className="flex items-center gap-2">
+                        <AlertTriangle className="h-4 w-4 text-warning" />
+                        <span className={`text-xs font-medium ${runAlerts.length > 0 ? 'text-foreground' : 'text-muted-foreground'}`}>
+                          Alerts {runAlerts.length > 0 && `(${runAlerts.length})`}
+                        </span>
+                      </div>
+                      {alertsOpen ? (
+                        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+                      )}
+                    </button>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <div className="border-t border-border px-3 pb-3">
+                      {runAlerts.length > 0 ? (
+                        <div className="mt-2 space-y-2">
+                          {runAlerts.map((alert) => {
+                            const severity = alert.severity === 'critical' ? 'error' : alert.severity === 'warning' ? 'warning' : 'info'
+                            const badgeClass =
+                              severity === 'error'
+                                ? 'border-destructive/50 bg-destructive/10 text-destructive'
+                                : severity === 'warning'
+                                  ? 'border-warning/50 bg-warning/10 text-warning'
+                                  : 'border-blue-400/50 bg-blue-400/10 text-blue-400'
+                            return (
+                              <div key={alert.id} className="rounded border border-border bg-secondary/40 p-2">
+                                <div className="flex items-start gap-2">
+                                  <AlertTriangle className={`h-3.5 w-3.5 mt-0.5 ${severity === 'error' ? 'text-destructive' : severity === 'warning' ? 'text-warning' : 'text-blue-400'}`} />
+                                  <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-2">
+                                      <Badge variant="outline" className={`text-[9px] h-4 ${badgeClass}`}>
+                                        {alert.severity}
+                                      </Badge>
+                                      <span className="text-[10px] text-muted-foreground">
+                                        {formatAlertTime(alert.timestamp)}
+                                      </span>
+                                    </div>
+                                    <p className="text-xs text-foreground mt-1 leading-relaxed">
+                                      {alert.message}
                                     </p>
-                                  )}
+                                    {alert.response && (
+                                      <p className="text-[10px] text-muted-foreground mt-1">
+                                        Response: {alert.response}
+                                      </p>
+                                    )}
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                          )
-                        })}
-                      </div>
-                    ) : (
-                      <div className="mt-2 py-4 text-center">
-                        <p className="text-xs text-muted-foreground">No alerts for this run</p>
-                      </div>
-                    )}
-                  </div>
-                </CollapsibleContent>
+                            )
+                          })}
+                        </div>
+                      ) : (
+                        <div className="mt-2 py-4 text-center">
+                          <p className="text-xs text-muted-foreground">No alerts for this run</p>
+                        </div>
+                      )}
+                    </div>
+                  </CollapsibleContent>
                 </div>
               </Collapsible>
             </div>
@@ -990,8 +990,8 @@ export function RunDetailView({ run, alerts = [], onSweepSelect, onUpdateRun, al
                         </>
                       ) : (
                         <>
-                          <div className="rounded bg-black/30 px-2 py-1.5">
-                            <code className="whitespace-pre-wrap break-all text-[11px] font-mono text-green-400">
+                          <div className="rounded bg-muted/50 px-2 py-1.5">
+                            <code className="whitespace-pre-wrap break-all text-[11px] font-mono text-foreground">
                               {run.command}
                             </code>
                           </div>

--- a/components/tmux-terminal-panel.tsx
+++ b/components/tmux-terminal-panel.tsx
@@ -76,23 +76,23 @@ export function TmuxTerminalPanel({
             )}
 
             {/* Terminal Placeholder */}
-            <div className="bg-black/50 p-1">
+            <div className="bg-muted/50 p-1">
                 {/* Placeholder for future embedded terminal */}
-                <div className="rounded border border-dashed border-gray-700 bg-gray-900/50 p-6 text-center">
-                    <Monitor className="h-10 w-10 mx-auto mb-3 text-gray-600" />
-                    <p className="text-sm text-gray-400 mb-1">
+                <div className="rounded border border-dashed border-border bg-secondary/50 p-6 text-center">
+                    <Monitor className="h-10 w-10 mx-auto mb-3 text-muted-foreground/50" />
+                    <p className="text-sm text-muted-foreground mb-1">
                         Embedded Terminal
                     </p>
-                    <p className="text-[10px] text-gray-500">
+                    <p className="text-[10px] text-muted-foreground">
                         Coming soon - Interactive terminal access
                     </p>
                 </div>
 
                 {/* Manual attach instructions */}
-                <div className="mt-1 rounded bg-gray-800/50 p-2 min-w-0">
-                    <p className="text-[10px] text-gray-400 mb-1 min-w-0">To attach manually:</p>
+                <div className="mt-1 rounded bg-secondary/50 p-2 min-w-0">
+                    <p className="text-[10px] text-muted-foreground mb-1 min-w-0">To attach manually:</p>
                     <div className="flex items-center gap-1 min-w-0">
-                        <code className="text-[11px] font-mono text-green-400 bg-black/30 rounded overflow-hidden text-ellipsis ">
+                        <code className="text-[11px] font-mono text-foreground bg-muted/50 rounded overflow-hidden text-ellipsis ">
                             {attachCommand}
                         </code>
                         <Button
@@ -112,7 +112,7 @@ export function TmuxTerminalPanel({
 
                 {/* Pane info */}
                 {tmuxPane && (
-                    <p className="ml-1 mt-2 text-[10px] text-gray-500">
+                    <p className="ml-1 mt-2 text-[10px] text-muted-foreground">
                         Pane ID: {tmuxPane}
                     </p>
                 )}


### PR DESCRIPTION
## Summary

The Logs, Terminal, Sidecar Logs, and Command sections used hardcoded dark backgrounds (`bg-black/50`, `bg-gray-900`, etc.) and text colors (`text-gray-300`, `text-green-400`) that clashed with the light theme.

Replaced with theme-aware Tailwind classes (`bg-muted/50`, `bg-secondary/50`, `text-foreground`, `text-muted-foreground`) so these sections blend naturally in both light and dark modes.

## Changes

| File | What changed |
|------|-------------|
| `components/log-viewer.tsx` | Log content bg + text color |
| `components/tmux-terminal-panel.tsx` | All hardcoded dark colors in terminal placeholder |
| `components/run-detail-view.tsx` | Command code block bg + text color |