### PR TITLE
Add e2e playbook framework for agent performance evaluation

### DIFF
--- a/tests/e2e_playbook/__init__.py
+++ b/tests/e2e_playbook/__init__.py
@@ -1,0 +1,5 @@
+"""Playbook-driven E2E chat evaluation framework."""
+
+from .runner import run_playbook_file, run_playbook_suite
+
+__all__ = ["run_playbook_file", "run_playbook_suite"]

--- a/tests/e2e_playbook/assertions.py
+++ b/tests/e2e_playbook/assertions.py
@@ -1,0 +1,237 @@
+"""Assertion evaluation for playbook steps."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+def evaluate_assertion(assertion: dict[str, Any], step_result: dict[str, Any]) -> dict[str, Any]:
+    assertion_id = assertion["id"]
+    assertion_type = assertion["type"]
+    expected = assertion.get("expected")
+
+    evaluator = ASSERTION_EVALUATORS.get(assertion_type)
+    if evaluator is None:
+        return {
+            "id": assertion_id,
+            "type": assertion_type,
+            "passed": False,
+            "error": f"Unsupported assertion type `{assertion_type}`",
+            "expected": expected,
+            "actual": None,
+        }
+
+    passed, actual, error = evaluator(assertion, step_result)
+    return {
+        "id": assertion_id,
+        "type": assertion_type,
+        "passed": passed,
+        "expected": expected,
+        "actual": actual,
+        "error": error,
+        "message": assertion.get("message"),
+    }
+
+
+def _assistant_text(step_result: dict[str, Any]) -> str:
+    value = step_result.get("assistant_text", "")
+    return value if isinstance(value, str) else ""
+
+
+def _tool_names(step_result: dict[str, Any]) -> list[str]:
+    value = step_result.get("tool_names", [])
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return []
+
+
+def _events(step_result: dict[str, Any]) -> list[dict[str, Any]]:
+    value = step_result.get("events", [])
+    if isinstance(value, list):
+        return [event for event in value if isinstance(event, dict)]
+    return []
+
+
+def _parse_json_from_response(text: str) -> tuple[dict[str, Any] | None, str | None]:
+    stripped = text.strip()
+    if not stripped:
+        return None, "Assistant response is empty"
+
+    for candidate in _json_candidates(stripped):
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed, None
+
+    return None, "Unable to parse a JSON object from assistant response"
+
+
+def _json_candidates(text: str) -> list[str]:
+    candidates = [text]
+
+    fenced_match = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", text, flags=re.IGNORECASE)
+    if fenced_match:
+        candidates.append(fenced_match.group(1))
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        candidates.append(text[start : end + 1])
+
+    return candidates
+
+
+def _json_get_field(data: dict[str, Any], path: str) -> Any:
+    current: Any = data
+    for segment in path.split("."):
+        if not isinstance(current, dict) or segment not in current:
+            return None
+        current = current[segment]
+    return current
+
+
+def _assert_assistant_contains(assertion: dict[str, Any], step_result: dict[str, Any]) -> tuple[bool, Any, str | None]:
+    expected = str(assertion.get("expected", ""))
+    text = _assistant_text(step_result)
+    return expected in text, text, None
+
+
+def _assert_assistant_not_contains(
+    assertion: dict[str, Any],
+    step_result: dict[str, Any],
+) -> tuple[bool, Any, str | None]:
+    expected = str(assertion.get("expected", ""))
+    text = _assistant_text(step_result)
+    return expected not in text, text, None
+
+
+def _assert_assistant_regex(assertion: dict[str, Any], step_result: dict[str, Any]) -> tuple[bool, Any, str | None]:
+    pattern = assertion.get("pattern")
+    if not isinstance(pattern, str) or not pattern:
+        return False, None, "Missing required `pattern`"
+
+    flags = 0
+    for flag in str(assertion.get("flags", "")):
+        if flag == "i":
+            flags |= re.IGNORECASE
+        elif flag == "m":
+            flags |= re.MULTILINE
+        elif flag == "s":
+            flags |= re.DOTALL
+
+    text = _assistant_text(step_result)
+    matched = re.search(pattern, text, flags=flags) is not None
+    should_match = bool(assertion.get("should_match", True))
+    return matched is should_match, text, None
+
+
+def _assert_response_is_json(assertion: dict[str, Any], step_result: dict[str, Any]) -> tuple[bool, Any, str | None]:
+    parsed, error = _parse_json_from_response(_assistant_text(step_result))
+    if parsed is None:
+        return False, None, error
+
+    required_fields = assertion.get("required_fields", [])
+    if isinstance(required_fields, list):
+        for field in required_fields:
+            if _json_get_field(parsed, str(field)) is None:
+                return False, parsed, f"Missing required field `{field}`"
+
+    return True, parsed, None
+
+
+def _assert_response_json_field_equals(
+    assertion: dict[str, Any],
+    step_result: dict[str, Any],
+) -> tuple[bool, Any, str | None]:
+    field = assertion.get("field")
+    if not isinstance(field, str) or not field:
+        return False, None, "Missing required `field`"
+
+    parsed, error = _parse_json_from_response(_assistant_text(step_result))
+    if parsed is None:
+        return False, None, error
+
+    actual_value = _json_get_field(parsed, field)
+    return actual_value == assertion.get("expected"), actual_value, None
+
+
+def _assert_tool_name_contains(assertion: dict[str, Any], step_result: dict[str, Any]) -> tuple[bool, Any, str | None]:
+    expected = str(assertion.get("expected", ""))
+    tools = _tool_names(step_result)
+    return any(expected in tool for tool in tools), tools, None
+
+
+def _assert_tool_name_not_contains(
+    assertion: dict[str, Any],
+    step_result: dict[str, Any],
+) -> tuple[bool, Any, str | None]:
+    expected = str(assertion.get("expected", ""))
+    tools = _tool_names(step_result)
+    return all(expected not in tool for tool in tools), tools, None
+
+
+def _assert_first_token_latency(
+    assertion: dict[str, Any],
+    step_result: dict[str, Any],
+) -> tuple[bool, Any, str | None]:
+    max_ms = assertion.get("expected")
+    if not isinstance(max_ms, (int, float)):
+        return False, None, "`expected` must be numeric milliseconds"
+
+    latency_ms = step_result.get("first_token_latency_ms")
+    if not isinstance(latency_ms, (int, float)):
+        return False, latency_ms, "No first token latency recorded"
+
+    return latency_ms < float(max_ms), latency_ms, None
+
+
+def _assert_total_latency(assertion: dict[str, Any], step_result: dict[str, Any]) -> tuple[bool, Any, str | None]:
+    max_ms = assertion.get("expected")
+    if not isinstance(max_ms, (int, float)):
+        return False, None, "`expected` must be numeric milliseconds"
+
+    latency_ms = step_result.get("total_latency_ms")
+    if not isinstance(latency_ms, (int, float)):
+        return False, latency_ms, "No total latency recorded"
+
+    return latency_ms < float(max_ms), latency_ms, None
+
+
+def _assert_event_type_seen(assertion: dict[str, Any], step_result: dict[str, Any]) -> tuple[bool, Any, str | None]:
+    expected = str(assertion.get("expected", "")).strip()
+    if not expected:
+        return False, None, "Missing required `expected` event type"
+    events = _events(step_result)
+    seen = any(event.get("type") == expected for event in events)
+    return seen, [event.get("type") for event in events], None
+
+
+def _assert_event_type_not_seen(
+    assertion: dict[str, Any],
+    step_result: dict[str, Any],
+) -> tuple[bool, Any, str | None]:
+    expected = str(assertion.get("expected", "")).strip()
+    if not expected:
+        return False, None, "Missing required `expected` event type"
+    events = _events(step_result)
+    seen = any(event.get("type") == expected for event in events)
+    return not seen, [event.get("type") for event in events], None
+
+
+ASSERTION_EVALUATORS = {
+    "assistant_contains": _assert_assistant_contains,
+    "assistant_not_contains": _assert_assistant_not_contains,
+    "assistant_regex": _assert_assistant_regex,
+    "response_is_json": _assert_response_is_json,
+    "response_json_field_equals": _assert_response_json_field_equals,
+    "tool_name_contains": _assert_tool_name_contains,
+    "tool_name_not_contains": _assert_tool_name_not_contains,
+    "first_token_latency_lt_ms": _assert_first_token_latency,
+    "total_latency_lt_ms": _assert_total_latency,
+    "event_type_seen": _assert_event_type_seen,
+    "event_type_not_seen": _assert_event_type_not_seen,
+}

--- a/tests/e2e_playbook/client.py
+++ b/tests/e2e_playbook/client.py
@@ -1,0 +1,211 @@
+"""HTTP client for playbook-driven chat streaming tests."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import requests
+
+
+@dataclass
+class TurnStreamResult:
+    assistant_text: str
+    events: list[dict[str, Any]]
+    first_token_latency_ms: Optional[float]
+    total_latency_ms: float
+    stream_reconnects: int
+    tool_names: list[str]
+
+
+class ChatTestClient:
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        auth_token: str = "",
+        connect_timeout_s: float = 8.0,
+        read_timeout_s: float = 240.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.headers: dict[str, str] = {"Content-Type": "application/json"}
+        if auth_token:
+            self.headers["X-Auth-Token"] = auth_token
+        self.connect_timeout_s = connect_timeout_s
+        self.read_timeout_s = read_timeout_s
+
+    def healthcheck(self) -> None:
+        response = requests.get(
+            f"{self.base_url}/health",
+            headers=self.headers,
+            timeout=(self.connect_timeout_s, self.read_timeout_s),
+        )
+        response.raise_for_status()
+
+    def create_session(
+        self,
+        *,
+        title: str,
+        model_provider: str | None = None,
+        model_id: str | None = None,
+    ) -> str:
+        payload: dict[str, Any] = {"title": title}
+        if model_provider:
+            payload["model_provider"] = model_provider
+        if model_id:
+            payload["model_id"] = model_id
+        response = requests.post(
+            f"{self.base_url}/sessions",
+            headers=self.headers,
+            json=payload,
+            timeout=(self.connect_timeout_s, self.read_timeout_s),
+        )
+        response.raise_for_status()
+        session_id = response.json().get("id")
+        if not session_id:
+            raise RuntimeError("Session creation succeeded but no session id was returned")
+        return str(session_id)
+
+    def set_system_prompt(self, session_id: str, system_prompt: str) -> None:
+        response = requests.put(
+            f"{self.base_url}/sessions/{session_id}/system-prompt",
+            headers=self.headers,
+            json={"system_prompt": system_prompt},
+            timeout=(self.connect_timeout_s, self.read_timeout_s),
+        )
+        response.raise_for_status()
+
+    def send_turn(
+        self,
+        *,
+        session_id: str,
+        message: str,
+        mode: str = "agent",
+        prompt_override: str | None = None,
+        max_stream_retries: int = 2,
+    ) -> TurnStreamResult:
+        payload: dict[str, Any] = {
+            "session_id": session_id,
+            "message": message,
+            "mode": mode,
+        }
+        if prompt_override:
+            payload["prompt_override"] = prompt_override
+
+        started_at = time.perf_counter()
+        first_token_latency_ms: Optional[float] = None
+        assistant_chunks: list[str] = []
+        events: list[dict[str, Any]] = []
+        tool_names: list[str] = []
+        max_seq_seen = 0
+        reconnects = 0
+        done = False
+
+        done, max_seq_seen, first_token_latency_ms = self._consume_stream(
+            method="POST",
+            path="/chat",
+            stream_kwargs={"json": payload},
+            events=events,
+            assistant_chunks=assistant_chunks,
+            tool_names=tool_names,
+            max_seq_seen=max_seq_seen,
+            first_token_latency_ms=first_token_latency_ms,
+            started_at=started_at,
+            suppress_request_errors=False,
+        )
+
+        while not done and reconnects < max_stream_retries:
+            reconnects += 1
+            done, max_seq_seen, first_token_latency_ms = self._consume_stream(
+                method="GET",
+                path=f"/sessions/{session_id}/stream",
+                stream_kwargs={"params": {"from_seq": max_seq_seen + 1}},
+                events=events,
+                assistant_chunks=assistant_chunks,
+                tool_names=tool_names,
+                max_seq_seen=max_seq_seen,
+                first_token_latency_ms=first_token_latency_ms,
+                started_at=started_at,
+                suppress_request_errors=True,
+            )
+
+        if not done:
+            raise RuntimeError(
+                f"Stream for session `{session_id}` did not complete after {max_stream_retries} reconnects"
+            )
+
+        total_latency_ms = (time.perf_counter() - started_at) * 1000.0
+        return TurnStreamResult(
+            assistant_text="".join(assistant_chunks).strip(),
+            events=events,
+            first_token_latency_ms=first_token_latency_ms,
+            total_latency_ms=total_latency_ms,
+            stream_reconnects=reconnects,
+            tool_names=tool_names,
+        )
+
+    def _consume_stream(
+        self,
+        *,
+        method: str,
+        path: str,
+        stream_kwargs: dict[str, Any],
+        events: list[dict[str, Any]],
+        assistant_chunks: list[str],
+        tool_names: list[str],
+        max_seq_seen: int,
+        first_token_latency_ms: Optional[float],
+        started_at: float,
+        suppress_request_errors: bool,
+    ) -> tuple[bool, int, Optional[float]]:
+        done = False
+
+        try:
+            with requests.request(
+                method,
+                f"{self.base_url}{path}",
+                headers=self.headers,
+                timeout=(self.connect_timeout_s, self.read_timeout_s),
+                stream=True,
+                **stream_kwargs,
+            ) as response:
+                response.raise_for_status()
+
+                for raw_line in response.iter_lines(decode_unicode=True):
+                    if not raw_line:
+                        continue
+                    try:
+                        event = json.loads(raw_line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    events.append(event)
+
+                    seq_value = event.get("seq")
+                    if isinstance(seq_value, int):
+                        max_seq_seen = max(max_seq_seen, seq_value)
+
+                    event_type = event.get("type")
+                    if event_type == "part_delta" and event.get("ptype") == "text":
+                        delta = event.get("delta")
+                        if isinstance(delta, str):
+                            if first_token_latency_ms is None:
+                                first_token_latency_ms = (time.perf_counter() - started_at) * 1000.0
+                            assistant_chunks.append(delta)
+
+                    if event.get("ptype") == "tool":
+                        tool_name = event.get("name")
+                        if isinstance(tool_name, str) and tool_name.strip():
+                            tool_names.append(tool_name.strip())
+
+                    if event_type == "session_status" and event.get("status") == "idle":
+                        done = True
+                        break
+        except requests.exceptions.RequestException:
+            if not suppress_request_errors:
+                raise
+            done = False
+
+        return done, max_seq_seen, first_token_latency_ms

--- a/tests/e2e_playbook/playbook.py
+++ b/tests/e2e_playbook/playbook.py
@@ -1,0 +1,109 @@
+"""Playbook loading and validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_ASSERTION_TYPES = {
+    "assistant_contains",
+    "assistant_not_contains",
+    "assistant_regex",
+    "response_is_json",
+    "response_json_field_equals",
+    "tool_name_contains",
+    "tool_name_not_contains",
+    "first_token_latency_lt_ms",
+    "total_latency_lt_ms",
+    "event_type_seen",
+    "event_type_not_seen",
+}
+
+
+def load_playbook(path: str | Path) -> dict[str, Any]:
+    playbook_path = Path(path).expanduser().resolve()
+    with playbook_path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    validate_playbook(data, source=str(playbook_path))
+    return data
+
+
+def validate_playbook(data: dict[str, Any], *, source: str = "<memory>") -> None:
+    if not isinstance(data, dict):
+        raise ValueError(f"{source}: playbook root must be an object")
+
+    if not isinstance(data.get("name"), str) or not data["name"].strip():
+        raise ValueError(f"{source}: playbook must include non-empty string `name`")
+
+    steps = data.get("steps")
+    if not isinstance(steps, list) or not steps:
+        raise ValueError(f"{source}: playbook must include non-empty list `steps`")
+
+    assertion_ids: set[str] = set()
+    for step_index, step in enumerate(steps):
+        _validate_step(step, step_index=step_index, source=source, assertion_ids=assertion_ids)
+
+    evaluation_points = data.get("evaluation_points", [])
+    if evaluation_points is None:
+        evaluation_points = []
+    if not isinstance(evaluation_points, list):
+        raise ValueError(f"{source}: `evaluation_points` must be a list if provided")
+
+    for point in evaluation_points:
+        if not isinstance(point, dict):
+            raise ValueError(f"{source}: each evaluation point must be an object")
+        point_id = point.get("id")
+        if not isinstance(point_id, str) or not point_id.strip():
+            raise ValueError(f"{source}: evaluation point missing non-empty `id`")
+        assertion_refs = point.get("assertion_ids")
+        if not isinstance(assertion_refs, list) or not assertion_refs:
+            raise ValueError(f"{source}: evaluation point `{point_id}` needs non-empty `assertion_ids`")
+        for assertion_id in assertion_refs:
+            if assertion_id not in assertion_ids:
+                raise ValueError(
+                    f"{source}: evaluation point `{point_id}` references unknown assertion `{assertion_id}`"
+                )
+
+
+def _validate_step(
+    step: dict[str, Any],
+    *,
+    step_index: int,
+    source: str,
+    assertion_ids: set[str],
+) -> None:
+    if not isinstance(step, dict):
+        raise ValueError(f"{source}: step index {step_index} must be an object")
+
+    step_id = step.get("id")
+    if not isinstance(step_id, str) or not step_id.strip():
+        raise ValueError(f"{source}: step index {step_index} missing non-empty `id`")
+
+    message = step.get("message")
+    if not isinstance(message, str) or not message.strip():
+        raise ValueError(f"{source}: step `{step_id}` missing non-empty `message`")
+
+    assertions = step.get("assertions")
+    if not isinstance(assertions, list) or not assertions:
+        raise ValueError(f"{source}: step `{step_id}` must include non-empty list `assertions`")
+
+    for assertion in assertions:
+        if not isinstance(assertion, dict):
+            raise ValueError(f"{source}: step `{step_id}` has non-object assertion")
+        assertion_id = assertion.get("id")
+        if not isinstance(assertion_id, str) or not assertion_id.strip():
+            raise ValueError(f"{source}: step `{step_id}` has assertion missing non-empty `id`")
+        if assertion_id in assertion_ids:
+            raise ValueError(f"{source}: duplicate assertion id `{assertion_id}`")
+        assertion_ids.add(assertion_id)
+
+        assertion_type = assertion.get("type")
+        if assertion_type not in SUPPORTED_ASSERTION_TYPES:
+            supported = ", ".join(sorted(SUPPORTED_ASSERTION_TYPES))
+            raise ValueError(
+                f"{source}: step `{step_id}` assertion `{assertion_id}` has unsupported type "
+                f"`{assertion_type}` (supported: {supported})"
+            )
+

--- a/tests/e2e_playbook/runner.py
+++ b/tests/e2e_playbook/runner.py
@@ -1,0 +1,208 @@
+"""Core orchestration for playbook-driven E2E chat tests."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .assertions import evaluate_assertion
+from .client import ChatTestClient
+from .playbook import load_playbook
+
+
+def run_playbook_file(
+    playbook_path: str | Path,
+    *,
+    server_url_override: str | None = None,
+    auth_token: str = "",
+) -> dict[str, Any]:
+    playbook = load_playbook(playbook_path)
+    server_cfg = playbook.get("server", {})
+    defaults_cfg = playbook.get("defaults", {})
+    session_cfg = playbook.get("session", {})
+
+    base_url = (
+        server_url_override
+        or server_cfg.get("base_url")
+        or "http://127.0.0.1:10000"
+    )
+
+    client = ChatTestClient(base_url=base_url, auth_token=auth_token)
+    client.healthcheck()
+
+    started_at = time.time()
+    session_title = str(session_cfg.get("title") or f"playbook:{playbook['name']}")
+    session_id = client.create_session(
+        title=session_title,
+        model_provider=session_cfg.get("model_provider"),
+        model_id=session_cfg.get("model_id"),
+    )
+
+    system_prompt = session_cfg.get("system_prompt")
+    if isinstance(system_prompt, str) and system_prompt.strip():
+        client.set_system_prompt(session_id, system_prompt)
+
+    max_stream_retries = int(defaults_cfg.get("max_stream_retries", 2))
+    default_mode = str(defaults_cfg.get("mode", "agent"))
+
+    assertion_results_by_id: dict[str, dict[str, Any]] = {}
+    step_results: list[dict[str, Any]] = []
+    total_assertions = 0
+    passed_assertions = 0
+
+    for step in playbook["steps"]:
+        step_started = time.perf_counter()
+        stream_result = client.send_turn(
+            session_id=session_id,
+            message=step["message"],
+            mode=str(step.get("mode") or default_mode),
+            prompt_override=step.get("prompt_override"),
+            max_stream_retries=max_stream_retries,
+        )
+        step_elapsed_ms = (time.perf_counter() - step_started) * 1000.0
+
+        step_result: dict[str, Any] = {
+            "id": step["id"],
+            "message": step["message"],
+            "mode": str(step.get("mode") or default_mode),
+            "assistant_text": stream_result.assistant_text,
+            "events": stream_result.events,
+            "tool_names": stream_result.tool_names,
+            "first_token_latency_ms": stream_result.first_token_latency_ms,
+            "total_latency_ms": stream_result.total_latency_ms,
+            "step_elapsed_ms": step_elapsed_ms,
+            "stream_reconnects": stream_result.stream_reconnects,
+            "assertion_results": [],
+        }
+
+        for assertion in step["assertions"]:
+            total_assertions += 1
+            result = evaluate_assertion(assertion, step_result)
+            result["step_id"] = step["id"]
+            if result["passed"]:
+                passed_assertions += 1
+            assertion_results_by_id[assertion["id"]] = result
+            step_result["assertion_results"].append(result)
+
+        step_results.append(step_result)
+
+    evaluation_scores = _score_evaluation_points(
+        playbook=playbook,
+        assertion_results_by_id=assertion_results_by_id,
+    )
+
+    total_score = sum(point["score"] for point in evaluation_scores)
+    max_score = sum(point["max_score"] for point in evaluation_scores)
+    overall_percent = 100.0 if max_score == 0 else (100.0 * total_score / max_score)
+    points_passed = all(point["passed"] for point in evaluation_scores)
+
+    finished_at = time.time()
+    return {
+        "playbook_name": playbook["name"],
+        "playbook_path": str(Path(playbook_path).resolve()),
+        "description": playbook.get("description", ""),
+        "server_url": base_url,
+        "session_id": session_id,
+        "started_at": _iso8601(started_at),
+        "finished_at": _iso8601(finished_at),
+        "duration_s": round(finished_at - started_at, 3),
+        "steps": step_results,
+        "evaluation_points": evaluation_scores,
+        "summary": {
+            "passed_assertions": passed_assertions,
+            "total_assertions": total_assertions,
+            "assertion_pass_rate": 1.0 if total_assertions == 0 else passed_assertions / total_assertions,
+            "overall_score": total_score,
+            "overall_max_score": max_score,
+            "overall_percent": overall_percent,
+            "passed": passed_assertions == total_assertions and points_passed,
+        },
+    }
+
+
+def run_playbook_suite(
+    playbook_paths: list[str | Path],
+    *,
+    server_url_override: str | None = None,
+    auth_token: str = "",
+) -> dict[str, Any]:
+    reports: list[dict[str, Any]] = []
+    for path in playbook_paths:
+        report = run_playbook_file(
+            path,
+            server_url_override=server_url_override,
+            auth_token=auth_token,
+        )
+        reports.append(report)
+
+    suite_max_score = sum(report["summary"]["overall_max_score"] for report in reports)
+    suite_score = sum(report["summary"]["overall_score"] for report in reports)
+    suite_percent = 100.0 if suite_max_score == 0 else (100.0 * suite_score / suite_max_score)
+
+    return {
+        "reports": reports,
+        "summary": {
+            "playbooks_total": len(reports),
+            "playbooks_passed": sum(1 for report in reports if report["summary"]["passed"]),
+            "overall_score": suite_score,
+            "overall_max_score": suite_max_score,
+            "overall_percent": suite_percent,
+            "passed": all(report["summary"]["passed"] for report in reports),
+        },
+    }
+
+
+def _score_evaluation_points(
+    *,
+    playbook: dict[str, Any],
+    assertion_results_by_id: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    points: list[dict[str, Any]] = []
+    for point in playbook.get("evaluation_points", []):
+        assertion_ids = point.get("assertion_ids", [])
+        results = [assertion_results_by_id[item] for item in assertion_ids if item in assertion_results_by_id]
+
+        passed_checks = sum(1 for item in results if item["passed"])
+        total_checks = len(results)
+        ratio = 1.0 if total_checks == 0 else (passed_checks / total_checks)
+
+        max_score = float(point.get("max_score", 10.0))
+        pass_threshold = float(point.get("pass_threshold", 1.0))
+        score = ratio * max_score
+
+        points.append({
+            "id": point["id"],
+            "description": point.get("description", ""),
+            "max_score": max_score,
+            "score": score,
+            "passed_checks": passed_checks,
+            "total_checks": total_checks,
+            "pass_threshold": pass_threshold,
+            "ratio": ratio,
+            "passed": ratio >= pass_threshold,
+            "assertion_ids": assertion_ids,
+            "failed_assertion_ids": [item["id"] for item in results if not item["passed"]],
+        })
+
+    if not points:
+        points.append({
+            "id": "default",
+            "description": "Default score from all assertions",
+            "max_score": 100.0,
+            "score": 100.0,
+            "passed_checks": len(assertion_results_by_id),
+            "total_checks": len(assertion_results_by_id),
+            "pass_threshold": 1.0,
+            "ratio": 1.0,
+            "passed": True,
+            "assertion_ids": list(assertion_results_by_id.keys()),
+            "failed_assertion_ids": [],
+        })
+
+    return points
+
+
+def _iso8601(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat()

--- a/tests/run_chat_playbook.py
+++ b/tests/run_chat_playbook.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""CLI for running chat E2E playbook suites."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Running this file directly sets sys.path[0] to tests/, so local package import works.
+from e2e_playbook.runner import run_playbook_suite
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run playbook-driven chat E2E tests")
+    parser.add_argument(
+        "--playbook",
+        required=True,
+        help="Playbook file or directory containing *.json playbooks",
+    )
+    parser.add_argument(
+        "--server-url",
+        default=None,
+        help="Override server URL (default uses playbook.server.base_url or http://127.0.0.1:10000)",
+    )
+    parser.add_argument(
+        "--auth-token",
+        default=os.environ.get("RESEARCH_AGENT_USER_AUTH_TOKEN", ""),
+        help="Auth token for server requests (default from RESEARCH_AGENT_USER_AUTH_TOKEN)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="tests/e2e_reports",
+        help="Directory to store JSON report output",
+    )
+    parser.add_argument(
+        "--min-overall-score",
+        type=float,
+        default=100.0,
+        help="Minimum suite score percent required for success",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    playbook_paths = _resolve_playbook_paths(args.playbook)
+    if not playbook_paths:
+        print("No playbook JSON files found.", file=sys.stderr)
+        return 2
+
+    suite_report = run_playbook_suite(
+        playbook_paths,
+        server_url_override=args.server_url,
+        auth_token=args.auth_token,
+    )
+
+    _print_summary(suite_report)
+    output_path = _write_report(suite_report, output_dir=args.output_dir)
+    print(f"\nSaved report: {output_path}")
+
+    min_score = float(args.min_overall_score)
+    score = float(suite_report["summary"]["overall_percent"])
+    suite_passed = bool(suite_report["summary"]["passed"])
+    if not suite_passed or score < min_score:
+        return 1
+    return 0
+
+
+def _resolve_playbook_paths(playbook_arg: str) -> list[Path]:
+    path = Path(playbook_arg).expanduser().resolve()
+    if path.is_file():
+        return [path]
+    if path.is_dir():
+        return sorted(path.glob("*.json"))
+    return []
+
+
+def _write_report(report: dict, *, output_dir: str) -> Path:
+    output_root = Path(output_dir).expanduser().resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    output_path = output_root / f"chat-playbook-report-{stamp}.json"
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2)
+    return output_path
+
+
+def _print_summary(report: dict) -> None:
+    summary = report["summary"]
+    print("\n=== Playbook Suite Summary ===")
+    print(
+        f"Playbooks: {summary['playbooks_passed']}/{summary['playbooks_total']} passed | "
+        f"Score: {summary['overall_percent']:.1f}%"
+    )
+
+    for item in report["reports"]:
+        s = item["summary"]
+        status = "PASS" if s["passed"] else "FAIL"
+        print(
+            f"- [{status}] {item['playbook_name']}: "
+            f"{s['passed_assertions']}/{s['total_assertions']} assertions | "
+            f"score={s['overall_percent']:.1f}%"
+        )
+        for point in item["evaluation_points"]:
+            point_status = "PASS" if point["passed"] else "FAIL"
+            print(
+                f"    - [{point_status}] {point['id']}: "
+                f"{point['passed_checks']}/{point['total_checks']} checks "
+                f"(score={point['score']:.2f}/{point['max_score']:.2f})"
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/story/e2e-agent-playbooks/README.md
+++ b/tests/story/e2e-agent-playbooks/README.md
@@ -1,0 +1,55 @@
+# E2E Agent Playbooks
+
+This folder stores story-driven playbooks for chat E2E evaluation.
+
+Run all playbooks:
+
+```bash
+python tests/run_chat_playbook.py --playbook tests/story/e2e-agent-playbooks
+```
+
+Run one playbook:
+
+```bash
+python tests/run_chat_playbook.py --playbook tests/story/e2e-agent-playbooks/gpu-wrapper-gating.json
+```
+
+## Playbook schema (JSON)
+
+- `name` (string): playbook identifier.
+- `description` (string): scenario summary.
+- `server.base_url` (string, optional): backend URL.
+- `session` (object, optional): chat session config.
+- `defaults.mode` (string, optional): default chat mode.
+- `defaults.max_stream_retries` (int, optional): stream reattach attempts.
+- `steps` (array, required): ordered interaction turns.
+- `evaluation_points` (array, optional): weighted score categories.
+
+### Step
+
+- `id` (string): unique step id.
+- `message` (string): user message sent to `/chat`.
+- `mode` (string, optional): overrides default mode.
+- `prompt_override` (string, optional): optional raw prompt override.
+- `assertions` (array, required): checks for this turn.
+
+### Assertion types
+
+- `assistant_contains`
+- `assistant_not_contains`
+- `assistant_regex`
+- `response_is_json`
+- `response_json_field_equals`
+- `tool_name_contains`
+- `tool_name_not_contains`
+- `first_token_latency_lt_ms`
+- `total_latency_lt_ms`
+- `event_type_seen`
+- `event_type_not_seen`
+
+### Evaluation point
+
+- `id` (string): score category id.
+- `assertion_ids` (array): assertion ids in this category.
+- `max_score` (number): max points for this category.
+- `pass_threshold` (number): required pass ratio in `[0, 1]`.

--- a/tests/story/e2e-agent-playbooks/format-contract.json
+++ b/tests/story/e2e-agent-playbooks/format-contract.json
@@ -1,0 +1,86 @@
+{
+  "name": "format-contract",
+  "description": "Check strict format obedience for plain text and JSON contracts.",
+  "server": {
+    "base_url": "http://127.0.0.1:10000"
+  },
+  "defaults": {
+    "mode": "agent",
+    "max_stream_retries": 3
+  },
+  "session": {
+    "title": "E2E Format Contract",
+    "system_prompt": "You are being evaluated for exact response formatting."
+  },
+  "steps": [
+    {
+      "id": "exact_word",
+      "message": "Reply with exactly one word: READY",
+      "assertions": [
+        {
+          "id": "exact_ready",
+          "type": "assistant_regex",
+          "pattern": "^READY$",
+          "flags": "m"
+        },
+        {
+          "id": "event_idle_seen",
+          "type": "event_type_seen",
+          "expected": "session_status"
+        }
+      ]
+    },
+    {
+      "id": "json_contract",
+      "message": "Return ONLY JSON object with this exact shape and values: {\"priority\":\"high\",\"action\":\"investigate\"}",
+      "assertions": [
+        {
+          "id": "json_contract_valid",
+          "type": "response_is_json",
+          "required_fields": ["priority", "action"]
+        },
+        {
+          "id": "json_priority_high",
+          "type": "response_json_field_equals",
+          "field": "priority",
+          "expected": "high"
+        },
+        {
+          "id": "json_action_investigate",
+          "type": "response_json_field_equals",
+          "field": "action",
+          "expected": "investigate"
+        },
+        {
+          "id": "json_latency",
+          "type": "total_latency_lt_ms",
+          "expected": 45000
+        }
+      ]
+    }
+  ],
+  "evaluation_points": [
+    {
+      "id": "exactness",
+      "description": "Agent follows exact format contracts.",
+      "assertion_ids": [
+        "exact_ready",
+        "json_contract_valid",
+        "json_priority_high",
+        "json_action_investigate"
+      ],
+      "max_score": 90,
+      "pass_threshold": 1.0
+    },
+    {
+      "id": "runtime-signals",
+      "description": "Expected stream/event behavior and latency.",
+      "assertion_ids": [
+        "event_idle_seen",
+        "json_latency"
+      ],
+      "max_score": 10,
+      "pass_threshold": 1.0
+    }
+  ]
+}

--- a/tests/story/e2e-agent-playbooks/gpu-wrapper-gating.json
+++ b/tests/story/e2e-agent-playbooks/gpu-wrapper-gating.json
@@ -1,0 +1,107 @@
+{
+  "name": "gpu-wrapper-gating",
+  "description": "Validate instruction-following for GPU wrapper/detector policy across CPU-only and GPU machines.",
+  "server": {
+    "base_url": "http://127.0.0.1:10000"
+  },
+  "defaults": {
+    "mode": "agent",
+    "max_stream_retries": 3
+  },
+  "session": {
+    "title": "E2E GPU Wrapper Gating",
+    "system_prompt": "You are being evaluated for strict instruction-following. Keep replies concise."
+  },
+  "steps": [
+    {
+      "id": "cpu_only_case",
+      "message": "You are preparing a run policy. Machine profile: gpu_count=0, cuda_available=false. Reply with ONLY JSON object: {\"use_gpu_wrapper\": <bool>, \"use_gpu_detector\": <bool>, \"reason\": \"...\"}. Rule: gpu wrapper and detector must only be used on GPU machines.",
+      "assertions": [
+        {
+          "id": "cpu_json",
+          "type": "response_is_json",
+          "required_fields": ["use_gpu_wrapper", "use_gpu_detector", "reason"]
+        },
+        {
+          "id": "cpu_wrapper_false",
+          "type": "response_json_field_equals",
+          "field": "use_gpu_wrapper",
+          "expected": false
+        },
+        {
+          "id": "cpu_detector_false",
+          "type": "response_json_field_equals",
+          "field": "use_gpu_detector",
+          "expected": false
+        },
+        {
+          "id": "cpu_first_token_latency",
+          "type": "first_token_latency_lt_ms",
+          "expected": 15000
+        }
+      ]
+    },
+    {
+      "id": "gpu_case",
+      "message": "You are preparing a run policy. Machine profile: gpu_count=8, cuda_available=true. Reply with ONLY JSON object: {\"use_gpu_wrapper\": <bool>, \"use_gpu_detector\": <bool>, \"reason\": \"...\"}. Rule: gpu wrapper and detector must only be used on GPU machines.",
+      "assertions": [
+        {
+          "id": "gpu_json",
+          "type": "response_is_json",
+          "required_fields": ["use_gpu_wrapper", "use_gpu_detector", "reason"]
+        },
+        {
+          "id": "gpu_wrapper_true",
+          "type": "response_json_field_equals",
+          "field": "use_gpu_wrapper",
+          "expected": true
+        },
+        {
+          "id": "gpu_detector_true",
+          "type": "response_json_field_equals",
+          "field": "use_gpu_detector",
+          "expected": true
+        },
+        {
+          "id": "gpu_total_latency",
+          "type": "total_latency_lt_ms",
+          "expected": 60000
+        }
+      ]
+    }
+  ],
+  "evaluation_points": [
+    {
+      "id": "gpu-policy-correctness",
+      "description": "Agent toggles wrapper/detector correctly based on hardware profile.",
+      "assertion_ids": [
+        "cpu_wrapper_false",
+        "cpu_detector_false",
+        "gpu_wrapper_true",
+        "gpu_detector_true"
+      ],
+      "max_score": 70,
+      "pass_threshold": 1.0
+    },
+    {
+      "id": "structured-output",
+      "description": "Agent follows strict JSON contract for both turns.",
+      "assertion_ids": [
+        "cpu_json",
+        "gpu_json"
+      ],
+      "max_score": 20,
+      "pass_threshold": 1.0
+    },
+    {
+      "id": "latency-basic",
+      "description": "Response latency stays within baseline envelope.",
+      "assertion_ids": [
+        "cpu_first_token_latency",
+        "gpu_total_latency"
+      ],
+      "max_score": 10,
+      "pass_threshold": 1.0
+    }
+  ]
+}

--- a/tests/story/e2e-agent-playbooks/session-memory-followup.json
+++ b/tests/story/e2e-agent-playbooks/session-memory-followup.json
@@ -1,0 +1,87 @@
+{
+  "name": "session-memory-followup",
+  "description": "Verify the same chat session retains earlier instructions across turns.",
+  "server": {
+    "base_url": "http://127.0.0.1:10000"
+  },
+  "defaults": {
+    "mode": "agent",
+    "max_stream_retries": 3
+  },
+  "session": {
+    "title": "E2E Session Memory",
+    "system_prompt": "You are being evaluated for memory and format compliance."
+  },
+  "steps": [
+    {
+      "id": "store_token",
+      "message": "Remember token ALPHA-4281 for this chat session. Reply exactly `ACK ALPHA-4281`.",
+      "assertions": [
+        {
+          "id": "store_exact_ack",
+          "type": "assistant_regex",
+          "pattern": "^ACK ALPHA-4281$",
+          "flags": "m"
+        },
+        {
+          "id": "store_fast_first_token",
+          "type": "first_token_latency_lt_ms",
+          "expected": 15000
+        }
+      ]
+    },
+    {
+      "id": "recall_token",
+      "message": "What token did I ask you to remember? Reply with ONLY JSON object: {\"token\": \"...\"}.",
+      "assertions": [
+        {
+          "id": "recall_json",
+          "type": "response_is_json",
+          "required_fields": ["token"]
+        },
+        {
+          "id": "recall_correct_token",
+          "type": "response_json_field_equals",
+          "field": "token",
+          "expected": "ALPHA-4281"
+        },
+        {
+          "id": "recall_total_latency",
+          "type": "total_latency_lt_ms",
+          "expected": 45000
+        }
+      ]
+    }
+  ],
+  "evaluation_points": [
+    {
+      "id": "session-memory",
+      "description": "Agent preserves prior-turn state in the same session.",
+      "assertion_ids": [
+        "store_exact_ack",
+        "recall_correct_token"
+      ],
+      "max_score": 70,
+      "pass_threshold": 1.0
+    },
+    {
+      "id": "format-compliance",
+      "description": "Agent follows requested output formats.",
+      "assertion_ids": [
+        "recall_json"
+      ],
+      "max_score": 20,
+      "pass_threshold": 1.0
+    },
+    {
+      "id": "latency-basic",
+      "description": "Latency remains within baseline limits.",
+      "assertion_ids": [
+        "store_fast_first_token",
+        "recall_total_latency"
+      ],
+      "max_score": 10,
+      "pass_threshold": 1.0
+    }
+  ]
+}

--- a/tests/test_e2e_playbook_framework.py
+++ b/tests/test_e2e_playbook_framework.py
@@ -1,0 +1,79 @@
+"""Unit tests for playbook framework components."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+
+from e2e_playbook.assertions import evaluate_assertion
+from e2e_playbook.playbook import validate_playbook
+from e2e_playbook.runner import _score_evaluation_points
+
+
+def test_validate_playbook_accepts_minimal_valid_shape():
+    playbook = {
+        "name": "minimal",
+        "steps": [
+            {
+                "id": "s1",
+                "message": "hello",
+                "assertions": [
+                    {"id": "a1", "type": "assistant_contains", "expected": "world"},
+                ],
+            }
+        ],
+        "evaluation_points": [
+            {"id": "p1", "assertion_ids": ["a1"], "max_score": 10, "pass_threshold": 1.0}
+        ],
+    }
+
+    validate_playbook(playbook)
+
+
+def test_evaluate_assertion_json_field_equals():
+    assertion = {
+        "id": "a-json",
+        "type": "response_json_field_equals",
+        "field": "token",
+        "expected": "ALPHA-1",
+    }
+    step_result = {"assistant_text": "{\"token\":\"ALPHA-1\"}"}
+    result = evaluate_assertion(assertion, step_result)
+    assert result["passed"] is True
+
+
+def test_evaluate_assertion_regex_failure():
+    assertion = {
+        "id": "a-rx",
+        "type": "assistant_regex",
+        "pattern": "^READY$",
+    }
+    step_result = {"assistant_text": "READY NOW"}
+    result = evaluate_assertion(assertion, step_result)
+    assert result["passed"] is False
+
+
+def test_score_evaluation_points_handles_partial_pass():
+    playbook = {
+        "evaluation_points": [
+            {
+                "id": "quality",
+                "assertion_ids": ["a1", "a2"],
+                "max_score": 100,
+                "pass_threshold": 0.5,
+            }
+        ]
+    }
+    assertion_results_by_id = {
+        "a1": {"id": "a1", "passed": True},
+        "a2": {"id": "a2", "passed": False},
+    }
+
+    scored = _score_evaluation_points(
+        playbook=playbook,
+        assertion_results_by_id=assertion_results_by_id,
+    )
+    assert scored[0]["score"] == pytest.approx(50.0)
+    assert scored[0]["passed"] is True


### PR DESCRIPTION
Summary
- build a reusable e2e playbook framework with client/runner/assertion APIs for driving and scoring agent instructions
- add story playbooks covering GPU gating, session memory, and format contracts plus a smoke test that wires the framework together
Testing
- Not run (not requested)