### PR TITLE
fix: remove chat context panel setting, default panel to hidden

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -113,7 +113,7 @@ export default function ResearchChat() {
   const collapseChats = settings.appearance.chatCollapseAllChats === true
   const collapseArtifactsInChat = settings.appearance.chatCollapseArtifactsInChat === true
   const [chatDraftInsert, setChatDraftInsert] = useState<{ id: number; text: string } | null>(null)
-  const [chatContextPanelHidden, setChatContextPanelHidden] = useState(false)
+  const [chatContextPanelHidden, setChatContextPanelHidden] = useState(true)
   const [focusAuthTokenInApp, setFocusAuthTokenInApp] = useState(false)
 
   // API configuration for auth/connection check
@@ -742,7 +742,7 @@ export default function ResearchChat() {
               ...settings,
               appearance: { ...settings.appearance, chatCollapseAllChats: collapsed },
             })}
-            contextPanelVisible={!chatContextPanelHidden && settings.developer?.showChatContextPanel === true}
+            contextPanelVisible={!chatContextPanelHidden}
             onContextPanelToggle={() => setChatContextPanelHidden(prev => !prev)}
             reportIsPreviewMode={reportToolbar?.isPreviewMode ?? true}
             onReportPreviewModeChange={reportToolbar?.setPreviewMode}

--- a/components/connected-chat-view.tsx
+++ b/components/connected-chat-view.tsx
@@ -107,7 +107,7 @@ export function ConnectedChatView({
     const isMobile = useIsMobile()
     const [showTerminationDialog, setShowTerminationDialog] = useState(false)
     const [mobilePanelTab, setMobilePanelTab] = useState<'chat' | 'context'>('chat')
-    const [localContextPanelHidden, setLocalContextPanelHidden] = useState(false)
+    const [localContextPanelHidden, setLocalContextPanelHidden] = useState(true)
     // Use parent-controlled state if provided, otherwise fall back to local state
     const contextPanelHidden = contextPanelHiddenProp ?? localContextPanelHidden
     const setContextPanelHidden = onContextPanelHiddenChange ?? setLocalContextPanelHidden
@@ -122,7 +122,7 @@ export function ConnectedChatView({
     const [isExcerptPreviewOpen, setIsExcerptPreviewOpen] = useState(false)
     const { settings, setSettings } = useAppSettings()
     const showStarterCards = settings.appearance.starterCardFlavor !== 'none'
-    const showChatContextPanel = settings.developer?.showChatContextPanel === true
+    const showChatContextPanel = true  // always available; visibility controlled by contextPanelHidden
     const starterCardFlavor = settings.appearance.starterCardFlavor || 'novice'
     const customTemplates = settings.appearance.starterCardTemplates ?? {}
     const handleEditTemplate = useCallback((cardId: string, template: string | null) => {
@@ -145,7 +145,6 @@ export function ConnectedChatView({
     // Counter to force re-render when provenance is added (ref alone won't trigger)
     // Track the previous streaming state to detect when streaming finishes
     const prevStreamingRef = useRef(false)
-    const wasChatContextPanelEnabledRef = useRef(showChatContextPanel)
 
     // Web notification hook
     const { notify } = useWebNotification(webNotificationsEnabled)
@@ -203,17 +202,7 @@ export function ConnectedChatView({
         window.localStorage.setItem(STORAGE_KEY_CHAT_CONTEXT_PANEL_HIDDEN, String(localContextPanelHidden))
     }, [localContextPanelHidden, contextPanelHiddenProp])
 
-    useEffect(() => {
-        if (showChatContextPanel && !wasChatContextPanelEnabledRef.current) {
-            setContextPanelHidden(false)
-        } else if (!showChatContextPanel) {
-            setContextPanelHidden(true)
-            if (mobilePanelTab === 'context') {
-                setMobilePanelTab('chat')
-            }
-        }
-        wasChatContextPanelEnabledRef.current = showChatContextPanel
-    }, [showChatContextPanel, mobilePanelTab])
+
 
     const getScrollViewport = useCallback((): HTMLDivElement | null => {
         if (!scrollRef.current) return null

--- a/components/settings-dialog.tsx
+++ b/components/settings-dialog.tsx
@@ -445,14 +445,6 @@ export function SettingsDialog({
           type: 'toggle' as const,
           value: settings.developer?.showJourneyPanel === true,
         },
-        {
-          id: 'showChatContextPanel',
-          label: 'Chat Context Panel',
-          description: 'Show or hide the right-side context panel in chat',
-          icon: settings.developer?.showChatContextPanel === true ? Eye : EyeOff,
-          type: 'toggle' as const,
-          value: settings.developer?.showChatContextPanel === true,
-        },
       ],
     },
     {
@@ -1039,12 +1031,6 @@ export function SettingsDialog({
                   onSettingsChange({
                     ...settings,
                     developer: { ...settings.developer, showJourneyPanel: checked },
-                  })
-                }
-                if (item.id === 'showChatContextPanel') {
-                  onSettingsChange({
-                    ...settings,
-                    developer: { ...settings.developer, showChatContextPanel: checked },
                   })
                 }
               }}

--- a/components/settings-page-content.tsx
+++ b/components/settings-page-content.tsx
@@ -500,14 +500,6 @@ export function SettingsPageContent({
           type: 'toggle' as const,
           value: settings.developer?.showJourneyPanel === true,
         },
-        {
-          id: 'showChatContextPanel',
-          label: 'Chat Context Panel',
-          description: 'Show or hide the right-side context panel in chat',
-          icon: settings.developer?.showChatContextPanel !== false ? Eye : EyeOff,
-          type: 'toggle' as const,
-          value: settings.developer?.showChatContextPanel === true,
-        },
       ],
     },
     {
@@ -1102,12 +1094,6 @@ export function SettingsPageContent({
                   onSettingsChange({
                     ...settings,
                     developer: { ...settings.developer, showJourneyPanel: checked },
-                  })
-                }
-                if (item.id === 'showChatContextPanel') {
-                  onSettingsChange({
-                    ...settings,
-                    developer: { ...settings.developer, showChatContextPanel: checked },
                   })
                 }
                 if (item.id === 'showSidebarRunsSweepsPreview') {


### PR DESCRIPTION
Closes #270

## Summary

Follow-up to #268. Removes the **Chat Context Panel** toggle from both settings UIs (dialog + page) since the nav bar button now handles visibility.

### Changes
- **`settings-dialog.tsx`** / **`settings-page-content.tsx`**: Removed the `showChatContextPanel` setting entry and its toggle handler
- **`connected-chat-view.tsx`**: Context panel is now always available (`showChatContextPanel = true`), but defaults to **hidden** (`localContextPanelHidden = true`). Removed the old sync effect that watched the setting.
- **`page.tsx`**: Default `chatContextPanelHidden` to `true`, removed the `settings.developer?.showChatContextPanel` gate from `contextPanelVisible`

Users toggle the panel via the nav bar button. Preference persists in localStorage.