### PR TITLE
fix: clear starter draft on submit to prevent text duplication

### DIFF
--- a/components/chat-input-simple.tsx
+++ b/components/chat-input-simple.tsx
@@ -203,11 +203,7 @@ export function ChatInput({
   // ---- insert draft ----
   useEffect(() => {
     if (!insertDraft?.text) return;
-    setMessage((prev) => {
-      if (!prev) return insertDraft.text;
-      const sep = prev.endsWith(" ") ? "" : " ";
-      return `${prev}${sep}${insertDraft.text}`;
-    });
+    setMessage(insertDraft.text);
     setTimeout(() => textareaRef.current?.focus(), 0);
   }, [insertDraft?.id, insertDraft?.text]);
 

--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -558,11 +558,7 @@ export function ChatInput({
 
   useEffect(() => {
     if (!insertDraft?.text) return
-    setMessage((prev) => {
-      if (!prev) return insertDraft.text
-      const separator = prev.endsWith(' ') ? '' : ' '
-      return `${prev}${separator}${insertDraft.text}`
-    })
+    setMessage(insertDraft.text)
     setTimeout(() => {
       textareaRef.current?.focus()
       if (textareaRef.current) {

--- a/components/connected-chat-view.tsx
+++ b/components/connected-chat-view.tsx
@@ -393,6 +393,7 @@ export function ConnectedChatView({
 
     // Handle send - create session if needed, start wild loop if in wild mode
     const handleSend = useCallback(async (message: string, _attachments?: File[], msgMode?: ChatMode) => {
+        setStarterDraftInsert(null)
         let sessionId = currentSessionId
         if (!sessionId) {
             sessionId = await createNewSession()


### PR DESCRIPTION
## Problem
When clicking a starter card and submitting, the text box was not cleared and the prompt text got duplicated.

## Root Cause
Two issues:
1. The `insertDraft` effect used append logic (`setMessage(prev => prev + text)`) instead of a direct set, causing duplication if the effect re-fired
2. `starterDraftInsert` state in `connected-chat-view.tsx` was never cleared after submission, so when `handleSend` created a new session the effect re-fired

## Fix
- **`chat-input-simple.tsx` / `chat-input.tsx`**: Changed `insertDraft` effect from append to direct set (`setMessage(text)`)
- **`connected-chat-view.tsx`**: Clear `starterDraftInsert` at the start of `handleSend`

> Reimplements #227 on a fresh branch from `main` (original was too far behind).