### PR TITLE
feat: settings cleanup, view-all-runs fix, chat tooltips

### DIFF
--- a/components/connected-chat-view.tsx
+++ b/components/connected-chat-view.tsx
@@ -114,7 +114,7 @@ export function ConnectedChatView({
     const [isExcerptPreviewOpen, setIsExcerptPreviewOpen] = useState(false)
     const { settings, setSettings } = useAppSettings()
     const showStarterCards = settings.appearance.starterCardFlavor !== 'none'
-    const showChatContextPanel = settings.appearance.showChatContextPanel !== false
+    const showChatContextPanel = settings.developer?.showChatContextPanel === true
     const starterCardFlavor = settings.appearance.starterCardFlavor || 'novice'
     const customTemplates = settings.appearance.starterCardTemplates ?? {}
     const handleEditTemplate = useCallback((cardId: string, template: string | null) => {

--- a/components/desktop-sidebar.tsx
+++ b/components/desktop-sidebar.tsx
@@ -475,6 +475,7 @@ export function DesktopSidebar({
                     if (item.tab === 'report') return settings.developer?.showReportPanel
                     if (item.tab === 'terminal') return settings.developer?.showTerminalPanel
                     if (item.tab === 'contextual') return settings.developer?.showContextualPanel
+                    if (item.tab === 'journey') return settings.developer?.showJourneyPanel
 
                     const configItem = settings.leftPanel?.items.find((i) => i.id === item.tab)
                     if (configItem) return configItem.visible
@@ -506,7 +507,12 @@ export function DesktopSidebar({
                             onMouseEnter={() => setIsRunsMenuOpen(true)}
                             onMouseLeave={() => setIsRunsMenuOpen(false)}
                           >
-                            <DropdownMenuItem onSelect={() => onTabChange('runs')}>
+                            <DropdownMenuItem onSelect={() => {
+                              if (typeof window !== 'undefined' && window.location.hash) {
+                                window.location.hash = ''
+                              }
+                              onTabChange('runs')
+                            }}>
                               <span className="font-medium">View All Runs</span>
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />

--- a/components/floating-nav.tsx
+++ b/components/floating-nav.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { Menu, Bell, Download, Eye, Edit3, Plus, ChevronDown, Type, Code, BarChart3, Sparkles, PanelLeftOpen, Pause, Play, Square, Target } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -200,48 +201,61 @@ export function FloatingNav({
         <div className="flex items-center gap-1 shrink-0">
           {/* Collapse All Chats Button */}
           {onCollapseChatsChange && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => onCollapseChatsChange(!collapseChats)}
-              className={`h-8 w-8 ${collapseChats ? 'bg-secondary text-secondary-foreground' : ''}`}
-              title={collapseChats ? 'Expand all chats' : 'Collapse all chats'}
-            >
-              <PanelLeftOpen className="h-4 w-4" />
-              <span className="sr-only">{collapseChats ? 'Expand all chats' : 'Collapse all chats'}</span>
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => onCollapseChatsChange(!collapseChats)}
+                  className={`h-8 w-8 ${collapseChats ? 'bg-secondary text-secondary-foreground' : ''}`}
+                >
+                  <PanelLeftOpen className="h-4 w-4" />
+                  <span className="sr-only">{collapseChats ? 'Expand all chats' : 'Collapse all chats'}</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{collapseChats ? 'Expand all chats' : 'Collapse all chats'}</TooltipContent>
+            </Tooltip>
           )}
           {/* Export Button */}
           {onExportSession && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={onExportSession}
-              className="h-8 w-8"
-              title="Export session as Markdown"
-            >
-              <Download className="h-4 w-4" />
-              <span className="sr-only">Export session</span>
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={onExportSession}
+                  className="h-8 w-8"
+                >
+                  <Download className="h-4 w-4" />
+                  <span className="sr-only">Export session</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Export session as Markdown</TooltipContent>
+            </Tooltip>
           )}
           {/* Alert Button with Badge */}
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onAlertClick}
-            className="h-8 w-8 relative"
-          >
-            <Bell className="h-4 w-4" />
-            {eventCount > 0 && (
-              <Badge
-                variant="destructive"
-                className="absolute -top-1 -right-1 h-4 min-w-4 px-1 text-[10px] flex items-center justify-center"
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onAlertClick}
+                className="h-8 w-8 relative"
               >
-                {eventCount > 99 ? '99+' : eventCount}
-              </Badge>
-            )}
-            <span className="sr-only">View alerts ({eventCount})</span>
-          </Button>
+                <Bell className="h-4 w-4" />
+                {eventCount > 0 && (
+                  <Badge
+                    variant="destructive"
+                    className="absolute -top-1 -right-1 h-4 min-w-4 px-1 text-[10px] flex items-center justify-center"
+                  >
+                    {eventCount > 99 ? '99+' : eventCount}
+                  </Badge>
+                )}
+                <span className="sr-only">View alerts ({eventCount})</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>View alerts ({eventCount})</TooltipContent>
+          </Tooltip>
         </div>
       )}
 

--- a/components/left-panel.tsx
+++ b/components/left-panel.tsx
@@ -54,15 +54,15 @@ const NAV_ITEM_CONFIG = {
   },
 } as const
 
-export function LeftPanel({ 
-  open, 
-  onOpenChange, 
+export function LeftPanel({
+  open,
+  onOpenChange,
   onSettingsClick,
   activeTab,
   onTabChange,
 }: LeftPanelProps) {
   const { settings } = useAppSettings()
-  
+
   const handleNavClick = (tab: 'chat' | 'runs' | 'charts' | 'insights' | 'journey') => {
     onTabChange(tab)
     onOpenChange(false)
@@ -96,19 +96,18 @@ export function LeftPanel({
               {navItems.map((item) => {
                 const config = NAV_ITEM_CONFIG[item.id as LeftPanelItemId]
                 if (!config) return null
-                
+
                 const Icon = config.icon
-                
+
                 return (
                   <button
                     key={item.id}
                     type="button"
                     onClick={() => handleNavClick(item.id as 'chat' | 'runs' | 'charts' | 'insights')}
-                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors ${
-                      activeTab === item.id
+                    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors ${activeTab === item.id
                         ? 'bg-secondary text-foreground'
                         : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground'
-                    }`}
+                      }`}
                   >
                     <Icon className="h-4 w-4" />
                     {config.label}
@@ -139,18 +138,19 @@ export function LeftPanel({
               <HelpCircle className="h-4 w-4" />
               Help & Support
             </button>
-            <button
-              type="button"
-              onClick={() => handleNavClick('journey')}
-              className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors ${
-                activeTab === 'journey'
-                  ? 'bg-secondary text-foreground'
-                  : 'text-muted-foreground hover:bg-secondary hover:text-foreground'
-              }`}
-            >
-              <Sparkles className="h-4 w-4" />
-              Our Journey
-            </button>
+            {settings.developer?.showJourneyPanel && (
+              <button
+                type="button"
+                onClick={() => handleNavClick('journey')}
+                className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors ${activeTab === 'journey'
+                    ? 'bg-secondary text-foreground'
+                    : 'text-muted-foreground hover:bg-secondary hover:text-foreground'
+                  }`}
+              >
+                <Sparkles className="h-4 w-4" />
+                Our Journey
+              </button>
+            )}
           </div>
         </div>
       </SheetContent>

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -356,14 +356,6 @@ export function SettingsDialog({
           value: settings.appearance.starterCardFlavor || 'novice',
         },
         {
-          id: 'showChatContextPanel',
-          label: 'Chat Context Panel',
-          description: 'Show or hide the right-side context panel in chat',
-          icon: settings.appearance.showChatContextPanel !== false ? Eye : EyeOff,
-          type: 'toggle' as const,
-          value: settings.appearance.showChatContextPanel !== false,
-        },
-        {
           id: 'showChatArtifacts',
           label: 'Show Artifacts',
           description: 'Show or hide artifacts panel in chat views',
@@ -444,6 +436,22 @@ export function SettingsDialog({
           icon: Eye,
           type: 'toggle' as const,
           value: settings.developer?.showSidebarRunsSweepsPreview !== false,
+        },
+        {
+          id: 'showJourneyPanel',
+          label: 'User Journey Panel',
+          description: 'Show the User Journey tab in the sidebar',
+          icon: Sparkles,
+          type: 'toggle' as const,
+          value: settings.developer?.showJourneyPanel === true,
+        },
+        {
+          id: 'showChatContextPanel',
+          label: 'Chat Context Panel',
+          description: 'Show or hide the right-side context panel in chat',
+          icon: settings.developer?.showChatContextPanel === true ? Eye : EyeOff,
+          type: 'toggle' as const,
+          value: settings.developer?.showChatContextPanel === true,
         },
       ],
     },
@@ -1007,7 +1015,6 @@ export function SettingsDialog({
               onCheckedChange={(checked) => {
                 if (item.id === 'alertsEnabled') handleAlertsToggle(checked)
                 if (item.id === 'webNotifications') handleWebNotificationsToggle(checked)
-                if (item.id === 'showChatContextPanel') updateAppearanceSettings({ showChatContextPanel: checked })
                 if (item.id === 'showChatArtifacts') updateAppearanceSettings({ showChatArtifacts: checked })
                 if (item.id === 'chatCollapseArtifactsInChat') updateAppearanceSettings({ chatCollapseArtifactsInChat: checked })
                 if (item.id === 'showWildLoopState') {
@@ -1026,6 +1033,18 @@ export function SettingsDialog({
                   onSettingsChange({
                     ...settings,
                     developer: { ...settings.developer, showSidebarRunsSweepsPreview: checked },
+                  })
+                }
+                if (item.id === 'showJourneyPanel') {
+                  onSettingsChange({
+                    ...settings,
+                    developer: { ...settings.developer, showJourneyPanel: checked },
+                  })
+                }
+                if (item.id === 'showChatContextPanel') {
+                  onSettingsChange({
+                    ...settings,
+                    developer: { ...settings.developer, showChatContextPanel: checked },
                   })
                 }
               }}
@@ -1047,235 +1066,235 @@ export function SettingsDialog({
               </div>
 
               <div className="mt-4 space-y-3 border-t border-border pt-4">
-                  <div className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-background/60 px-3 py-2">
-                    <div>
-                      <Label htmlFor="sidebar-new-chat-toggle-dialog" className="text-xs">Sidebar New Chat Button</Label>
-                      <p className="text-[11px] text-muted-foreground">Show or hide the New Chat button in the desktop sidebar</p>
-                    </div>
-                    <Switch
-                      id="sidebar-new-chat-toggle-dialog"
-                      checked={settings.appearance.showSidebarNewChatButton === true}
-                      onCheckedChange={(checked) => updateAppearanceSettings({ showSidebarNewChatButton: checked })}
-                    />
+                <div className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-background/60 px-3 py-2">
+                  <div>
+                    <Label htmlFor="sidebar-new-chat-toggle-dialog" className="text-xs">Sidebar New Chat Button</Label>
+                    <p className="text-[11px] text-muted-foreground">Show or hide the New Chat button in the desktop sidebar</p>
                   </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="custom-font-size-dialog" className="text-xs">Font Size (px) <span className="font-normal text-muted-foreground">1–1000</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Overrides small/medium/large when set</p>
-                    </div>
-                    <Input
-                      id="custom-font-size-dialog"
-                      type="number"
-                      min={1}
-                      max={1000}
-                      value={fontSizeInput}
-                      onChange={(e) => handleCustomFontSizeChange(e.target.value)}
-                      onBlur={(e) => handleCustomFontSizeBlur(e.target.value)}
-                      placeholder={settings.appearance.fontSize === 'small' ? '14' : settings.appearance.fontSize === 'large' ? '18' : '16'}
-                      className="h-8 w-24 text-xs"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="custom-button-scale-dialog" className="text-xs">Button Scale (%) <span className="font-normal text-muted-foreground">1–1000</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Scales global button sizes</p>
-                    </div>
-                    <Input
-                      id="custom-button-scale-dialog"
-                      type="number"
-                      min={1}
-                      max={1000}
-                      value={buttonScaleInput}
-                      onChange={(e) => handleCustomButtonScaleChange(e.target.value)}
-                      onBlur={(e) => handleCustomButtonScaleBlur(e.target.value)}
-                      placeholder="120"
-                      className="h-8 w-24 text-xs"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="chat-toolbar-button-size-dialog" className="text-xs">Chat Bottom Buttons (px) <span className="font-normal text-muted-foreground">1–1000</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Mode/add/mention/command controls</p>
-                    </div>
-                    <Input
-                      id="chat-toolbar-button-size-dialog"
-                      type="number"
-                      min={1}
-                      max={1000}
-                      value={chatToolbarSizeInput}
-                      onChange={(e) => handleChatToolbarButtonSizeChange(e.target.value)}
-                      onBlur={(e) => handleChatToolbarButtonSizeBlur(e.target.value)}
-                      placeholder="36"
-                      className="h-8 w-24 text-xs"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="chat-input-initial-height-dialog" className="text-xs">Chat Input Initial Height (px) <span className="font-normal text-muted-foreground">40–120</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Default one-line composer height before expansion</p>
-                    </div>
-                    <Input
-                      id="chat-input-initial-height-dialog"
-                      type="number"
-                      min={40}
-                      max={120}
-                      value={chatInputInitialHeightInput}
-                      onChange={(e) => handleChatInputInitialHeightChange(e.target.value, chatInputInitialHeightInput)}
-                      onBlur={(e) => handleChatInputInitialHeightBlur(e.target.value)}
-                      placeholder="48"
-                      className="h-8 w-24 text-xs"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="tool-box-height-dialog" className="text-xs">Tool / Thinking Box Height (rem) <span className="font-normal text-muted-foreground">1–1000</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Max height of tool/thinking boxes during streaming</p>
-                    </div>
-                    <Input
-                      id="tool-box-height-dialog"
-                      type="number"
-                      min={1}
-                      max={1000}
-                      step={0.5}
-                      value={toolBoxHeightInput}
-                      onChange={(e) => handleToolBoxHeightChange(e.target.value, toolBoxHeightInput)}
-                      onBlur={(e) => handleToolBoxHeightBlur(e.target.value)}
-                      placeholder="7.5"
-                      className="h-8 w-24 text-xs"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="custom-primary-color-dialog" className="text-xs">Primary Color</Label>
-                      <p className="text-[11px] text-muted-foreground">Hex color for --primary (example: #f59e0b)</p>
-                    </div>
-                    <Input
-                      id="custom-primary-color-dialog"
-                      value={primaryColorInput}
-                      onChange={(e) => handlePrimaryColorChange(e.target.value)}
-                      onBlur={(e) => handlePrimaryColorBlur(e.target.value)}
-                      placeholder="#f59e0b"
-                      className="h-8 w-28 text-xs font-mono"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="wild-loop-tasks-font-size-dialog" className="text-xs">Wild Loop Tasks Font (px) <span className="font-normal text-muted-foreground">12–28</span></Label>
-                      <p className="text-[11px] text-muted-foreground">tasks.md text size in the Wild Loop Debug panel</p>
-                    </div>
-                    <Input
-                      id="wild-loop-tasks-font-size-dialog"
-                      type="number"
-                      min={12}
-                      max={28}
-                      value={wildLoopTasksFontSizeInput}
-                      onChange={(e) => handleWildLoopTasksFontSizeChange(e.target.value, wildLoopTasksFontSizeInput)}
-                      onBlur={(e) => handleWildLoopTasksFontSizeBlur(e.target.value)}
-                      placeholder="16"
-                      className="h-8 w-24 text-xs"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="wild-loop-tasks-box-height-dialog" className="text-xs">Wild Loop Tasks Box Height (px) <span className="font-normal text-muted-foreground">160–1200</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Max height of the tasks.md scroll area in the Wild Loop Debug panel</p>
-                    </div>
-                    <Input
-                      id="wild-loop-tasks-box-height-dialog"
-                      type="number"
-                      min={160}
-                      max={1200}
-                      value={wildLoopTasksBoxHeightInput}
-                      onChange={(e) => handleWildLoopTasksBoxHeightChange(e.target.value, wildLoopTasksBoxHeightInput)}
-                      onBlur={(e) => handleWildLoopTasksBoxHeightBlur(e.target.value)}
-                      placeholder="420"
-                      className="h-8 w-24 text-xs"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="custom-accent-color-dialog" className="text-xs">Accent Color</Label>
-                      <p className="text-[11px] text-muted-foreground">Hex color for --accent (example: #fb923c)</p>
-                    </div>
-                    <Input
-                      id="custom-accent-color-dialog"
-                      value={accentColorInput}
-                      onChange={(e) => handleAccentColorChange(e.target.value)}
-                      onBlur={(e) => handleAccentColorBlur(e.target.value)}
-                      placeholder="#fb923c"
-                      className="h-8 w-28 text-xs font-mono"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="wild-loop-history-font-size-dialog" className="text-xs">Wild Loop History Font (px) <span className="font-normal text-muted-foreground">12–28</span></Label>
-                      <p className="text-[11px] text-muted-foreground">iteration history text size in the Wild Loop Debug panel</p>
-                    </div>
-                    <Input
-                      id="wild-loop-history-font-size-dialog"
-                      type="number"
-                      min={12}
-                      max={28}
-                      value={wildLoopHistoryFontSizeInput}
-                      onChange={(e) => handleWildLoopHistoryFontSizeChange(e.target.value, wildLoopHistoryFontSizeInput)}
-                      onBlur={(e) => handleWildLoopHistoryFontSizeBlur(e.target.value)}
-                      placeholder="15"
-                      className="h-8 w-24 text-xs"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="wild-loop-history-box-height-dialog" className="text-xs">Wild Loop History Box Height (px) <span className="font-normal text-muted-foreground">120–1000</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Max height of iteration history list in the Wild Loop Debug panel</p>
-                    </div>
-                    <Input
-                      id="wild-loop-history-box-height-dialog"
-                      type="number"
-                      min={120}
-                      max={1000}
-                      value={wildLoopHistoryBoxHeightInput}
-                      onChange={(e) => handleWildLoopHistoryBoxHeightChange(e.target.value, wildLoopHistoryBoxHeightInput)}
-                      onBlur={(e) => handleWildLoopHistoryBoxHeightBlur(e.target.value)}
-                      placeholder="300"
-                      className="h-8 w-24 text-xs"
-                    />
-                  </div>
-
-                  <div className="flex justify-end">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() =>
-                        updateAppearanceSettings({
-                          customFontSizePx: null,
-                          customButtonScalePercent: null,
-                          chatToolbarButtonSizePx: null,
-                          chatInputInitialHeightPx: null,
-                          streamingToolBoxHeightRem: null,
-                          customPrimaryColor: null,
-                          customAccentColor: null,
-                          wildLoopTasksFontSizePx: null,
-                          wildLoopHistoryFontSizePx: null,
-                          wildLoopTasksBoxHeightPx: null,
-                          wildLoopHistoryBoxHeightPx: null,
-                        })
-                      }
-                    >
-                      Reset Advanced
-                    </Button>
-                  </div>
+                  <Switch
+                    id="sidebar-new-chat-toggle-dialog"
+                    checked={settings.appearance.showSidebarNewChatButton === true}
+                    onCheckedChange={(checked) => updateAppearanceSettings({ showSidebarNewChatButton: checked })}
+                  />
                 </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="custom-font-size-dialog" className="text-xs">Font Size (px) <span className="font-normal text-muted-foreground">1–1000</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Overrides small/medium/large when set</p>
+                  </div>
+                  <Input
+                    id="custom-font-size-dialog"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    value={fontSizeInput}
+                    onChange={(e) => handleCustomFontSizeChange(e.target.value)}
+                    onBlur={(e) => handleCustomFontSizeBlur(e.target.value)}
+                    placeholder={settings.appearance.fontSize === 'small' ? '14' : settings.appearance.fontSize === 'large' ? '18' : '16'}
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="custom-button-scale-dialog" className="text-xs">Button Scale (%) <span className="font-normal text-muted-foreground">1–1000</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Scales global button sizes</p>
+                  </div>
+                  <Input
+                    id="custom-button-scale-dialog"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    value={buttonScaleInput}
+                    onChange={(e) => handleCustomButtonScaleChange(e.target.value)}
+                    onBlur={(e) => handleCustomButtonScaleBlur(e.target.value)}
+                    placeholder="120"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="chat-toolbar-button-size-dialog" className="text-xs">Chat Bottom Buttons (px) <span className="font-normal text-muted-foreground">1–1000</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Mode/add/mention/command controls</p>
+                  </div>
+                  <Input
+                    id="chat-toolbar-button-size-dialog"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    value={chatToolbarSizeInput}
+                    onChange={(e) => handleChatToolbarButtonSizeChange(e.target.value)}
+                    onBlur={(e) => handleChatToolbarButtonSizeBlur(e.target.value)}
+                    placeholder="36"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="chat-input-initial-height-dialog" className="text-xs">Chat Input Initial Height (px) <span className="font-normal text-muted-foreground">40–120</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Default one-line composer height before expansion</p>
+                  </div>
+                  <Input
+                    id="chat-input-initial-height-dialog"
+                    type="number"
+                    min={40}
+                    max={120}
+                    value={chatInputInitialHeightInput}
+                    onChange={(e) => handleChatInputInitialHeightChange(e.target.value, chatInputInitialHeightInput)}
+                    onBlur={(e) => handleChatInputInitialHeightBlur(e.target.value)}
+                    placeholder="48"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="tool-box-height-dialog" className="text-xs">Tool / Thinking Box Height (rem) <span className="font-normal text-muted-foreground">1–1000</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Max height of tool/thinking boxes during streaming</p>
+                  </div>
+                  <Input
+                    id="tool-box-height-dialog"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    step={0.5}
+                    value={toolBoxHeightInput}
+                    onChange={(e) => handleToolBoxHeightChange(e.target.value, toolBoxHeightInput)}
+                    onBlur={(e) => handleToolBoxHeightBlur(e.target.value)}
+                    placeholder="7.5"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="custom-primary-color-dialog" className="text-xs">Primary Color</Label>
+                    <p className="text-[11px] text-muted-foreground">Hex color for --primary (example: #f59e0b)</p>
+                  </div>
+                  <Input
+                    id="custom-primary-color-dialog"
+                    value={primaryColorInput}
+                    onChange={(e) => handlePrimaryColorChange(e.target.value)}
+                    onBlur={(e) => handlePrimaryColorBlur(e.target.value)}
+                    placeholder="#f59e0b"
+                    className="h-8 w-28 text-xs font-mono"
+                  />
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="wild-loop-tasks-font-size-dialog" className="text-xs">Wild Loop Tasks Font (px) <span className="font-normal text-muted-foreground">12–28</span></Label>
+                    <p className="text-[11px] text-muted-foreground">tasks.md text size in the Wild Loop Debug panel</p>
+                  </div>
+                  <Input
+                    id="wild-loop-tasks-font-size-dialog"
+                    type="number"
+                    min={12}
+                    max={28}
+                    value={wildLoopTasksFontSizeInput}
+                    onChange={(e) => handleWildLoopTasksFontSizeChange(e.target.value, wildLoopTasksFontSizeInput)}
+                    onBlur={(e) => handleWildLoopTasksFontSizeBlur(e.target.value)}
+                    placeholder="16"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="wild-loop-tasks-box-height-dialog" className="text-xs">Wild Loop Tasks Box Height (px) <span className="font-normal text-muted-foreground">160–1200</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Max height of the tasks.md scroll area in the Wild Loop Debug panel</p>
+                  </div>
+                  <Input
+                    id="wild-loop-tasks-box-height-dialog"
+                    type="number"
+                    min={160}
+                    max={1200}
+                    value={wildLoopTasksBoxHeightInput}
+                    onChange={(e) => handleWildLoopTasksBoxHeightChange(e.target.value, wildLoopTasksBoxHeightInput)}
+                    onBlur={(e) => handleWildLoopTasksBoxHeightBlur(e.target.value)}
+                    placeholder="420"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="custom-accent-color-dialog" className="text-xs">Accent Color</Label>
+                    <p className="text-[11px] text-muted-foreground">Hex color for --accent (example: #fb923c)</p>
+                  </div>
+                  <Input
+                    id="custom-accent-color-dialog"
+                    value={accentColorInput}
+                    onChange={(e) => handleAccentColorChange(e.target.value)}
+                    onBlur={(e) => handleAccentColorBlur(e.target.value)}
+                    placeholder="#fb923c"
+                    className="h-8 w-28 text-xs font-mono"
+                  />
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="wild-loop-history-font-size-dialog" className="text-xs">Wild Loop History Font (px) <span className="font-normal text-muted-foreground">12–28</span></Label>
+                    <p className="text-[11px] text-muted-foreground">iteration history text size in the Wild Loop Debug panel</p>
+                  </div>
+                  <Input
+                    id="wild-loop-history-font-size-dialog"
+                    type="number"
+                    min={12}
+                    max={28}
+                    value={wildLoopHistoryFontSizeInput}
+                    onChange={(e) => handleWildLoopHistoryFontSizeChange(e.target.value, wildLoopHistoryFontSizeInput)}
+                    onBlur={(e) => handleWildLoopHistoryFontSizeBlur(e.target.value)}
+                    placeholder="15"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="wild-loop-history-box-height-dialog" className="text-xs">Wild Loop History Box Height (px) <span className="font-normal text-muted-foreground">120–1000</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Max height of iteration history list in the Wild Loop Debug panel</p>
+                  </div>
+                  <Input
+                    id="wild-loop-history-box-height-dialog"
+                    type="number"
+                    min={120}
+                    max={1000}
+                    value={wildLoopHistoryBoxHeightInput}
+                    onChange={(e) => handleWildLoopHistoryBoxHeightChange(e.target.value, wildLoopHistoryBoxHeightInput)}
+                    onBlur={(e) => handleWildLoopHistoryBoxHeightBlur(e.target.value)}
+                    placeholder="300"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+
+                <div className="flex justify-end">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      updateAppearanceSettings({
+                        customFontSizePx: null,
+                        customButtonScalePercent: null,
+                        chatToolbarButtonSizePx: null,
+                        chatInputInitialHeightPx: null,
+                        streamingToolBoxHeightRem: null,
+                        customPrimaryColor: null,
+                        customAccentColor: null,
+                        wildLoopTasksFontSizePx: null,
+                        wildLoopHistoryFontSizePx: null,
+                        wildLoopTasksBoxHeightPx: null,
+                        wildLoopHistoryBoxHeightPx: null,
+                      })
+                    }
+                  >
+                    Reset Advanced
+                  </Button>
+                </div>
+              </div>
             </div>
           )
         }

--- a/components/settings-page-content.tsx
+++ b/components/settings-page-content.tsx
@@ -349,14 +349,6 @@ export function SettingsPageContent({
           value: settings.appearance.starterCardFlavor || 'novice',
         },
         {
-          id: 'showChatContextPanel',
-          label: 'Chat Context Panel',
-          description: 'Show or hide the right-side context panel in chat',
-          icon: settings.appearance.showChatContextPanel !== false ? Eye : EyeOff,
-          type: 'toggle' as const,
-          value: settings.appearance.showChatContextPanel !== false,
-        },
-        {
           id: 'showChatArtifacts',
           label: 'Show Artifacts',
           description: 'Show or hide artifacts panel in chat views',
@@ -499,6 +491,22 @@ export function SettingsPageContent({
           type: 'toggle' as const,
           value: settings.developer?.showContextualPanel === true,
           beta: true,
+        },
+        {
+          id: 'showJourneyPanel',
+          label: 'User Journey Panel',
+          description: 'Show the User Journey tab in the sidebar',
+          icon: Sparkles,
+          type: 'toggle' as const,
+          value: settings.developer?.showJourneyPanel === true,
+        },
+        {
+          id: 'showChatContextPanel',
+          label: 'Chat Context Panel',
+          description: 'Show or hide the right-side context panel in chat',
+          icon: settings.developer?.showChatContextPanel !== false ? Eye : EyeOff,
+          type: 'toggle' as const,
+          value: settings.developer?.showChatContextPanel === true,
         },
       ],
     },
@@ -1051,7 +1059,6 @@ export function SettingsPageContent({
                 if (item.id === 'alertsEnabled') handleAlertsToggle(checked)
                 if (item.id === 'webNotifications') handleWebNotificationsToggle(checked)
                 if (item.id === 'showRunItemMetadata') updateAppearanceSettings({ showRunItemMetadata: checked })
-                if (item.id === 'showChatContextPanel') updateAppearanceSettings({ showChatContextPanel: checked })
                 if (item.id === 'showChatArtifacts') updateAppearanceSettings({ showChatArtifacts: checked })
                 if (item.id === 'chatCollapseArtifactsInChat') updateAppearanceSettings({ chatCollapseArtifactsInChat: checked })
                 if (item.id === 'mobileEnterToNewline') updateAppearanceSettings({ mobileEnterToNewline: checked })
@@ -1089,6 +1096,18 @@ export function SettingsPageContent({
                   onSettingsChange({
                     ...settings,
                     developer: { ...settings.developer, showContextualPanel: checked },
+                  })
+                }
+                if (item.id === 'showJourneyPanel') {
+                  onSettingsChange({
+                    ...settings,
+                    developer: { ...settings.developer, showJourneyPanel: checked },
+                  })
+                }
+                if (item.id === 'showChatContextPanel') {
+                  onSettingsChange({
+                    ...settings,
+                    developer: { ...settings.developer, showChatContextPanel: checked },
                   })
                 }
                 if (item.id === 'showSidebarRunsSweepsPreview') {
@@ -1153,258 +1172,258 @@ export function SettingsPageContent({
               </div>
 
               <div className="rounded-lg bg-secondary/50 p-4">
-                  <div className="flex items-center justify-between gap-3 rounded-md px-1 py-1">
-                    <div>
-                      <Label htmlFor="sidebar-new-chat-toggle" className="text-xs">Sidebar New Chat Button</Label>
-                      <p className="text-[11px] text-muted-foreground">Show or hide the New Chat button in the desktop sidebar</p>
-                    </div>
-                    <Switch
-                      id="sidebar-new-chat-toggle"
-                      checked={settings.appearance.showSidebarNewChatButton === true}
-                      onCheckedChange={(checked) => updateAppearanceSettings({ showSidebarNewChatButton: checked })}
-                    />
+                <div className="flex items-center justify-between gap-3 rounded-md px-1 py-1">
+                  <div>
+                    <Label htmlFor="sidebar-new-chat-toggle" className="text-xs">Sidebar New Chat Button</Label>
+                    <p className="text-[11px] text-muted-foreground">Show or hide the New Chat button in the desktop sidebar</p>
                   </div>
+                  <Switch
+                    id="sidebar-new-chat-toggle"
+                    checked={settings.appearance.showSidebarNewChatButton === true}
+                    onCheckedChange={(checked) => updateAppearanceSettings({ showSidebarNewChatButton: checked })}
+                  />
+                </div>
               </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="custom-font-size" className="text-xs">Font Size (px) <span className="font-normal text-muted-foreground">1–1000</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Overrides small/medium/large when set</p>
-                    </div>
-                    <Input
-                      id="custom-font-size"
-                      type="number"
-                      min={1}
-                      max={1000}
-                      value={fontSizeInput}
-                      onChange={(e) => handleCustomFontSizeChange(e.target.value)}
-                      onBlur={(e) => handleCustomFontSizeBlur(e.target.value)}
-                      placeholder={settings.appearance.fontSize === 'small' ? '14' : settings.appearance.fontSize === 'large' ? '18' : '16'}
-                      className="h-8 w-24 text-xs"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="custom-font-size" className="text-xs">Font Size (px) <span className="font-normal text-muted-foreground">1–1000</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Overrides small/medium/large when set</p>
                   </div>
-                  </div>
+                  <Input
+                    id="custom-font-size"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    value={fontSizeInput}
+                    onChange={(e) => handleCustomFontSizeChange(e.target.value)}
+                    onBlur={(e) => handleCustomFontSizeBlur(e.target.value)}
+                    placeholder={settings.appearance.fontSize === 'small' ? '14' : settings.appearance.fontSize === 'large' ? '18' : '16'}
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+              </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="custom-button-scale" className="text-xs">Button Scale (%) <span className="font-normal text-muted-foreground">1–1000</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Scales global button sizes</p>
-                    </div>
-                    <Input
-                      id="custom-button-scale"
-                      type="number"
-                      min={1}
-                      max={1000}
-                      value={buttonScaleInput}
-                      onChange={(e) => handleCustomButtonScaleChange(e.target.value)}
-                      onBlur={(e) => handleCustomButtonScaleBlur(e.target.value)}
-                      placeholder="120"
-                      className="h-8 w-24 text-xs"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="custom-button-scale" className="text-xs">Button Scale (%) <span className="font-normal text-muted-foreground">1–1000</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Scales global button sizes</p>
                   </div>
-                  </div>
+                  <Input
+                    id="custom-button-scale"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    value={buttonScaleInput}
+                    onChange={(e) => handleCustomButtonScaleChange(e.target.value)}
+                    onBlur={(e) => handleCustomButtonScaleBlur(e.target.value)}
+                    placeholder="120"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+              </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="chat-toolbar-button-size" className="text-xs">Chat Bottom Buttons (px) <span className="font-normal text-muted-foreground">1–1000</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Mode/add/mention/command controls</p>
-                    </div>
-                    <Input
-                      id="chat-toolbar-button-size"
-                      type="number"
-                      min={1}
-                      max={1000}
-                      value={chatToolbarSizeInput}
-                      onChange={(e) => handleChatToolbarButtonSizeChange(e.target.value)}
-                      onBlur={(e) => handleChatToolbarButtonSizeBlur(e.target.value)}
-                      placeholder="36"
-                      className="h-8 w-24 text-xs"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="chat-toolbar-button-size" className="text-xs">Chat Bottom Buttons (px) <span className="font-normal text-muted-foreground">1–1000</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Mode/add/mention/command controls</p>
                   </div>
-                  </div>
+                  <Input
+                    id="chat-toolbar-button-size"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    value={chatToolbarSizeInput}
+                    onChange={(e) => handleChatToolbarButtonSizeChange(e.target.value)}
+                    onBlur={(e) => handleChatToolbarButtonSizeBlur(e.target.value)}
+                    placeholder="36"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+              </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="chat-input-initial-height" className="text-xs">Chat Input Initial Height (px) <span className="font-normal text-muted-foreground">40–120</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Default one-line composer height before expansion</p>
-                    </div>
-                    <Input
-                      id="chat-input-initial-height"
-                      type="number"
-                      min={40}
-                      max={120}
-                      value={chatInputInitialHeightInput}
-                      onChange={(e) => handleChatInputInitialHeightChange(e.target.value, chatInputInitialHeightInput)}
-                      onBlur={(e) => handleChatInputInitialHeightBlur(e.target.value)}
-                      placeholder="48"
-                      className="h-8 w-24 text-xs"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="chat-input-initial-height" className="text-xs">Chat Input Initial Height (px) <span className="font-normal text-muted-foreground">40–120</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Default one-line composer height before expansion</p>
                   </div>
-                  </div>
+                  <Input
+                    id="chat-input-initial-height"
+                    type="number"
+                    min={40}
+                    max={120}
+                    value={chatInputInitialHeightInput}
+                    onChange={(e) => handleChatInputInitialHeightChange(e.target.value, chatInputInitialHeightInput)}
+                    onBlur={(e) => handleChatInputInitialHeightBlur(e.target.value)}
+                    placeholder="48"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+              </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="tool-box-height" className="text-xs">Tool / Thinking Box Height (rem) <span className="font-normal text-muted-foreground">1–1000</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Max height of tool/thinking boxes during streaming</p>
-                    </div>
-                    <Input
-                      id="tool-box-height"
-                      type="number"
-                      min={1}
-                      max={1000}
-                      step={0.5}
-                      value={toolBoxHeightInput}
-                      onChange={(e) => handleToolBoxHeightChange(e.target.value, toolBoxHeightInput)}
-                      onBlur={(e) => handleToolBoxHeightBlur(e.target.value)}
-                      placeholder="7.5"
-                      className="h-8 w-24 text-xs"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="tool-box-height" className="text-xs">Tool / Thinking Box Height (rem) <span className="font-normal text-muted-foreground">1–1000</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Max height of tool/thinking boxes during streaming</p>
                   </div>
-                  </div>
+                  <Input
+                    id="tool-box-height"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    step={0.5}
+                    value={toolBoxHeightInput}
+                    onChange={(e) => handleToolBoxHeightChange(e.target.value, toolBoxHeightInput)}
+                    onBlur={(e) => handleToolBoxHeightBlur(e.target.value)}
+                    placeholder="7.5"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+              </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="custom-primary-color" className="text-xs">Primary Color</Label>
-                      <p className="text-[11px] text-muted-foreground">Hex color for --primary (example: #f59e0b)</p>
-                    </div>
-                    <Input
-                      id="custom-primary-color"
-                      value={primaryColorInput}
-                      onChange={(e) => handlePrimaryColorChange(e.target.value)}
-                      onBlur={(e) => handlePrimaryColorBlur(e.target.value)}
-                      placeholder="#f59e0b"
-                      className="h-8 w-28 text-xs font-mono"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="custom-primary-color" className="text-xs">Primary Color</Label>
+                    <p className="text-[11px] text-muted-foreground">Hex color for --primary (example: #f59e0b)</p>
                   </div>
-                  </div>
+                  <Input
+                    id="custom-primary-color"
+                    value={primaryColorInput}
+                    onChange={(e) => handlePrimaryColorChange(e.target.value)}
+                    onBlur={(e) => handlePrimaryColorBlur(e.target.value)}
+                    placeholder="#f59e0b"
+                    className="h-8 w-28 text-xs font-mono"
+                  />
+                </div>
+              </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="custom-accent-color" className="text-xs">Accent Color</Label>
-                      <p className="text-[11px] text-muted-foreground">Hex color for --accent (example: #fb923c)</p>
-                    </div>
-                    <Input
-                      id="custom-accent-color"
-                      value={accentColorInput}
-                      onChange={(e) => handleAccentColorChange(e.target.value)}
-                      onBlur={(e) => handleAccentColorBlur(e.target.value)}
-                      placeholder="#fb923c"
-                      className="h-8 w-28 text-xs font-mono"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="custom-accent-color" className="text-xs">Accent Color</Label>
+                    <p className="text-[11px] text-muted-foreground">Hex color for --accent (example: #fb923c)</p>
                   </div>
-                  </div>
+                  <Input
+                    id="custom-accent-color"
+                    value={accentColorInput}
+                    onChange={(e) => handleAccentColorChange(e.target.value)}
+                    onBlur={(e) => handleAccentColorBlur(e.target.value)}
+                    placeholder="#fb923c"
+                    className="h-8 w-28 text-xs font-mono"
+                  />
+                </div>
+              </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="wild-loop-tasks-font-size" className="text-xs">Wild Loop Tasks Font (px) <span className="font-normal text-muted-foreground">12–28</span></Label>
-                      <p className="text-[11px] text-muted-foreground">tasks.md text size in the Wild Loop Debug panel</p>
-                    </div>
-                    <Input
-                      id="wild-loop-tasks-font-size"
-                      type="number"
-                      min={12}
-                      max={28}
-                      value={wildLoopTasksFontSizeInput}
-                      onChange={(e) => handleWildLoopTasksFontSizeChange(e.target.value, wildLoopTasksFontSizeInput)}
-                      onBlur={(e) => handleWildLoopTasksFontSizeBlur(e.target.value)}
-                      placeholder="16"
-                      className="h-8 w-24 text-xs"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="wild-loop-tasks-font-size" className="text-xs">Wild Loop Tasks Font (px) <span className="font-normal text-muted-foreground">12–28</span></Label>
+                    <p className="text-[11px] text-muted-foreground">tasks.md text size in the Wild Loop Debug panel</p>
                   </div>
-                  </div>
+                  <Input
+                    id="wild-loop-tasks-font-size"
+                    type="number"
+                    min={12}
+                    max={28}
+                    value={wildLoopTasksFontSizeInput}
+                    onChange={(e) => handleWildLoopTasksFontSizeChange(e.target.value, wildLoopTasksFontSizeInput)}
+                    onBlur={(e) => handleWildLoopTasksFontSizeBlur(e.target.value)}
+                    placeholder="16"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+              </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="wild-loop-tasks-box-height" className="text-xs">Wild Loop Tasks Box Height (px) <span className="font-normal text-muted-foreground">160–1200</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Max height of the tasks.md scroll area in the Wild Loop Debug panel</p>
-                    </div>
-                    <Input
-                      id="wild-loop-tasks-box-height"
-                      type="number"
-                      min={160}
-                      max={1200}
-                      value={wildLoopTasksBoxHeightInput}
-                      onChange={(e) => handleWildLoopTasksBoxHeightChange(e.target.value, wildLoopTasksBoxHeightInput)}
-                      onBlur={(e) => handleWildLoopTasksBoxHeightBlur(e.target.value)}
-                      placeholder="420"
-                      className="h-8 w-24 text-xs"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="wild-loop-tasks-box-height" className="text-xs">Wild Loop Tasks Box Height (px) <span className="font-normal text-muted-foreground">160–1200</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Max height of the tasks.md scroll area in the Wild Loop Debug panel</p>
                   </div>
-                  </div>
+                  <Input
+                    id="wild-loop-tasks-box-height"
+                    type="number"
+                    min={160}
+                    max={1200}
+                    value={wildLoopTasksBoxHeightInput}
+                    onChange={(e) => handleWildLoopTasksBoxHeightChange(e.target.value, wildLoopTasksBoxHeightInput)}
+                    onBlur={(e) => handleWildLoopTasksBoxHeightBlur(e.target.value)}
+                    placeholder="420"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+              </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="wild-loop-history-font-size" className="text-xs">Wild Loop History Font (px) <span className="font-normal text-muted-foreground">12–28</span></Label>
-                      <p className="text-[11px] text-muted-foreground">iteration history text size in the Wild Loop Debug panel</p>
-                    </div>
-                    <Input
-                      id="wild-loop-history-font-size"
-                      type="number"
-                      min={12}
-                      max={28}
-                      value={wildLoopHistoryFontSizeInput}
-                      onChange={(e) => handleWildLoopHistoryFontSizeChange(e.target.value, wildLoopHistoryFontSizeInput)}
-                      onBlur={(e) => handleWildLoopHistoryFontSizeBlur(e.target.value)}
-                      placeholder="15"
-                      className="h-8 w-24 text-xs"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="wild-loop-history-font-size" className="text-xs">Wild Loop History Font (px) <span className="font-normal text-muted-foreground">12–28</span></Label>
+                    <p className="text-[11px] text-muted-foreground">iteration history text size in the Wild Loop Debug panel</p>
                   </div>
-                  </div>
+                  <Input
+                    id="wild-loop-history-font-size"
+                    type="number"
+                    min={12}
+                    max={28}
+                    value={wildLoopHistoryFontSizeInput}
+                    onChange={(e) => handleWildLoopHistoryFontSizeChange(e.target.value, wildLoopHistoryFontSizeInput)}
+                    onBlur={(e) => handleWildLoopHistoryFontSizeBlur(e.target.value)}
+                    placeholder="15"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+              </div>
 
-                  <div className="rounded-lg bg-secondary/50 p-4">
-                    <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-                    <div>
-                      <Label htmlFor="wild-loop-history-box-height" className="text-xs">Wild Loop History Box Height (px) <span className="font-normal text-muted-foreground">120–1000</span></Label>
-                      <p className="text-[11px] text-muted-foreground">Max height of iteration history list in the Wild Loop Debug panel</p>
-                    </div>
-                    <Input
-                      id="wild-loop-history-box-height"
-                      type="number"
-                      min={120}
-                      max={1000}
-                      value={wildLoopHistoryBoxHeightInput}
-                      onChange={(e) => handleWildLoopHistoryBoxHeightChange(e.target.value, wildLoopHistoryBoxHeightInput)}
-                      onBlur={(e) => handleWildLoopHistoryBoxHeightBlur(e.target.value)}
-                      placeholder="300"
-                      className="h-8 w-24 text-xs"
-                    />
+              <div className="rounded-lg bg-secondary/50 p-4">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
+                  <div>
+                    <Label htmlFor="wild-loop-history-box-height" className="text-xs">Wild Loop History Box Height (px) <span className="font-normal text-muted-foreground">120–1000</span></Label>
+                    <p className="text-[11px] text-muted-foreground">Max height of iteration history list in the Wild Loop Debug panel</p>
                   </div>
-                  </div>
+                  <Input
+                    id="wild-loop-history-box-height"
+                    type="number"
+                    min={120}
+                    max={1000}
+                    value={wildLoopHistoryBoxHeightInput}
+                    onChange={(e) => handleWildLoopHistoryBoxHeightChange(e.target.value, wildLoopHistoryBoxHeightInput)}
+                    onBlur={(e) => handleWildLoopHistoryBoxHeightBlur(e.target.value)}
+                    placeholder="300"
+                    className="h-8 w-24 text-xs"
+                  />
+                </div>
+              </div>
 
-                  <div className="flex justify-end">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() =>
-                        updateAppearanceSettings({
-                          customFontSizePx: null,
-                          customButtonScalePercent: null,
-                          chatToolbarButtonSizePx: null,
-                          chatInputInitialHeightPx: null,
-                          streamingToolBoxHeightRem: null,
-                          customPrimaryColor: null,
-                          customAccentColor: null,
-                          wildLoopTasksFontSizePx: null,
-                          wildLoopHistoryFontSizePx: null,
-                          wildLoopTasksBoxHeightPx: null,
-                          wildLoopHistoryBoxHeightPx: null,
-                          thinkingToolFontSizePx: null,
-                        })
-                      }
-                    >
-                      Reset Advanced
-                    </Button>
-                  </div>
+              <div className="flex justify-end">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    updateAppearanceSettings({
+                      customFontSizePx: null,
+                      customButtonScalePercent: null,
+                      chatToolbarButtonSizePx: null,
+                      chatInputInitialHeightPx: null,
+                      streamingToolBoxHeightRem: null,
+                      customPrimaryColor: null,
+                      customAccentColor: null,
+                      wildLoopTasksFontSizePx: null,
+                      wildLoopHistoryFontSizePx: null,
+                      wildLoopTasksBoxHeightPx: null,
+                      wildLoopHistoryBoxHeightPx: null,
+                      thinkingToolFontSizePx: null,
+                    })
+                  }
+                >
+                  Reset Advanced
+                </Button>
+              </div>
             </div>
           )
         }

--- a/lib/app-settings.tsx
+++ b/lib/app-settings.tsx
@@ -56,7 +56,7 @@ export const defaultAppSettings: AppSettings = {
     wildLoopHistoryBoxHeightPx: null,
     showStarterCards: true,
     starterCardFlavor: "novice",
-    showChatContextPanel: true,
+    showChatContextPanel: false,
     showChatArtifacts: false,
     chatCollapseAllChats: false,
     chatCollapseArtifactsInChat: false,
@@ -90,6 +90,8 @@ export const defaultAppSettings: AppSettings = {
     showReportPanel: false,
     showTerminalPanel: false,
     showContextualPanel: false,
+    showJourneyPanel: false,
+    showChatContextPanel: false,
   },
 };
 
@@ -174,8 +176,8 @@ function writeSettingsToStorage(nextSettings: AppSettings) {
   localStorage.setItem(
     STORAGE_KEY_APPEARANCE_RUN_ITEM_INTERACTION,
     nextSettings.appearance.runItemInteractionMode ||
-      defaultAppSettings.appearance.runItemInteractionMode ||
-      "detail-page",
+    defaultAppSettings.appearance.runItemInteractionMode ||
+    "detail-page",
   );
 
   const customFontSizePx = sanitizePositiveNumber(
@@ -463,7 +465,7 @@ function readStoredSettings(): AppSettings {
           isValidDisplayMode(parsed?.appearance?.thinkingDisplayMode)
             ? parsed!.appearance.thinkingDisplayMode
             // Migration: map old 'collapsible' to 'collapse'
-            : (parsed?.appearance as Record<string,unknown>)?.thinkingDisplayMode === 'collapsible'
+            : (parsed?.appearance as Record<string, unknown>)?.thinkingDisplayMode === 'collapsible'
               ? 'collapse'
               : defaultAppSettings.appearance.thinkingDisplayMode,
         toolDisplayMode:

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -143,6 +143,8 @@ export interface AppSettings {
     showReportPanel?: boolean;
     showTerminalPanel?: boolean;
     showContextualPanel?: boolean;
+    showJourneyPanel?: boolean;
+    showChatContextPanel?: boolean;
   };
 }
 


### PR DESCRIPTION
## Changes

### 1. Move Chat Context Panel to Developer Settings (default hidden)
- Toggle moved from **Appearance** → **Developer** in both settings page and dialog
- Default changed to `false` (panel hidden by default)
- Reading logic updated in `connected-chat-view.tsx`

### 2. Fix View All Runs Navigation Bug
- Clicking "View All Runs" from inside a detailed run now properly clears the URL hash
- This causes `runs-view.tsx` to reset `selectedRunId` via the `hashchange` listener

### 3. Add User Journey Toggle (default hidden)
- New `showJourneyPanel` toggle in **Developer** settings
- Journey tab hidden from desktop sidebar nav, mobile left panel by default
- Defaults to `false`

### 4. Chat Toolbar Tooltips
- Collapse, Export, and Alert buttons wrapped with `Tooltip` components
- Consistent hover behavior matching the rest of the app