### PR TITLE
feat: chat context nav toggle & collapse chevron

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,6 +49,7 @@ const STORAGE_KEY_DESKTOP_SIDEBAR_WIDTH = 'desktopSidebarWidth'
 const STORAGE_KEY_DESKTOP_SIDEBAR_COLLAPSED = 'desktopSidebarCollapsed'
 const STORAGE_KEY_JOURNEY_SUB_TAB = 'journeySubTab'
 const DESKTOP_SIDEBAR_ICON_RAIL_TRIGGER_WIDTH = 136
+const STORAGE_KEY_CHAT_CONTEXT_PANEL_HIDDEN = 'chatContextPanelHidden'
 
 export default function ResearchChat() {
   const router = useRouter()
@@ -112,6 +113,7 @@ export default function ResearchChat() {
   const collapseChats = settings.appearance.chatCollapseAllChats === true
   const collapseArtifactsInChat = settings.appearance.chatCollapseArtifactsInChat === true
   const [chatDraftInsert, setChatDraftInsert] = useState<{ id: number; text: string } | null>(null)
+  const [chatContextPanelHidden, setChatContextPanelHidden] = useState(false)
   const [focusAuthTokenInApp, setFocusAuthTokenInApp] = useState(false)
 
   // API configuration for auth/connection check
@@ -141,6 +143,11 @@ export default function ResearchChat() {
       setJourneySubTab(storedJourneySubTab)
     }
 
+    const storedContextPanel = window.localStorage.getItem(STORAGE_KEY_CHAT_CONTEXT_PANEL_HIDDEN)
+    if (storedContextPanel != null) {
+      setChatContextPanelHidden(storedContextPanel === 'true')
+    }
+
   }, [])
 
   useEffect(() => {
@@ -154,6 +161,10 @@ export default function ResearchChat() {
   useEffect(() => {
     window.localStorage.setItem(STORAGE_KEY_JOURNEY_SUB_TAB, journeySubTab)
   }, [journeySubTab])
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY_CHAT_CONTEXT_PANEL_HIDDEN, String(chatContextPanelHidden))
+  }, [chatContextPanelHidden])
 
   useEffect(() => {
     return () => {
@@ -731,6 +742,8 @@ export default function ResearchChat() {
               ...settings,
               appearance: { ...settings.appearance, chatCollapseAllChats: collapsed },
             })}
+            contextPanelVisible={!chatContextPanelHidden && settings.developer?.showChatContextPanel === true}
+            onContextPanelToggle={() => setChatContextPanelHidden(prev => !prev)}
             reportIsPreviewMode={reportToolbar?.isPreviewMode ?? true}
             onReportPreviewModeChange={reportToolbar?.setPreviewMode}
             onReportAddCell={reportToolbar?.addCell}
@@ -759,6 +772,8 @@ export default function ResearchChat() {
                 contextTokenCount={contextTokenCount}
                 onRefreshContext={handleRefreshExperimentState}
                 scrollToRoundRef={scrollToRoundRef}
+                contextPanelHidden={chatContextPanelHidden}
+                onContextPanelHiddenChange={setChatContextPanelHidden}
               />
             )}
             {activeTab === 'runs' && (

--- a/components/floating-nav.tsx
+++ b/components/floating-nav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Menu, Bell, Download, Eye, Edit3, Plus, ChevronDown, Type, Code, BarChart3, Sparkles, PanelLeftOpen, Pause, Play, Square, Target } from 'lucide-react'
+import { Menu, Bell, Download, Eye, Edit3, Plus, ChevronDown, ChevronRight, Type, Code, BarChart3, Sparkles, PanelLeftOpen, PanelRightOpen, PanelRightClose, Pause, Play, Square, Target } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -67,6 +67,9 @@ interface FloatingNavProps {
   onExportSession?: () => void
   collapseChats?: boolean
   onCollapseChatsChange?: (collapsed: boolean) => void
+  // Chat context panel toggle
+  contextPanelVisible?: boolean
+  onContextPanelToggle?: () => void
   // Session selector props (for chat tab)
   sessionTitle?: string
   currentSessionId?: string | null
@@ -91,6 +94,8 @@ export function FloatingNav({
   onExportSession,
   collapseChats = false,
   onCollapseChatsChange,
+  contextPanelVisible = false,
+  onContextPanelToggle,
   sessionTitle = 'New Chat',
   currentSessionId,
   sessions = [],
@@ -209,11 +214,28 @@ export function FloatingNav({
                   onClick={() => onCollapseChatsChange(!collapseChats)}
                   className={`h-8 w-8 ${collapseChats ? 'bg-secondary text-secondary-foreground' : ''}`}
                 >
-                  <PanelLeftOpen className="h-4 w-4" />
+                  <ChevronRight className={`h-4 w-4 transition-transform duration-200 ${collapseChats ? 'rotate-90' : ''}`} />
                   <span className="sr-only">{collapseChats ? 'Expand all chats' : 'Collapse all chats'}</span>
                 </Button>
               </TooltipTrigger>
               <TooltipContent>{collapseChats ? 'Expand all chats' : 'Collapse all chats'}</TooltipContent>
+            </Tooltip>
+          )}
+          {/* Chat Context Panel Toggle */}
+          {onContextPanelToggle && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={onContextPanelToggle}
+                  className={`h-8 w-8 ${contextPanelVisible ? 'bg-secondary text-secondary-foreground' : ''}`}
+                >
+                  {contextPanelVisible ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
+                  <span className="sr-only">{contextPanelVisible ? 'Hide context panel' : 'Show context panel'}</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{contextPanelVisible ? 'Hide context panel' : 'Show context panel'}</TooltipContent>
             </Tooltip>
           )}
           {/* Export Button */}


### PR DESCRIPTION
## Summary

Two UI changes to the chat nav bar:

1. **Chat Context toggle on nav bar** — a `PanelRightOpen`/`PanelRightClose` button that toggles the right-side chat context panel. This replaces the floating mid-chat reopen button, so you can always toggle the panel from the nav bar even when it's closed.

2. **Collapse-all-chats chevron** — replaced the `PanelLeftOpen` icon with a `ChevronRight` (`>`) that rotates 90° downward when toggled on, making the collapse state visually obvious.

## Changes

### `floating-nav.tsx`
- Added `ChevronRight` with CSS `rotate-90` transition for collapse-chats button
- Added `PanelRightOpen`/`PanelRightClose` toggle for context panel
- New props: `contextPanelVisible`, `onContextPanelToggle`

### `connected-chat-view.tsx`
- Accept external `contextPanelHidden` + `onContextPanelHiddenChange` props (falls back to local state if not provided)
- Removed the floating mid-chat reopen button (nav bar handles it now)

### `page.tsx`
- Lifted `chatContextPanelHidden` state with localStorage persistence
- Wired it to both `FloatingNav` and `ConnectedChatView`