### PR TITLE
fix: strip ANSI escape codes from sidecar logs for readability

### DIFF
--- a/server/tools/job_sidecar.py
+++ b/server/tools/job_sidecar.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import sys
 import time
 import math
@@ -874,10 +875,25 @@ def monitor_job(
     if os.path.exists(completion_file):
         os.remove(completion_file)
     
-    # Setup log capture via pipe-pane
+    # Setup log capture via pipe-pane with ANSI stripping.
+    # Strategy (mirrors tmux-logging plugin):
+    #   1. ansifilter — C-based, fastest, handles all sequences
+    #   2. strip_ansi_filter.py — our Python fallback
+    #   3. raw cat — last resort if nothing else is available
     try:
         logger.info(f"Piping pane output to {log_file}")
-        job_pane.cmd("pipe-pane", f"cat >> {log_file}")
+        if shutil.which("ansifilter"):
+            pipe_cmd = f"ansifilter >> {log_file}"
+            logger.info("Using ansifilter for ANSI stripping (native C)")
+        else:
+            filter_script = _resolve_sidecar_script("strip_ansi_filter.py")
+            if filter_script:
+                pipe_cmd = f"{sys.executable} {shlex.quote(filter_script)} >> {log_file}"
+                logger.info("Using strip_ansi_filter.py for ANSI stripping")
+            else:
+                logger.warning("No ANSI filter available; falling back to raw capture")
+                pipe_cmd = f"cat >> {log_file}"
+        job_pane.cmd("pipe-pane", pipe_cmd)
     except Exception as e:
         logger.error(f"Failed to setup pipe-pane: {e}")
     

--- a/server/tools/strip_ansi_filter.py
+++ b/server/tools/strip_ansi_filter.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Stdin-to-stdout filter that strips ANSI escape codes.
+
+Used by job_sidecar.py as the pipe-pane filter so that run.log
+is written clean — no server-side stripping needed on every read.
+
+Usage:  tmux pipe-pane "python3 strip_ansi_filter.py >> run.log"
+"""
+
+import re
+import sys
+
+_ANSI_RE = re.compile(
+    r"""
+    \x1b
+    (?:
+        \[  [0-9;?]* [ -/]* [@-~]   # CSI  (colors, cursor, erase)
+      | \]  .*? (?:\x07|\x1b\\)      # OSC  (window title, etc.)
+      | [()][A-Z0-9]                 # charset designation
+      | [^[\]() \x1b]               # other single-char escapes
+    )
+    """,
+    re.VERBOSE,
+)
+
+# Collapse CR-based overwrite lines (progress bars) to just the final version.
+_CR_OVERWRITE_RE = re.compile(r"^.*\r(?!\n)", re.MULTILINE)
+
+if __name__ == "__main__":
+    for line in sys.stdin:
+        line = _ANSI_RE.sub("", line)
+        line = _CR_OVERWRITE_RE.sub("", line)
+        sys.stdout.write(line)
+        sys.stdout.flush()

--- a/tests/test_strip_ansi.py
+++ b/tests/test_strip_ansi.py
@@ -1,0 +1,137 @@
+"""
+Tests for strip_ansi — the ANSI escape code removal utility.
+
+Covers common escape sequences found in tmux-captured terminal output:
+SGR color codes, cursor movements, OSC window titles, and
+carriage-return based progress bar overwrites.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "server", "tools"))
+
+import strip_ansi_filter  # noqa: E402
+
+# Import the regex-based stripping function for testing
+def strip_ansi(text: str) -> str:
+    """Apply the same transformations as the filter script."""
+    text = strip_ansi_filter._ANSI_RE.sub("", text)
+    text = strip_ansi_filter._CR_OVERWRITE_RE.sub("", text)
+    return text
+
+
+class TestBasicSGR:
+    """Standard Select Graphic Rendition sequences (colors, bold, etc.)."""
+
+    def test_single_color(self):
+        assert strip_ansi("\x1b[31mERROR\x1b[0m") == "ERROR"
+
+    def test_bold(self):
+        assert strip_ansi("\x1b[1mBold text\x1b[0m") == "Bold text"
+
+    def test_multi_param(self):
+        assert strip_ansi("\x1b[1;32;40mGreen on Black\x1b[0m") == "Green on Black"
+
+    def test_256_color(self):
+        assert strip_ansi("\x1b[38;5;196mRed256\x1b[0m") == "Red256"
+
+    def test_truecolor(self):
+        assert strip_ansi("\x1b[38;2;255;0;0mTrueRed\x1b[0m") == "TrueRed"
+
+    def test_reset_only(self):
+        assert strip_ansi("\x1b[0m") == ""
+
+
+class TestCursorAndScreen:
+    """Cursor movement, screen clearing, etc."""
+
+    def test_clear_screen(self):
+        assert strip_ansi("\x1b[2JCleared") == "Cleared"
+
+    def test_cursor_home(self):
+        assert strip_ansi("\x1b[HHome") == "Home"
+
+    def test_cursor_position(self):
+        assert strip_ansi("\x1b[10;20HAt pos") == "At pos"
+
+    def test_erase_line(self):
+        assert strip_ansi("\x1b[KLine cleared") == "Line cleared"
+
+    def test_scroll_up(self):
+        assert strip_ansi("\x1b[2SScrolled") == "Scrolled"
+
+
+class TestOSC:
+    """Operating System Command sequences (window titles, etc.)."""
+
+    def test_set_title_bel(self):
+        assert strip_ansi("\x1b]0;My Window Title\x07Content") == "Content"
+
+    def test_set_title_st(self):
+        assert strip_ansi("\x1b]2;Title\x1b\\Content") == "Content"
+
+
+class TestSimpleEscapes:
+    """Single-character escape sequences."""
+
+    def test_charset_switch(self):
+        # ESC(B is a common charset switch
+        assert strip_ansi("\x1b(BNormal text") == "Normal text"
+
+
+class TestCarriageReturn:
+    """Progress bar / spinner overwrite patterns using \\r."""
+
+    def test_progress_bar_overwrite(self):
+        text = "Downloading: 50%\rDownloading: 100%\n"
+        result = strip_ansi(text)
+        assert "100%" in result
+        # The intermediate 50% state should be collapsed
+        assert result.count("Downloading") == 1
+
+    def test_single_cr_before_newline_preserved(self):
+        # \r\n should be preserved (Windows line ending)
+        text = "Line 1\r\nLine 2\r\n"
+        assert strip_ansi(text) == text
+
+
+class TestPassthrough:
+    """Clean text should pass through unchanged."""
+
+    def test_plain_text(self):
+        text = "Hello, world! This is a normal log line."
+        assert strip_ansi(text) == text
+
+    def test_empty_string(self):
+        assert strip_ansi("") == ""
+
+    def test_multiline(self):
+        text = "Line 1\nLine 2\nLine 3\n"
+        assert strip_ansi(text) == text
+
+    def test_numbers_and_symbols(self):
+        text = "loss=0.0123 | accuracy=99.5% | epoch 10/50"
+        assert strip_ansi(text) == text
+
+
+class TestMixedContent:
+    """Real-world scenarios with mixed ANSI codes and content."""
+
+    def test_pytorch_training_output(self):
+        raw = (
+            "\x1b[1m\x1b[34mEpoch 1/10\x1b[0m: "
+            "\x1b[32mloss=0.4521\x1b[0m | "
+            "\x1b[33macc=0.85\x1b[0m"
+        )
+        result = strip_ansi(raw)
+        assert result == "Epoch 1/10: loss=0.4521 | acc=0.85"
+
+    def test_tqdm_style_bar(self):
+        raw = (
+            "\r\x1b[32m 50%\x1b[0m|████     | 50/100"
+            "\r\x1b[32m100%\x1b[0m|█████████| 100/100\n"
+        )
+        result = strip_ansi(raw)
+        assert "100/100" in result
+        assert "\x1b" not in result


