### PR TITLE
feat(ui): polish skills library — system filter, create form, button layout

### DIFF
--- a/server/skills/manager.py
+++ b/server/skills/manager.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("research-agent-server")
 INTERNAL_SKILL_IDS = {
     "ra_mode_plan",
 }
-INTERNAL_SKILL_PREFIXES = ("ra_mode_",)
+INTERNAL_SKILL_PREFIXES = ("ra_mode_", "wild_v2_")
 
 
 def _is_internal_skill(skill_id: str) -> bool:

--- a/tests/skill_manager_test.py
+++ b/tests/skill_manager_test.py
@@ -28,6 +28,7 @@ _spec.loader.exec_module(_server_mod)
 
 PromptSkillManager = _server_mod.PromptSkillManager
 INTERNAL_SKILL_IDS = _server_mod.INTERNAL_SKILL_IDS
+INTERNAL_SKILL_PREFIXES = _server_mod.INTERNAL_SKILL_PREFIXES
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -80,6 +81,22 @@ class TestInternalFlag:
         """Smoke test that the expected internal IDs exist."""
         expected = {"ra_mode_plan"}
         assert INTERNAL_SKILL_IDS == expected
+
+    def test_wild_v2_skills_are_internal(self, manager, tmp_skills_dir):
+        """Skills with wild_v2_ prefix should be marked as internal."""
+        wild_dir = tmp_skills_dir / "wild_v2_planning"
+        wild_dir.mkdir()
+        (wild_dir / "SKILL.md").write_text(
+            "---\nname: Wild V2 Planning\ndescription: Planning skill\ncategory: prompt\n---\nTemplate body.\n"
+        )
+        manager.load_all()
+        skill = manager.get("wild_v2_planning")
+        assert skill is not None
+        assert skill["internal"] is True
+
+    def test_wild_v2_prefix_in_prefixes(self):
+        """Ensure wild_v2_ is registered as an internal prefix."""
+        assert "wild_v2_" in INTERNAL_SKILL_PREFIXES
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Polish the Prompt Skills Library page with 6 improvements based on user feedback:

### Changes

**Backend**
- Mark all `wild_v2_*` skills as system/internal via `INTERNAL_SKILL_PREFIXES`

**Frontend (`skills-browser-view.tsx`)**
1. **System skills filter** — toggle to show/hide system skills (default: hidden), keeping the list clean
2. **Right-panel creation form** — full-featured form with name, description, category selector, and initial template textarea (replaces cramped inline form)
3. **Remove Install button** — removed button and all related state/logic
4. **Button layout** — New + Refresh buttons side-by-side in header, both with tooltips
5. **Variable chips** — display-only `<span>` elements (no click-to-insert behavior)
6. **Tree node fix** — use `div[role=button]` instead of nested `<button>` to avoid hydration errors

**Tests**
- Added `test_wild_v2_skills_are_internal` and `test_wild_v2_prefix_in_prefixes` tests (25/25 pass)