### PR TITLE
feat: simplify GPU detector to process-count-only + unlimited retries

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -448,10 +448,8 @@ export interface Run {
 
 export interface GpuwrapConfig {
     enabled?: boolean
-    retries?: number
+    retries?: number | null  // null = unlimited, 0 = no retry
     retry_delay_seconds?: number
-    max_memory_used_mb?: number
-    max_utilization?: number
 }
 
 export interface Alert {

--- a/server/core/models.py
+++ b/server/core/models.py
@@ -64,10 +64,8 @@ class SessionModelUpdate(BaseModel):
 
 class GpuwrapConfig(BaseModel):
     enabled: Optional[bool] = None
-    retries: Optional[int] = Field(default=None, ge=0, le=20)
+    retries: Optional[int] = Field(default=None, ge=-1)
     retry_delay_seconds: Optional[float] = Field(default=None, gt=0, le=600)
-    max_memory_used_mb: Optional[int] = Field(default=None, ge=0, le=10_000_000)
-    max_utilization: Optional[int] = Field(default=None, ge=0, le=100)
 
 
 class RunCreate(BaseModel):


### PR DESCRIPTION
## Summary
Addresses #248.

### Changes
1. **GPU availability** now uses `process_count == 0` (no running processes) instead of memory/utilization thresholds
2. **Retries** default to **unlimited** (`None`) with **5-second** interval (was 2 retries / 8s)
3. User can set retries to `0` (no retry), any positive integer, or ∞ (unlimited)

### Files Changed
| File | What |
|------|------|
| `server/tools/gpuwrap_detect.py` | Removed `_is_available`, `_split_availability`, threshold CLI args; availability = `process_count == 0` |
| `server/tools/job_sidecar.py` | `resolve_gpuwrap_settings` defaults to unlimited retries / 5s delay; infinite retry loop support |
| `server/core/models.py` | Removed `max_memory_used_mb`, `max_utilization` from `GpuwrapConfig` |
| `lib/api.ts` | Updated `GpuwrapConfig` interface (removed threshold fields, retries accepts `null`) |
| `components/runs-view.tsx` | Added ∞ checkbox (default checked), removed memory/utilization inputs, updated defaults |

Closes #248