### PR DESCRIPTION
## Summary

Closes #240. See research in #245.

Sidecar logs captured from tmux via `pipe-pane` included raw ANSI escape codes (colors, cursor movements, progress bars, etc.), making logs unreadable in the frontend `LogViewer` and chat context.

The fix strips at the **sidecar/tmux level** so `run.log` is clean from the start — zero per-read overhead on the server. Uses a tiered strategy mirroring the [tmux-logging plugin](https://github.com/tmux-plugins/tmux-logging):

```
1. ansifilter (C-based, fastest)  — if installed
2. strip_ansi_filter.py (Python)  — bundled fallback
3. raw cat                        — last resort
```

## Changes

### New: `server/tools/strip_ansi_filter.py`
- Standalone stdin→stdout Python filter for `pipe-pane`
- Strips CSI (colors, cursor), OSC (titles), charset switches, and CR-based progress bar overwrites
- Importable as a module for testing

### Modified: `server/tools/job_sidecar.py`
- `pipe-pane` now uses `ansifilter` > Python filter > `cat` fallback chain
- Logs which filter is selected for debugging

### New: `tests/test_strip_ansi.py`
- 22 test cases covering SGR colors, cursor movement, OSC titles, charset switches, CR overwrites, mixed content, and passthrough

## Architecture
```
tmux pane output → pipe-pane → [ansifilter | strip_ansi_filter.py] → run.log (clean)
                                                                        ↓
                                                       log_routes.py serves as-is
```

## Testing
```
python -m pytest tests/test_strip_ansi.py -v
# 22 passed in 0.02s
```