### PR TITLE
ci: optimize preview deploy pipeline — image caching + comment-first flow

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -69,7 +69,71 @@ jobs:
           MODAL_PREVIEW_OPENCODE_URL: ${{ format('https://{0}--research-agent-preview-pr-{1}-preview-opencode.modal.run', github.repository_owner, github.event.pull_request.number) }}
           RESEARCH_AGENT_USER_AUTH_TOKEN: ${{ env.PREVIEW_AUTH_TOKEN }}
 
+      - name: Comment preview URL on PR
+        id: comment-preview
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_AUTH_TOKEN: ${{ env.PREVIEW_AUTH_TOKEN }}
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const sha = context.sha.slice(0, 7);
+            const appSlug = `research-agent-preview-pr-${prNumber}`;
+            const previewUrl = `https://${context.repo.owner}--${appSlug}-preview-app.modal.run`;
+            const opencodeUrl = `https://${context.repo.owner}--${appSlug}-preview-opencode.modal.run`;
+            const serverUrl = `https://${context.repo.owner}--${appSlug}-preview-server.modal.run`;
+            const previewAuthToken = process.env.PREVIEW_AUTH_TOKEN;
+            const setupPayload = Buffer.from(
+              JSON.stringify({ apiUrl: serverUrl, authToken: previewAuthToken }),
+              'utf8'
+            ).toString('base64url');
+            const setupUrl = `${previewUrl}/#setup=${setupPayload}`;
+
+            // Look for an existing preview bot comment to update
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('<!-- preview-bot -->')
+            );
+
+            const body = [
+              '<!-- preview-bot -->',
+              '## 🚀 Preview Deployed',
+              '',
+              `| | |`,
+              `|---|---|`,
+              `| **Preview (Setup)** | [${setupUrl}](${setupUrl}) |`,
+              `| **Preview (Clean)** | [Open App](${previewUrl}) |`,
+              `| **OpenCode** | [${opencodeUrl}](${opencodeUrl}) |`,
+              `| **Server** | [${serverUrl}](${serverUrl}) |`,
+              `| **Commit** | \`${sha}\` |`,
+              `| **Status** | ⏳ Verifying health… |`,
+              '',
+              '> `Open App` preloads URL + auth token into local settings for this preview.',
+              `> Updated at ${new Date().toISOString()}`,
+            ].join('\n');
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
       - name: Verify deployed preview health
+        id: health-check
         run: |
           set -euo pipefail
 
@@ -157,10 +221,12 @@ jobs:
         env:
           PREVIEW_AUTH_TOKEN: ${{ env.PREVIEW_AUTH_TOKEN }}
 
-      - name: Comment preview URL on PR
+      - name: Update comment with health status
+        if: always() && steps.comment-preview.outcome == 'success'
         uses: actions/github-script@v7
         env:
           PREVIEW_AUTH_TOKEN: ${{ env.PREVIEW_AUTH_TOKEN }}
+          HEALTH_OUTCOME: ${{ steps.health-check.outcome }}
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -176,7 +242,10 @@ jobs:
             ).toString('base64url');
             const setupUrl = `${previewUrl}/#setup=${setupPayload}`;
 
-            // Look for an existing preview bot comment to update
+            const healthy = process.env.HEALTH_OUTCOME === 'success';
+            const statusEmoji = healthy ? '✅' : '❌';
+            const statusText = healthy ? 'Deployed' : 'Health check failed';
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -197,7 +266,7 @@ jobs:
               `| **OpenCode** | [${opencodeUrl}](${opencodeUrl}) |`,
               `| **Server** | [${serverUrl}](${serverUrl}) |`,
               `| **Commit** | \`${sha}\` |`,
-              `| **Status** | ✅ Deployed |`,
+              `| **Status** | ${statusEmoji} ${statusText} |`,
               '',
               '> `Open App` preloads URL + auth token into local settings for this preview.',
               `> Updated at ${new Date().toISOString()}`,

--- a/modal_preview.py
+++ b/modal_preview.py
@@ -50,13 +50,16 @@ image = (
         "mv /root/.opencode/bin/opencode /usr/local/bin/opencode",
         "which opencode"
     )
-    # Copy the full repo into the image
-    .add_local_dir(".", "/app", copy=True, ignore=["node_modules", ".next", ".git", "out", "dist", ".ra-venv", "__pycache__"])
-    # Install frontend deps (dev mode, no static export needed)
+    # Install pnpm globally (stable layer, rarely changes)
+    .run_commands("npm install -g pnpm")
+    # Copy only lockfiles so the pnpm-install layer is cached when deps don't change
+    .add_local_file("package.json", "/app/package.json")
+    .add_local_file("pnpm-lock.yaml", "/app/pnpm-lock.yaml")
     .run_commands(
-        "npm install -g pnpm",
         "cd /app && pnpm install --frozen-lockfile || cd /app && pnpm install",
     )
+    # Copy the rest of the app code (busts cache on every commit, but node_modules stays cached)
+    .add_local_dir(".", "/app", copy=True, ignore=["node_modules", ".next", ".git", "out", "dist", ".ra-venv", "__pycache__"])
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two optimizations to the PR preview deploy pipeline (currently **1m 27s**):

### 1. Modal Image Layer Caching (`modal_preview.py`)

Restructured the image build layers so `pnpm install` is cached when only source code changes (no dependency changes):

- **Before**: `add_local_dir(repo)→ pnpm install` — every commit busts the npm cache
- **After**: `add_local_file(package.json, pnpm-lock.yaml) → pnpm install → add_local_dir(repo)`

When dependencies haven't changed, the pnpm install layer is a cache hit and Modal skips it entirely.

### 2. Comment-First Flow (`preview-deploy.yml`)

Reordered the workflow steps so the PR comment with preview URLs is posted **immediately after deploy** (before health checks):

- **Before**: Deploy → Health check (39s) → Comment
- **After**: Deploy → Comment (⏳ Verifying…) → Health check → Update comment (✅/❌)

Developers get the preview URL ~39s sooner and can click through while health checks run in the background.

### CI Timing Context (from [run #22215718991](https://github.com/hao-ai-lab/research-agent/actions/runs/22215718991/job/64258975305?pr=254))

| Step | Time | % |
|------|------|---|
| Deploy preview to Modal | 32s | 37% |
| Verify deployed preview health | 39s | 45% |
| Setup + other | 16s | 18% |