### PR TITLE
ci: move preview comment before health check & add deploy timing

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -61,13 +61,85 @@ jobs:
 
       - name: Deploy preview to Modal
         run: |
+          DEPLOY_START=$SECONDS
           modal deploy modal_preview.py \
             --name "research-agent-preview-pr-${{ github.event.pull_request.number }}"
+          DEPLOY_ELAPSED=$(( SECONDS - DEPLOY_START ))
+          echo "DEPLOY_DURATION_SECONDS=${DEPLOY_ELAPSED}" >> "$GITHUB_ENV"
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           MODAL_PREVIEW_OPENCODE_URL: ${{ format('https://{0}--research-agent-preview-pr-{1}-preview-opencode.modal.run', github.repository_owner, github.event.pull_request.number) }}
           RESEARCH_AGENT_USER_AUTH_TOKEN: ${{ env.PREVIEW_AUTH_TOKEN }}
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_AUTH_TOKEN: ${{ env.PREVIEW_AUTH_TOKEN }}
+          DEPLOY_DURATION_SECONDS: ${{ env.DEPLOY_DURATION_SECONDS }}
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const sha = context.sha.slice(0, 7);
+            const appSlug = `research-agent-preview-pr-${prNumber}`;
+            const previewUrl = `https://${context.repo.owner}--${appSlug}-preview-app.modal.run`;
+            const opencodeUrl = `https://${context.repo.owner}--${appSlug}-preview-opencode.modal.run`;
+            const serverUrl = `https://${context.repo.owner}--${appSlug}-preview-server.modal.run`;
+            const previewAuthToken = process.env.PREVIEW_AUTH_TOKEN;
+            const setupPayload = Buffer.from(
+              JSON.stringify({ apiUrl: serverUrl, authToken: previewAuthToken }),
+              'utf8'
+            ).toString('base64url');
+            const setupUrl = `${previewUrl}/#setup=${setupPayload}`;
+
+            const elapsed = parseInt(process.env.DEPLOY_DURATION_SECONDS || '0', 10);
+            const mins = Math.floor(elapsed / 60);
+            const secs = elapsed % 60;
+            const deployTime = mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+
+            // Look for an existing preview bot comment to update
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('<!-- preview-bot -->')
+            );
+
+            const body = [
+              '<!-- preview-bot -->',
+              '## 🚀 Preview Deployed',
+              '',
+              `| | |`,
+              `|---|---|`,
+              `| **Preview (Setup)** | [${setupUrl}](${setupUrl}) |`,
+              `| **Preview (Clean)** | [Open App](${previewUrl}) |`,
+              `| **OpenCode** | [${opencodeUrl}](${opencodeUrl}) |`,
+              `| **Server** | [${serverUrl}](${serverUrl}) |`,
+              `| **Commit** | \`${sha}\` |`,
+              `| **Deploy time** | ${deployTime} |`,
+              `| **Status** | ⏳ Verifying… |`,
+              '',
+              '> `Open App` preloads URL + auth token into local settings for this preview.',
+              `> Updated at ${new Date().toISOString()}`,
+            ].join('\n');
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
 
       - name: Verify deployed preview health
         run: |
@@ -157,10 +229,12 @@ jobs:
         env:
           PREVIEW_AUTH_TOKEN: ${{ env.PREVIEW_AUTH_TOKEN }}
 
-      - name: Comment preview URL on PR
+      - name: Update preview comment (verified)
+        if: success()
         uses: actions/github-script@v7
         env:
           PREVIEW_AUTH_TOKEN: ${{ env.PREVIEW_AUTH_TOKEN }}
+          DEPLOY_DURATION_SECONDS: ${{ env.DEPLOY_DURATION_SECONDS }}
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -176,7 +250,11 @@ jobs:
             ).toString('base64url');
             const setupUrl = `${previewUrl}/#setup=${setupPayload}`;
 
-            // Look for an existing preview bot comment to update
+            const elapsed = parseInt(process.env.DEPLOY_DURATION_SECONDS || '0', 10);
+            const mins = Math.floor(elapsed / 60);
+            const secs = elapsed % 60;
+            const deployTime = mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -197,7 +275,8 @@ jobs:
               `| **OpenCode** | [${opencodeUrl}](${opencodeUrl}) |`,
               `| **Server** | [${serverUrl}](${serverUrl}) |`,
               `| **Commit** | \`${sha}\` |`,
-              `| **Status** | ✅ Deployed |`,
+              `| **Deploy time** | ${deployTime} |`,
+              `| **Status** | ✅ Deployed & Verified |`,
               '',
               '> `Open App` preloads URL + auth token into local settings for this preview.',
               `> Updated at ${new Date().toISOString()}`,


### PR DESCRIPTION
## Summary

Move the PR preview comment step **before** the health check so reviewers can access preview URLs immediately after deploy (instead of waiting 3-5 min for verification).

### Changes
- **Deploy timing**: Record `modal deploy` duration via `$SECONDS` and expose as `DEPLOY_DURATION_SECONDS` env var
- **Early comment**: Post the preview URLs comment right after deploy with `⏳ Verifying…` status and deploy time (e.g. `2m 34s`)
- **Post-verify update**: After health checks pass, update the same comment to `✅ Deployed & Verified`

### Step order (before → after)
| Before | After |
|--------|-------|
| Deploy to Modal | Deploy to Modal (+ timing) |
| Verify preview health | **Comment preview URL** (⏳ Verifying…) |
| Comment preview URL | Verify preview health |
| | **Update comment** (✅ Deployed & Verified) |