### PR TITLE
Add hidden report mode for GitHub bug issues

### DIFF
--- a/components/chat-input-simple.tsx
+++ b/components/chat-input-simple.tsx
@@ -50,7 +50,7 @@ import { useAppSettings } from "@/lib/app-settings";
 import { useIsMobile } from "@/components/ui/use-mobile";
 
 // Re-export types matching the original chat-input.tsx so imports stay compatible.
-export type ChatMode = "agent" | "wild" | "sweep" | "plan";
+export type ChatMode = "agent" | "wild" | "sweep" | "plan" | "report";
 export type MentionType = ReferenceTokenType;
 
 export interface MentionItem {
@@ -170,6 +170,7 @@ export function ChatInput({
   } | null>(null);
   const [isAttachOpen, setIsAttachOpen] = useState(false);
   const [isModeOpen, setIsModeOpen] = useState(false);
+  const [isAdvancedModesOpen, setIsAdvancedModesOpen] = useState(false);
   const [isModelOpen, setIsModelOpen] = useState(false);
   const [isQueueExpanded, setIsQueueExpanded] = useState(true);
   const [isRecording, setIsRecording] = useState(false);
@@ -804,6 +805,10 @@ export function ChatInput({
   // Mention type color map for filter pills
   // =========================================================================
   const mentionTypeColorMap = REFERENCE_TYPE_COLOR_MAP;
+  const inputPlaceholder =
+    mode === "report"
+      ? "Describe the bug you hit. I will open a Bug issue on GitHub."
+      : "Ask me about your research";
 
   // =========================================================================
   // Render
@@ -1075,7 +1080,7 @@ export function ChatInput({
               highlightedMessage
             ) : (
               <span className="text-muted-foreground">
-                Ask me about your research
+                {inputPlaceholder}
               </span>
             )}
           </div>
@@ -1089,7 +1094,7 @@ export function ChatInput({
               if (highlightRef.current)
                 highlightRef.current.scrollTop = e.currentTarget.scrollTop;
             }}
-            placeholder="Ask me about your research"
+            placeholder={inputPlaceholder}
             disabled={disabled}
             rows={1}
             className="relative z-10 w-full resize-none bg-transparent px-4 py-3 text-base leading-6 text-transparent caret-foreground placeholder:text-transparent focus:outline-none disabled:opacity-50"
@@ -1152,7 +1157,13 @@ export function ChatInput({
           </Button>
 
           {/* Mode toggle */}
-          <Popover open={isModeOpen} onOpenChange={setIsModeOpen}>
+          <Popover
+            open={isModeOpen}
+            onOpenChange={(open) => {
+              setIsModeOpen(open);
+              if (!open) setIsAdvancedModesOpen(false);
+            }}
+          >
             <PopoverTrigger asChild>
               <button
                 type="button"
@@ -1161,6 +1172,8 @@ export function ChatInput({
                     ? "border border-border/60 bg-secondary text-foreground shadow-sm hover:bg-secondary/80"
                     : mode === "wild"
                       ? "border border-violet-500/35 bg-violet-500/15 text-violet-700 dark:border-violet-400/50 dark:bg-violet-500/24 dark:text-violet-300"
+                      : mode === "report"
+                        ? "border border-red-500/35 bg-red-500/14 text-red-700 dark:border-red-400/50 dark:bg-red-500/24 dark:text-red-300"
                       : mode === "plan"
                         ? "border border-orange-500/35 bg-orange-500/15 text-orange-700 dark:border-orange-400/50 dark:bg-orange-500/24 dark:text-orange-300"
                         : "border border-blue-500/35 bg-blue-500/14 text-blue-700 dark:border-blue-400/50 dark:bg-blue-500/24 dark:text-blue-300"
@@ -1170,10 +1183,18 @@ export function ChatInput({
                   <MessageSquare className="h-3 w-3" />
                 ) : mode === "wild" ? (
                   <Zap className="h-3 w-3" />
+                ) : mode === "report" ? (
+                  <AlertTriangle className="h-3 w-3" />
                 ) : (
                   <ClipboardList className="h-3 w-3" />
                 )}
-                {mode === "wild" ? "Wild" : mode === "plan" ? "Plan" : "Agent"}
+                {mode === "wild"
+                  ? "Wild"
+                  : mode === "plan"
+                    ? "Plan"
+                    : mode === "report"
+                      ? "Report"
+                      : "Agent"}
               </button>
             </PopoverTrigger>
             <PopoverContent side="top" align="start" className="w-56 p-1.5">
@@ -1238,6 +1259,40 @@ export function ChatInput({
                     </p>
                   </div>
                 </button>
+                <div className="mt-1 border-t border-border/60 pt-1">
+                  <button
+                    type="button"
+                    onClick={() => setIsAdvancedModesOpen((prev) => !prev)}
+                    className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-left text-[11px] font-medium text-muted-foreground transition-colors hover:bg-secondary"
+                  >
+                    <span>Advanced</span>
+                    <ChevronDown
+                      className={`h-3.5 w-3.5 transition-transform ${isAdvancedModesOpen ? "rotate-180" : ""}`}
+                    />
+                  </button>
+                  {isAdvancedModesOpen && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onModeChange("report");
+                        setIsModeOpen(false);
+                      }}
+                      className={`mt-1 flex items-start gap-2 rounded-md px-2 py-2 text-left transition-colors ${mode === "report" ? "bg-red-500/10 border border-red-500/35 dark:bg-red-500/18 dark:border-red-400/45" : "hover:bg-secondary"}`}
+                    >
+                      <AlertTriangle
+                        className={`h-4 w-4 mt-0.5 shrink-0 ${mode === "report" ? "text-red-600 dark:text-red-300" : "text-muted-foreground"}`}
+                      />
+                      <div>
+                        <p className="text-xs font-medium text-foreground">
+                          Report Mode
+                        </p>
+                        <p className="text-[10px] text-muted-foreground">
+                          Create a GitHub bug issue from your message
+                        </p>
+                      </div>
+                    </button>
+                  )}
+                </div>
               </div>
             </PopoverContent>
           </Popover>

--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -52,7 +52,7 @@ import {
 import { useAppSettings } from '@/lib/app-settings'
 import { useIsMobile } from '@/components/ui/use-mobile'
 
-export type ChatMode = 'agent' | 'wild' | 'sweep' | 'plan'
+export type ChatMode = 'agent' | 'wild' | 'sweep' | 'plan' | 'report'
 
 export type MentionType = ReferenceTokenType
 

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -59,6 +59,8 @@ export type {
     JourneyRecommendationRespondRequest,
     JourneyDecisionCreateRequest,
     JourneyGenerateRecommendationsResponse,
+    ReportBugIssueRequest,
+    ReportBugIssueResponse,
 } from './api'
 
 // Dynamic API selection based on runtime config
@@ -231,3 +233,6 @@ export const listJourneyDecisions = (...args: Parameters<typeof realApi.listJour
 
 export const createJourneyDecision = (...args: Parameters<typeof realApi.createJourneyDecision>) =>
     getApi().createJourneyDecision(...args)
+
+export const reportBugIssue = (...args: Parameters<typeof realApi.reportBugIssue>) =>
+    getApi().reportBugIssue(...args)

--- a/lib/api-mock.ts
+++ b/lib/api-mock.ts
@@ -38,6 +38,8 @@ import type {
     JourneyRecommendationRespondRequest,
     JourneyDecisionCreateRequest,
     JourneyGenerateRecommendationsResponse,
+    ReportBugIssueRequest,
+    ReportBugIssueResponse,
     RepoDiffFileStatus,
     RepoDiffLine,
     RepoDiffFile,
@@ -1776,4 +1778,18 @@ export async function createJourneyDecision(
         note: created.title,
     })
     return created
+}
+
+export async function reportBugIssue(
+    request: ReportBugIssueRequest
+): Promise<ReportBugIssueResponse> {
+    await delay(120)
+    const title = request.title?.trim() || `Bug: ${request.description.slice(0, 64).trim()}`
+    return {
+        ok: true,
+        repo: 'mock/research-agent',
+        issue_url: 'https://github.com/mock/research-agent/issues/1',
+        issue_title: title,
+        label: 'Bug',
+    }
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1980,6 +1980,20 @@ export interface JourneyGenerateRecommendationsResponse {
     source?: string
 }
 
+export interface ReportBugIssueRequest {
+    description: string
+    session_id?: string
+    title?: string
+}
+
+export interface ReportBugIssueResponse {
+    ok: boolean
+    repo: string
+    issue_url: string
+    issue_title: string
+    label: string
+}
+
 export async function getJourneyNextActions(
     request: JourneyNextActionsRequest
 ): Promise<JourneyNextActionsResponse> {
@@ -2119,6 +2133,21 @@ export async function createJourneyDecision(
     })
     if (!response.ok) {
         throw new Error(`Failed to create journey decision: ${response.statusText}`)
+    }
+    return response.json()
+}
+
+export async function reportBugIssue(
+    request: ReportBugIssueRequest
+): Promise<ReportBugIssueResponse> {
+    const response = await trackedFetch(`${API_URL()}/integrations/github/report-bug`, {
+        method: 'POST',
+        headers: getHeaders(true),
+        body: JSON.stringify(request),
+    })
+    if (!response.ok) {
+        const message = await response.text()
+        throw new Error(message || `Failed to report bug issue: ${response.statusText}`)
     }
     return response.json()
 }

--- a/server/build-backend-binary.sh
+++ b/server/build-backend-binary.sh
@@ -78,6 +78,7 @@ log "Building one-file backend binary"
   --hidden-import integrations.slack_handler \
   --hidden-import integrations.slack_routes \
   --hidden-import integrations.git_routes \
+  --hidden-import integrations.github_routes \
   --hidden-import integrations.journey_routes \
   --hidden-import integrations.cluster_routes \
   --hidden-import integrations.plan_routes \

--- a/server/integrations/github_routes.py
+++ b/server/integrations/github_routes.py
@@ -1,0 +1,184 @@
+"""
+Research Agent Server — GitHub Integration Endpoints
+
+Creates bug issues in the repository's GitHub Issues via gh CLI.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+import time
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from core import config
+from core.state import chat_sessions, save_chat_state
+
+logger = logging.getLogger("research-agent-server")
+router = APIRouter()
+
+_ISSUE_URL_RE = re.compile(r"https://github\.com/[^\s/]+/[^\s/]+/issues/\d+")
+_REPO_RE = re.compile(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$")
+
+
+class GithubBugReportRequest(BaseModel):
+    description: str = Field(min_length=3, max_length=12000)
+    session_id: Optional[str] = None
+    title: Optional[str] = None
+
+
+def _run_cmd(args: list[str], timeout_seconds: int = 30) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=config.WORKDIR,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+
+
+def _resolve_repo() -> str:
+    configured = os.environ.get("RESEARCH_AGENT_GITHUB_REPO", "").strip()
+    if configured:
+        return configured
+
+    result = _run_cmd(["git", "remote", "get-url", "origin"], timeout_seconds=8)
+    if result.returncode != 0:
+        raise RuntimeError("Unable to resolve GitHub repository from git remote origin")
+
+    remote_url = result.stdout.strip()
+    match = _REPO_RE.search(remote_url)
+    if not match:
+        raise RuntimeError("Origin remote is not a GitHub repository URL")
+    return f"{match.group('owner')}/{match.group('repo')}"
+
+
+def _build_issue_title(req: GithubBugReportRequest) -> str:
+    raw = (req.title or req.description.splitlines()[0]).strip()
+    collapsed = re.sub(r"\s+", " ", raw).strip()
+    if not collapsed.lower().startswith("bug:"):
+        collapsed = f"Bug: {collapsed}"
+    return collapsed[:120]
+
+
+def _build_issue_body(req: GithubBugReportRequest) -> str:
+    reported_at = time.strftime("%Y-%m-%d %H:%M:%SZ", time.gmtime())
+    session_line = req.session_id if req.session_id else "n/a"
+    return (
+        "## Bug report\n\n"
+        f"{req.description.strip()}\n\n"
+        "## Metadata\n\n"
+        "- Reported via Research Agent chat\n"
+        f"- Session: `{session_line}`\n"
+        f"- Workdir: `{config.WORKDIR}`\n"
+        f"- Reported at (UTC): `{reported_at}`\n"
+    )
+
+
+def _extract_issue_url(output: str) -> Optional[str]:
+    match = _ISSUE_URL_RE.search(output or "")
+    if not match:
+        return None
+    return match.group(0)
+
+
+def _ensure_bug_label(repo: str) -> None:
+    _run_cmd(
+        [
+            "gh",
+            "label",
+            "create",
+            "Bug",
+            "--repo",
+            repo,
+            "--color",
+            "d73a4a",
+            "--description",
+            "Something is not working",
+        ],
+        timeout_seconds=10,
+    )
+
+
+def _create_bug_issue(repo: str, title: str, body: str) -> str:
+    _ensure_bug_label(repo)
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        title,
+        "--body",
+        body,
+        "--label",
+        "Bug",
+    ]
+    result = _run_cmd(cmd, timeout_seconds=45)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "Issue creation failed").strip()
+        raise RuntimeError(detail)
+
+    issue_url = _extract_issue_url(result.stdout) or _extract_issue_url(result.stderr)
+    if not issue_url:
+        raise RuntimeError("Issue was created but URL was not returned by gh")
+    return issue_url
+
+
+def _append_report_messages(session_id: Optional[str], user_text: str, issue_url: str) -> None:
+    if not session_id:
+        return
+    session = chat_sessions.get(session_id)
+    if not isinstance(session, dict):
+        return
+
+    now = time.time()
+    messages = session.setdefault("messages", [])
+    if not isinstance(messages, list):
+        return
+
+    messages.append({"role": "user", "content": user_text, "timestamp": now})
+    messages.append({
+        "role": "assistant",
+        "content": f"Created Bug issue: {issue_url}",
+        "timestamp": time.time(),
+    })
+    if session.get("title") == "New Chat" and len(messages) == 2:
+        preview = user_text[:50]
+        session["title"] = preview + ("..." if len(user_text) > 50 else "")
+    save_chat_state()
+
+
+@router.post("/integrations/github/report-bug")
+async def report_bug(req: GithubBugReportRequest):
+    """Create a GitHub issue labeled Bug in the current repo."""
+    try:
+        repo = _resolve_repo()
+        issue_title = _build_issue_title(req)
+        issue_body = _build_issue_body(req)
+        issue_url = _create_bug_issue(repo, issue_title, issue_body)
+        _append_report_messages(req.session_id, req.description, issue_url)
+        return {
+            "ok": True,
+            "repo": repo,
+            "issue_url": issue_url,
+            "issue_title": issue_title,
+            "label": "Bug",
+        }
+    except RuntimeError as exc:
+        logger.error("GitHub bug report failed: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc))
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=500,
+            detail="GitHub CLI not found. Install gh and authenticate with `gh auth login`.",
+        )
+    except Exception as exc:
+        logger.exception("Unexpected GitHub bug report error")
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {exc}")

--- a/server/server.py
+++ b/server/server.py
@@ -647,6 +647,9 @@ app.include_router(journey_routes.router)
 import integrations.git_routes as git_routes  # noqa: E402
 app.include_router(git_routes.router)
 
+import integrations.github_routes as github_routes  # noqa: E402
+app.include_router(github_routes.router)
+
 
 
 


### PR DESCRIPTION
Summary
- expose a hidden "Report" chat mode under the advanced mode picker so messages can trigger bug reports
- add bug-reporting API client/mocks and wire server route that uses GitHub CLI to create labeled issues
- update backend binary build to include the new GitHub integration

Testing
- Not run (not requested)