### PR TITLE
Add context compaction button

### DIFF
--- a/components/connected-chat-view.tsx
+++ b/components/connected-chat-view.tsx
@@ -169,6 +169,8 @@ export function ConnectedChatView({
         createNewSession,
         selectSession,
         stopStreaming,
+        compactContext,
+        isCompactingContext,
         queueMessage,
         messageQueue,
         removeFromQueue,
@@ -623,6 +625,8 @@ export function ConnectedChatView({
                 selectedModel={selectedModel}
                 isModelUpdating={isModelUpdating}
                 onModelChange={setSelectedModel}
+                onCompactContext={compactContext}
+                isCompactingContext={isCompactingContext}
             />
         </>
     )


### PR DESCRIPTION
Summary
- introduce a context compaction action in the chat input, including button state, recommendations, and loaders
- wire the connected chat view to pass compaction props from the session hook
- implement compaction transcript trimming, prompt construction, and session creation logic in `useChatSession`

Testing
- Not run (not requested)